### PR TITLE
Add skeleton of ND-GAr reco filler

### DIFF
--- a/cfg/ndcafmakerjob.fcl
+++ b/cfg/ndcafmakerjob.fcl
@@ -8,14 +8,19 @@ nd_cafmaker: @local::standard_nd_cafmaker
 #nd_cafmaker.CAFMakerSettings.NDLArRecoFile: "/dune/data/users/jwolcott/nd/nd-lar-reco/cafmaker_input/neutrino.LArTMSProductionJun23withLArCV.99.summary.h5"
 
 # CWret test setup
-nd_cafmaker.CAFMakerSettings.InputDumpFile: "/dune/app/users/cwret/ND_CAFMaker/death.root"
-nd_cafmaker.CAFMakerSettings.InputGHEPFile: "/dune/data/users/cwret/tms/dune_nd_production_2022_v1/genie/00/neutrino.0_1649778420.ghep.root"
+#nd_cafmaker.CAFMakerSettings.InputDumpFile: "/dune/app/users/cwret/ND_CAFMaker/death.root"
+#nd_cafmaker.CAFMakerSettings.InputGHEPFile: "/dune/data/users/cwret/tms/dune_nd_production_2022_v1/genie/00/neutrino.0_1649778420.ghep.root"
 #nd_cafmaker.CAFMakerSettings.NDLArRecoFile: "/dune/data/users/
-nd_cafmaker.CAFMakerSettings.TMSRecoFile: "/dune/app/users/cwret/SSRI/dune-ssri/neutrino.0_1649778420.edep_TMS_RecoCandidates_Hough_Cluster1.root"
+#nd_cafmaker.CAFMakerSettings.TMSRecoFile: "/dune/app/users/cwret/SSRI/dune-ssri/neutrino.0_1649778420.edep_TMS_RecoCandidates_Hough_Cluster1.root"
 
-nd_cafmaker.CAFMakerSettings.OutputFile: "/dune/app/users/cwret/ND_CAFMaker/out_caf.root"
+#nd_cafmaker.CAFMakerSettings.OutputFile: "/dune/app/users/cwret/ND_CAFMaker/out_caf.root"
 
 # SAND test setup
 #nd_cafmaker.CAFMakerSettings.SANDRecoFile: "/pnfs/dune/scratch/users/mvicenzi/100k_FHC.0.fast-reco.root"
 #nd_cafmaker.CAFMakerSettings.InputGHEPFile: "/pnfs/dune/scratch/users/mvicenzi/100k_FHC.0.ghep.root"
 #nd_cafmaker.CAFMakerSettings.OutputFile: "/pnfs/dune/scratch/users/mvicenzi/test_SAND_CAF.root"
+
+# ND-GAr test setup
+nd_cafmaker.CAFMakerSettings.InputGHEPFile: "/dune/app/users/abooth/Postdoc/NDGArSim/Output/input_file.ghep.root"
+nd_cafmaker.CAFMakerSettings.NDGArRecoFile: "/dune/app/users/fmlopez/garsoft/work/anatree.root"
+nd_cafmaker.CAFMakerSettings.OutputFile: "/dune/app/users/fmlopez/ND_CAFMaker/out_caf.root"

--- a/src/Params.h
+++ b/src/Params.h
@@ -38,6 +38,7 @@ namespace cafmaker
     fhicl::OptionalAtom<std::string> ndlarRecoFile  { fhicl::Name{"NDLArRecoFile"}, fhicl::Comment("Input ND-LAr (ML) reco .h5 file") };
     fhicl::OptionalAtom<std::string> tmsRecoFile  { fhicl::Name{"TMSRecoFile"}, fhicl::Comment("Input TMS reco .root file") };
     fhicl::OptionalAtom<std::string> sandRecoFile  { fhicl::Name{"SANDRecoFile"}, fhicl::Comment("Input SAND reco .root file") };
+    fhicl::OptionalAtom<std::string> ndgarRecoFile  { fhicl::Name{"NDGArRecoFile"}, fhicl::Comment("Input ND-GAr reco .root file") };
 
     // these are optional and have defaults
     fhicl::Atom<int>  first   { fhicl::Name("FirstEvt"), fhicl::Comment("Start processing from this event number"), 0 };

--- a/src/makeCAF.C
+++ b/src/makeCAF.C
@@ -20,6 +20,7 @@
 #include "reco/MLNDLArRecoBranchFiller.h"
 #include "reco/TMSRecoBranchFiller.h"
 #include "reco/NDLArTMSMatchRecoFiller.h"
+#include "reco/NDGArRecoBranchFiller.h"
 #include "reco/SANDRecoBranchFiller.h"
 #include "truth/FillTruth.h"
 
@@ -109,13 +110,16 @@ std::vector<std::unique_ptr<cafmaker::IRecoBranchFiller>> getRecoFillers(const c
 {
   std::vector<std::unique_ptr<cafmaker::IRecoBranchFiller>> recoFillers;
 
-  // first: we do SAND or ND-LAr reco
+  // first: we do SAND or ND-LAr or ND-GAr reco
   std::string ndlarFile;
   std::string sandFile;
+  std::string ndgarFile;
   if(par().cafmaker().ndlarRecoFile(ndlarFile))
     recoFillers.emplace_back(std::make_unique<cafmaker::MLNDLArRecoBranchFiller>(ndlarFile));
   else if (par().cafmaker().sandRecoFile(sandFile))
     recoFillers.emplace_back(std::make_unique<cafmaker::SANDRecoBranchFiller>(sandFile));
+  else if (par().cafmaker().ndgarRecoFile(ndgarFile))
+    recoFillers.emplace_back(std::make_unique<cafmaker::NDGArRecoBranchFiller>(ndgarFile));
 
   // next: did we do TMS reco?
   std::string tmsFile;

--- a/src/reco/NDGArRecoBranchFiller.cxx
+++ b/src/reco/NDGArRecoBranchFiller.cxx
@@ -1,0 +1,57 @@
+/// Fill NDGAr reco branches using NDGAr reco data
+///
+/// \author  F. Martinez Lopez
+/// \date    Oct. 2022
+///
+
+#include "NDGArRecoBranchFiller.h"
+
+#include "duneanaobj/StandardRecord/StandardRecord.h"
+
+#include "TFile.h"
+#include "TSystem.h"
+#include "TTree.h"
+
+namespace cafmaker
+{
+  
+  NDGArRecoBranchFiller::NDGArRecoBranchFiller(const std::string &NDGArRecoFilename)
+  {  
+    fNDGArRecoFile = new TFile(NDGArRecoFilename.c_str(), "READ");
+    if(!fNDGArRecoFile->IsZombie()){
+      SetConfigured(true);
+
+      // fTree = fNDGArRecoFile->Get<TTree>("anatree/GArAnaTree");
+      NDGArRecoTree = dynamic_cast<TTree*>(fNDGArRecoFile->Get("anatree/GArAnaTree"));
+
+      NDGArRecoTree->SetBranchAddress("Event", &fEvent);
+      NDGArRecoTree->SetBranchAddress("TrackStartX", &fTrackStartX);
+      NDGArRecoTree->SetBranchAddress("TrackPIDCheatedF", &fTrackPIDCheatedF);
+      NDGArRecoTree->SetBranchAddress("TrackLenF", &fTrackLenF);
+    } else {
+      NDGArRecoTree = NULL;
+      std::cerr << "Did not find input ND-GAr reco file you provided: " << NDGArRecoFilename << std::endl;
+      std::cerr << "Are you sure it exists?" << std::endl;
+      throw;
+    }
+  }
+
+  void NDGArRecoBranchFiller::_FillRecoBranches(std::size_t ii, 
+					       caf::StandardRecord &sr,
+					       const cafmaker::Params &par) const
+  {
+   
+   NDGArRecoTree->GetEntry(ii);
+
+   std::cout << "Event number: " << fEvent << std::endl;
+   std::cout << "Number of particles: " << fTrackStartX->size() << std::endl;
+    
+   //todo: currently filling simple variables
+   //rewrite once sr.nd.ndgar exists in StandardRecord
+  
+  for (size_t i=0; i< fTrackStartX->size(); ++i){
+      sr.nd.gar.pdg.push_back(fTrackPIDCheatedF->at(i));
+      sr.nd.gar.trkLen.push_back(fTrackLenF->at(i));
+   }
+  }
+}

--- a/src/reco/NDGArRecoBranchFiller.h
+++ b/src/reco/NDGArRecoBranchFiller.h
@@ -1,0 +1,41 @@
+/// Fill NDGAr reco branches using NDGAr reco data
+///
+/// \author  F. Martinez Lopez
+/// \date    Oct. 2022
+///
+
+#ifndef ND_CAFMAKER_NDGArRECOBRANCHFILLER_H
+#define ND_CAFMAKER_NDGArRECOBRANCHFILLER_H
+
+#include "IRecoBranchFiller.h"
+
+#include <vector>
+#include <cmath>
+
+class TFile;
+class TTree;
+
+namespace cafmaker
+{
+  class NDGArRecoBranchFiller : public cafmaker::IRecoBranchFiller
+  {
+    public:
+      NDGArRecoBranchFiller(const std::string &NDGArRecoFilename);
+
+    private:
+      void _FillRecoBranches(std::size_t evtIdx,
+			     caf::StandardRecord &sr,
+			     const cafmaker::Params &par) const override;
+
+      TFile* fNDGArRecoFile;
+      TTree* NDGArRecoTree;
+      
+      int                fEvent;
+      std::vector<float_t> * fTrackStartX;
+      std::vector<int>   * fTrackPIDCheatedF;
+      std::vector<float_t> * fTrackLenF;
+  };
+
+}
+
+#endif //ND_CAFMAKER_NDGArRECOBRANCHFILLER_H


### PR DESCRIPTION
Modified makeCAF.C and Params.h adding ND-GAr reco info variables. Created NDGArRecoBranchFiller able to fill some quantities in sr.nd.ndgar ("pseudo-reco" fields) using garsoft anatree.root.