### PR TITLE
Truth-matching updates for 2x2 Minirun4

### DIFF
--- a/src/Params.h
+++ b/src/Params.h
@@ -8,6 +8,7 @@
 
 #include "fhiclcpp/types/Atom.h"
 #include "fhiclcpp/types/OptionalAtom.h"
+#include "fhiclcpp/types/OptionalSequence.h"
 #include "fhiclcpp/types/Table.h"
 
 namespace cafmaker
@@ -27,9 +28,11 @@ namespace cafmaker
   struct ControlConfig
   {
     // these are mandatory and have no default values
-    fhicl::OptionalAtom<std::string> contNuGHEPFile     {fhicl::Name{"ContainedNuGHEPFile"},   fhicl::Comment("Input .ghep (GENIE) file for in-detector neutrinos") };
-    fhicl::OptionalAtom<std::string> uncontNuGHEPFile   {fhicl::Name{"UncontainedNuGHEPFile"}, fhicl::Comment("Input .ghep (GENIE) file for rock/hall neutrinos") };
-    fhicl::Atom<std::string> outputFile         { fhicl::Name{"OutputFile"},           fhicl::Comment("Filename for output CAF") };
+    fhicl::OptionalSequence<std::string> contNuGHEPFiles     { fhicl::Name{"ContainedNuGHEPFiles"},   fhicl::Comment("Input .ghep (GENIE) file(s) for in-detector neutrinos") };
+//    fhicl::OptionalAtom<std::string> contNuGHEPFile     {fhicl::Name{"ContainedNuGHEPFile"},   fhicl::Comment("Input .ghep (GENIE) file for in-detector neutrinos") };
+    fhicl::OptionalSequence<std::string> uncontNuGHEPFiles   {fhicl::Name{"UncontainedNuGHEPFiles"}, fhicl::Comment("Input .ghep (GENIE) file(s) for rock/hall neutrinos") };
+//    fhicl::OptionalAtom<std::string> uncontNuGHEPFile   {fhicl::Name{"UncontainedNuGHEPFile"}, fhicl::Comment("Input .ghep (GENIE) file for rock/hall neutrinos") };
+    fhicl::Atom<std::string> outputFile                      { fhicl::Name{"OutputFile"},           fhicl::Comment("Filename for output CAF") };
 
     // this one is mandatory but has a default.  (the 'fhicl.fcl' file is provided in the 'sim_inputs' directory).
     // fixme: this file is currently not used for anything, but will be once DIRT-II is done and re-enables the interaction systematics

--- a/src/reco/DLP_h5_classes.cxx
+++ b/src/reco/DLP_h5_classes.cxx
@@ -5,7 +5,7 @@
 //    
 //    The invocation that generated this file was:
 //
-//       ./h5_to_cpp.py -f /dune/data/users/jwolcott/nd/nd-lar-reco/reco-out/mlreco_official_test2x2.2.h5 -o ../src/reco/DLP_h5_classes -ns cafmaker::types::dlp -d events -cn Event -d interactions -cn Interaction -d particles -cn Particle -d truth_interactions -cn TrueInteraction -d truth_particles -cn TrueParticle -d run_info -cn RunInfo
+//       ./h5_to_cpp.py -f /dune/data/users/jwolcott/nd/nd-lar-reco/reco-out/minirun4.00041.larcv.h5 -o ../src/reco/DLP_h5_classes -ns cafmaker::types::dlp -d events -cn Event -d interactions -cn Interaction -d particles -cn Particle -d truth_interactions -cn TrueInteraction -d truth_particles -cn TrueParticle -d run_info -cn RunInfo
 //
 
 #include "DLP_h5_classes.h"
@@ -45,7 +45,6 @@ namespace cafmaker::types::dlp
     particle_ids.reset(&particle_ids_handle);
     truth_particle_counts.reset(&truth_particle_counts_handle);
     truth_primary_counts.reset(&truth_primary_counts_handle);
-    truth_vertex.reset(&truth_vertex_handle);
   }
   
   
@@ -81,13 +80,13 @@ namespace cafmaker::types::dlp
   {
     H5::CompType ctype(sizeof(Event));
   
-    ctype.insertMember("meta", HOFFSET(Event, meta), H5::PredType::STD_REF_DSETREG);
     ctype.insertMember("run_info", HOFFSET(Event, run_info), H5::PredType::STD_REF_DSETREG);
     ctype.insertMember("index", HOFFSET(Event, index), H5::PredType::STD_REF_DSETREG);
-    ctype.insertMember("truth_interactions", HOFFSET(Event, truth_interactions), H5::PredType::STD_REF_DSETREG);
+    ctype.insertMember("meta", HOFFSET(Event, meta), H5::PredType::STD_REF_DSETREG);
     ctype.insertMember("interactions", HOFFSET(Event, interactions), H5::PredType::STD_REF_DSETREG);
-    ctype.insertMember("particles", HOFFSET(Event, particles), H5::PredType::STD_REF_DSETREG);
+    ctype.insertMember("truth_interactions", HOFFSET(Event, truth_interactions), H5::PredType::STD_REF_DSETREG);
     ctype.insertMember("truth_particles", HOFFSET(Event, truth_particles), H5::PredType::STD_REF_DSETREG);
+    ctype.insertMember("particles", HOFFSET(Event, particles), H5::PredType::STD_REF_DSETREG);
   
     return ctype;
   }
@@ -131,7 +130,12 @@ namespace cafmaker::types::dlp
     units_strType.setCset(H5T_CSET_UTF8);
     ctype.insertMember("units", HOFFSET(Interaction, units), units_strType);
     
-    ctype.insertMember("vertex", HOFFSET(Interaction, vertex), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
+    ctype.insertMember("vertex", HOFFSET(Interaction, vertex), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
+    
+    H5::StrType vertex_mode_strType(H5::PredType::C_S1, H5T_VARIABLE);
+    vertex_mode_strType.setCset(H5T_CSET_UTF8);
+    ctype.insertMember("vertex_mode", HOFFSET(Interaction, vertex_mode), vertex_mode_strType);
+    
     ctype.insertMember("volume_id", HOFFSET(Interaction, volume_id), H5::PredType::STD_I64LE);
   
     return ctype;
@@ -143,9 +147,10 @@ namespace cafmaker::types::dlp
   {
     H5::CompType ctype(sizeof(Particle));
   
-    ctype.insertMember("csda_kinetic_energy", HOFFSET(Particle, csda_kinetic_energy), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("calo_ke", HOFFSET(Particle, calo_ke), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("csda_ke", HOFFSET(Particle, csda_ke), H5::PredType::IEEE_F64LE);
     ctype.insertMember("depositions_sum", HOFFSET(Particle, depositions_sum), H5::PredType::IEEE_F64LE);
-    ctype.insertMember("end_dir", HOFFSET(Particle, end_dir), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
+    ctype.insertMember("end_dir", HOFFSET(Particle, end_dir), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("end_point", HOFFSET(Particle, end_point), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("fragment_ids", HOFFSET(Particle, fragment_ids_handle), H5::VarLenType(H5::PredType::STD_I64LE));
     ctype.insertMember("id", HOFFSET(Particle, id), H5::PredType::STD_I64LE);
@@ -159,7 +164,8 @@ namespace cafmaker::types::dlp
     ctype.insertMember("match", HOFFSET(Particle, match_handle), H5::VarLenType(H5::PredType::STD_I64LE));
     ctype.insertMember("match_overlap", HOFFSET(Particle, match_overlap_handle), H5::VarLenType(H5::PredType::IEEE_F32LE));
     ctype.insertMember("matched", HOFFSET(Particle, matched), H5::PredType::STD_U8LE);
-    ctype.insertMember("momentum_mcs", HOFFSET(Particle, momentum_mcs), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("mcs_ke", HOFFSET(Particle, mcs_ke), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("momentum", HOFFSET(Particle, momentum), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("nu_id", HOFFSET(Particle, nu_id), H5::PredType::STD_I64LE);
     ctype.insertMember("num_fragments", HOFFSET(Particle, num_fragments), H5::PredType::STD_I64LE);
     ctype.insertMember("pdg_code", HOFFSET(Particle, pdg_code), H5::PredType::STD_I64LE);
@@ -167,6 +173,7 @@ namespace cafmaker::types::dlp
     H5::EnumType pid_enumtype(H5::PredType::STD_I64LE);
     int64_t pid_enum_val;
       pid_enum_val = 1; pid_enumtype.insert("Electron", &pid_enum_val);
+      pid_enum_val = 5; pid_enumtype.insert("Kaon", &pid_enum_val);
       pid_enum_val = 2; pid_enumtype.insert("Muon", &pid_enum_val);
       pid_enum_val = 0; pid_enumtype.insert("Photon", &pid_enum_val);
       pid_enum_val = 3; pid_enumtype.insert("Pion", &pid_enum_val);
@@ -188,7 +195,7 @@ namespace cafmaker::types::dlp
     ctype.insertMember("semantic_type", HOFFSET(Particle, semantic_type), semantic_type_enumtype);
     
     ctype.insertMember("size", HOFFSET(Particle, size), H5::PredType::STD_I64LE);
-    ctype.insertMember("start_dir", HOFFSET(Particle, start_dir), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
+    ctype.insertMember("start_dir", HOFFSET(Particle, start_dir), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("start_point", HOFFSET(Particle, start_point), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
     
     H5::StrType units_strType(H5::PredType::C_S1, H5T_VARIABLE);
@@ -366,6 +373,7 @@ namespace cafmaker::types::dlp
       nu_interaction_type_enum_val = 13; nu_interaction_type_enumtype.insert("WeakMix", &nu_interaction_type_enum_val);
     ctype.insertMember("nu_interaction_type", HOFFSET(TrueInteraction, nu_interaction_type), nu_interaction_type_enumtype);
     
+    ctype.insertMember("nu_pdg_code", HOFFSET(TrueInteraction, nu_pdg_code), H5::PredType::STD_I64LE);
     ctype.insertMember("num_particles", HOFFSET(TrueInteraction, num_particles), H5::PredType::STD_I64LE);
     ctype.insertMember("num_primaries", HOFFSET(TrueInteraction, num_primaries), H5::PredType::STD_I64LE);
     ctype.insertMember("particle_counts", HOFFSET(TrueInteraction, particle_counts), H5::ArrayType(H5::PredType::STD_I64LE, 1, &std::array<hsize_t, 1>{6}[0]));
@@ -377,6 +385,7 @@ namespace cafmaker::types::dlp
     topology_strType.setCset(H5T_CSET_UTF8);
     ctype.insertMember("topology", HOFFSET(TrueInteraction, topology), topology_strType);
     
+    ctype.insertMember("truth_id", HOFFSET(TrueInteraction, truth_id), H5::PredType::STD_I64LE);
     ctype.insertMember("truth_particle_counts", HOFFSET(TrueInteraction, truth_particle_counts_handle), H5::VarLenType(H5::PredType::STD_I64LE));
     ctype.insertMember("truth_primary_counts", HOFFSET(TrueInteraction, truth_primary_counts_handle), H5::VarLenType(H5::PredType::STD_I64LE));
     
@@ -384,13 +393,18 @@ namespace cafmaker::types::dlp
     truth_topology_strType.setCset(H5T_CSET_UTF8);
     ctype.insertMember("truth_topology", HOFFSET(TrueInteraction, truth_topology), truth_topology_strType);
     
-    ctype.insertMember("truth_vertex", HOFFSET(TrueInteraction, truth_vertex_handle), H5::VarLenType(H5::PredType::IEEE_F64LE));
+    ctype.insertMember("truth_vertex", HOFFSET(TrueInteraction, truth_vertex), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
     
     H5::StrType units_strType(H5::PredType::C_S1, H5T_VARIABLE);
     units_strType.setCset(H5T_CSET_UTF8);
     ctype.insertMember("units", HOFFSET(TrueInteraction, units), units_strType);
     
-    ctype.insertMember("vertex", HOFFSET(TrueInteraction, vertex), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
+    ctype.insertMember("vertex", HOFFSET(TrueInteraction, vertex), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
+    
+    H5::StrType vertex_mode_strType(H5::PredType::C_S1, H5T_VARIABLE);
+    vertex_mode_strType.setCset(H5T_CSET_UTF8);
+    ctype.insertMember("vertex_mode", HOFFSET(TrueInteraction, vertex_mode), vertex_mode_strType);
+    
     ctype.insertMember("volume_id", HOFFSET(TrueInteraction, volume_id), H5::PredType::STD_I64LE);
   
     return ctype;
@@ -411,6 +425,8 @@ namespace cafmaker::types::dlp
     ctype.insertMember("ancestor_position", HOFFSET(TrueParticle, ancestor_position_handle), H5::VarLenType(H5::PredType::IEEE_F64LE));
     ctype.insertMember("ancestor_t", HOFFSET(TrueParticle, ancestor_t), H5::PredType::IEEE_F64LE);
     ctype.insertMember("ancestor_track_id", HOFFSET(TrueParticle, ancestor_track_id), H5::PredType::STD_I64LE);
+    ctype.insertMember("calo_ke", HOFFSET(TrueParticle, calo_ke), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("calo_ke_tng", HOFFSET(TrueParticle, calo_ke_tng), H5::PredType::IEEE_F64LE);
     ctype.insertMember("children_counts", HOFFSET(TrueParticle, children_counts_handle), H5::VarLenType(H5::PredType::STD_I64LE));
     ctype.insertMember("children_id", HOFFSET(TrueParticle, children_id_handle), H5::VarLenType(H5::PredType::IEEE_F64LE));
     
@@ -418,12 +434,12 @@ namespace cafmaker::types::dlp
     creation_process_strType.setCset(H5T_CSET_UTF8);
     ctype.insertMember("creation_process", HOFFSET(TrueParticle, creation_process), creation_process_strType);
     
-    ctype.insertMember("csda_kinetic_energy", HOFFSET(TrueParticle, csda_kinetic_energy), H5::PredType::IEEE_F64LE);
-    ctype.insertMember("csda_kinetic_energy_tng", HOFFSET(TrueParticle, csda_kinetic_energy_tng), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("csda_ke", HOFFSET(TrueParticle, csda_ke), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("csda_ke_tng", HOFFSET(TrueParticle, csda_ke_tng), H5::PredType::IEEE_F64LE);
     ctype.insertMember("depositions_sum", HOFFSET(TrueParticle, depositions_sum), H5::PredType::IEEE_F64LE);
     ctype.insertMember("direction", HOFFSET(TrueParticle, direction_handle), H5::VarLenType(H5::PredType::IEEE_F64LE));
     ctype.insertMember("distance_travel", HOFFSET(TrueParticle, distance_travel), H5::PredType::IEEE_F64LE);
-    ctype.insertMember("end_dir", HOFFSET(TrueParticle, end_dir), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
+    ctype.insertMember("end_dir", HOFFSET(TrueParticle, end_dir), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("end_point", HOFFSET(TrueParticle, end_point), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("end_position", HOFFSET(TrueParticle, end_position), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("energy_deposit", HOFFSET(TrueParticle, energy_deposit), H5::PredType::IEEE_F64LE);
@@ -444,10 +460,11 @@ namespace cafmaker::types::dlp
     ctype.insertMember("match", HOFFSET(TrueParticle, match_handle), H5::VarLenType(H5::PredType::STD_I64LE));
     ctype.insertMember("match_overlap", HOFFSET(TrueParticle, match_overlap_handle), H5::VarLenType(H5::PredType::IEEE_F32LE));
     ctype.insertMember("matched", HOFFSET(TrueParticle, matched), H5::PredType::STD_U8LE);
+    ctype.insertMember("mcs_ke", HOFFSET(TrueParticle, mcs_ke), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("mcs_ke_tng", HOFFSET(TrueParticle, mcs_ke_tng), H5::PredType::IEEE_F64LE);
     ctype.insertMember("mcst_index", HOFFSET(TrueParticle, mcst_index), H5::PredType::STD_I64LE);
     ctype.insertMember("mct_index", HOFFSET(TrueParticle, mct_index), H5::PredType::STD_I64LE);
     ctype.insertMember("momentum", HOFFSET(TrueParticle, momentum), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
-    ctype.insertMember("momentum_mcs", HOFFSET(TrueParticle, momentum_mcs), H5::PredType::IEEE_F64LE);
     ctype.insertMember("nu_id", HOFFSET(TrueParticle, nu_id), H5::PredType::STD_I64LE);
     ctype.insertMember("num_fragments", HOFFSET(TrueParticle, num_fragments), H5::PredType::STD_I64LE);
     ctype.insertMember("num_voxels", HOFFSET(TrueParticle, num_voxels), H5::PredType::STD_I64LE);
@@ -467,15 +484,14 @@ namespace cafmaker::types::dlp
     H5::EnumType pid_enumtype(H5::PredType::STD_I64LE);
     int64_t pid_enum_val;
       pid_enum_val = 1; pid_enumtype.insert("Electron", &pid_enum_val);
+      pid_enum_val = 5; pid_enumtype.insert("Kaon", &pid_enum_val);
       pid_enum_val = 2; pid_enumtype.insert("Muon", &pid_enum_val);
       pid_enum_val = 0; pid_enumtype.insert("Photon", &pid_enum_val);
       pid_enum_val = 3; pid_enumtype.insert("Pion", &pid_enum_val);
       pid_enum_val = 4; pid_enumtype.insert("Proton", &pid_enum_val);
     ctype.insertMember("pid", HOFFSET(TrueParticle, pid), pid_enumtype);
     
-    ctype.insertMember("pid_scores", HOFFSET(TrueParticle, pid_scores), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{5}[0]));
     ctype.insertMember("position", HOFFSET(TrueParticle, position_handle), H5::VarLenType(H5::PredType::IEEE_F64LE));
-    ctype.insertMember("primary_scores", HOFFSET(TrueParticle, primary_scores), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{2}[0]));
     ctype.insertMember("sed_depositions_MeV_sum", HOFFSET(TrueParticle, sed_depositions_MeV_sum), H5::PredType::IEEE_F32LE);
     ctype.insertMember("sed_index", HOFFSET(TrueParticle, sed_index_handle), H5::VarLenType(H5::PredType::STD_I64LE));
     ctype.insertMember("sed_size", HOFFSET(TrueParticle, sed_size), H5::PredType::STD_I64LE);
@@ -493,7 +509,7 @@ namespace cafmaker::types::dlp
     
     ctype.insertMember("shape", HOFFSET(TrueParticle, shape), H5::PredType::STD_I64LE);
     ctype.insertMember("size", HOFFSET(TrueParticle, size), H5::PredType::STD_I64LE);
-    ctype.insertMember("start_dir", HOFFSET(TrueParticle, start_dir), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
+    ctype.insertMember("start_dir", HOFFSET(TrueParticle, start_dir), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("start_point", HOFFSET(TrueParticle, start_point), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("t", HOFFSET(TrueParticle, t), H5::PredType::IEEE_F64LE);
     ctype.insertMember("track_id", HOFFSET(TrueParticle, track_id), H5::PredType::STD_I64LE);

--- a/src/reco/DLP_h5_classes.h
+++ b/src/reco/DLP_h5_classes.h
@@ -5,7 +5,7 @@
 //    
 //    The invocation that generated this file was:
 //
-//       ./h5_to_cpp.py -f /dune/data/users/jwolcott/nd/nd-lar-reco/reco-out/mlreco_official_test2x2.2.h5 -o ../src/reco/DLP_h5_classes -ns cafmaker::types::dlp -d events -cn Event -d interactions -cn Interaction -d particles -cn Particle -d truth_interactions -cn TrueInteraction -d truth_particles -cn TrueParticle -d run_info -cn RunInfo
+//       ./h5_to_cpp.py -f /dune/data/users/jwolcott/nd/nd-lar-reco/reco-out/minirun4.00041.larcv.h5 -o ../src/reco/DLP_h5_classes -ns cafmaker::types::dlp -d events -cn Event -d interactions -cn Interaction -d particles -cn Particle -d truth_interactions -cn TrueInteraction -d truth_particles -cn TrueParticle -d run_info -cn RunInfo
 //
 
 
@@ -29,6 +29,7 @@ namespace cafmaker::types::dlp
   enum class Pid : int64_t
   {
     kElectron = 1,
+    kKaon = 5,
     kMuon = 2,
     kPhoton = 0,
     kPion = 3,
@@ -198,13 +199,13 @@ namespace cafmaker::types::dlp
   
   struct Event
   {
-    hdset_reg_ref_t meta;
     hdset_reg_ref_t run_info;
     hdset_reg_ref_t index;
-    hdset_reg_ref_t truth_interactions;
+    hdset_reg_ref_t meta;
     hdset_reg_ref_t interactions;
-    hdset_reg_ref_t particles;
+    hdset_reg_ref_t truth_interactions;
     hdset_reg_ref_t truth_particles;
+    hdset_reg_ref_t particles;
     
     void SyncVectors();
     
@@ -212,10 +213,10 @@ namespace cafmaker::types::dlp
     const hdset_reg_ref_t& GetRef() const
     {
       if constexpr(std::is_same_v<T, RunInfo>) return run_info;
-      else if(std::is_same_v<T, TrueInteraction>) return truth_interactions;
       else if(std::is_same_v<T, Interaction>) return interactions;
-      else if(std::is_same_v<T, Particle>) return particles;
+      else if(std::is_same_v<T, TrueInteraction>) return truth_interactions;
       else if(std::is_same_v<T, TrueParticle>) return truth_particles;
+      else if(std::is_same_v<T, Particle>) return particles;
     }
     
   };
@@ -248,7 +249,8 @@ namespace cafmaker::types::dlp
     int64_t size;
     char * topology;
     char * units;
-    std::array<double, 3> vertex;
+    std::array<float, 3> vertex;
+    char * vertex_mode;
     int64_t volume_id;
     
     void SyncVectors();
@@ -269,9 +271,10 @@ namespace cafmaker::types::dlp
   
   struct Particle
   {
-    double csda_kinetic_energy;
+    double calo_ke;
+    double csda_ke;
     double depositions_sum;
-    std::array<float, 3> end_dir;
+    std::array<double, 3> end_dir;
     std::array<double, 3> end_point;
     BufferView<int64_t> fragment_ids;
     int64_t id;
@@ -285,7 +288,8 @@ namespace cafmaker::types::dlp
     BufferView<int64_t> match;
     BufferView<float> match_overlap;
     uint8_t matched;
-    double momentum_mcs;
+    double mcs_ke;
+    std::array<double, 3> momentum;
     int64_t nu_id;
     int64_t num_fragments;
     int64_t pdg_code;
@@ -294,7 +298,7 @@ namespace cafmaker::types::dlp
     std::array<float, 2> primary_scores;
     SemanticType semantic_type;
     int64_t size;
-    std::array<float, 3> start_dir;
+    std::array<double, 3> start_dir;
     std::array<double, 3> start_point;
     char * units;
     int64_t volume_id;
@@ -339,6 +343,7 @@ namespace cafmaker::types::dlp
     int64_t nu_id;
     NuInteractionMode nu_interaction_mode;
     NuInteractionType nu_interaction_type;
+    int64_t nu_pdg_code;
     int64_t num_particles;
     int64_t num_primaries;
     std::array<int64_t, 6> particle_counts;
@@ -346,12 +351,14 @@ namespace cafmaker::types::dlp
     std::array<int64_t, 6> primary_counts;
     int64_t size;
     char * topology;
+    int64_t truth_id;
     BufferView<int64_t> truth_particle_counts;
     BufferView<int64_t> truth_primary_counts;
     char * truth_topology;
-    BufferView<double> truth_vertex;
+    std::array<double, 3> truth_vertex;
     char * units;
-    std::array<double, 3> vertex;
+    std::array<float, 3> vertex;
+    char * vertex_mode;
     int64_t volume_id;
     
     void SyncVectors();
@@ -369,7 +376,6 @@ namespace cafmaker::types::dlp
     hvl_t particle_ids_handle;
     hvl_t truth_particle_counts_handle;
     hvl_t truth_primary_counts_handle;
-    hvl_t truth_vertex_handle;
   };
   
   
@@ -380,15 +386,17 @@ namespace cafmaker::types::dlp
     BufferView<double> ancestor_position;
     double ancestor_t;
     int64_t ancestor_track_id;
+    double calo_ke;
+    double calo_ke_tng;
     BufferView<int64_t> children_counts;
     BufferView<double> children_id;
     char * creation_process;
-    double csda_kinetic_energy;
-    double csda_kinetic_energy_tng;
+    double csda_ke;
+    double csda_ke_tng;
     double depositions_sum;
     BufferView<double> direction;
     double distance_travel;
-    std::array<float, 3> end_dir;
+    std::array<double, 3> end_dir;
     std::array<double, 3> end_point;
     std::array<double, 3> end_position;
     double energy_deposit;
@@ -409,10 +417,11 @@ namespace cafmaker::types::dlp
     BufferView<int64_t> match;
     BufferView<float> match_overlap;
     uint8_t matched;
+    double mcs_ke;
+    double mcs_ke_tng;
     int64_t mcst_index;
     int64_t mct_index;
     std::array<double, 3> momentum;
-    double momentum_mcs;
     int64_t nu_id;
     int64_t num_fragments;
     int64_t num_voxels;
@@ -425,16 +434,14 @@ namespace cafmaker::types::dlp
     int64_t parent_track_id;
     int64_t pdg_code;
     Pid pid;
-    std::array<float, 5> pid_scores;
     BufferView<double> position;
-    std::array<float, 2> primary_scores;
     float sed_depositions_MeV_sum;
     BufferView<int64_t> sed_index;
     int64_t sed_size;
     SemanticType semantic_type;
     int64_t shape;
     int64_t size;
-    std::array<float, 3> start_dir;
+    std::array<double, 3> start_dir;
     std::array<double, 3> start_point;
     double t;
     int64_t track_id;

--- a/src/truth/FillTruth.h
+++ b/src/truth/FillTruth.h
@@ -106,7 +106,7 @@ namespace cafmaker
   class TruthMatcher : public cafmaker::Loggable
   {
     public:
-      TruthMatcher(TTree * contGTree, TTree * uncontGTree, const genie::NtpMCEventRecord * gEvt);
+      TruthMatcher(std::vector<TTree *> &contGTrees, std::vector<TTree *> &uncontGTrees, const genie::NtpMCEventRecord * gEvt);
 
       /// Find a TrueParticle within a given StandardRecord, or, if it doesn't exist, optionally make a new one
       ///
@@ -167,13 +167,15 @@ namespace cafmaker
                                                   std::function<bool(const genie::NtpMCEventRecord*)> genieCmp,
                                                   bool createNew = true) const;
 
-      bool HaveGENIE() const { return fContNuGTree != nullptr || fUncontNuGTree != nullptr; }
+      bool HaveGENIE() const;
 
     private:
       static void FillInteraction(caf::SRTrueInteraction& nu, const genie::NtpMCEventRecord * gEvt);
 
-      mutable TTree * fContNuGTree;           ///< GENIE tree for 'contained' neutrinos (near/inside the detector volumes)
-      mutable TTree * fUncontNuGTree;         ///< GENIE tree for 'uncontained' neutrinos (rock and/or ND hall interactions)
+      mutable std::vector<TTree*>    fContNuGTrees;         ///< GENIE tree(s) for 'contained' neutrinos (near/inside the detector volumes)
+      mutable int                    fLastFoundContTree;    ///< Index of tree in fContNuGTrees where last event was found
+      mutable std::vector<TTree*>    fUncontNuGTrees;       ///< GENIE tree(s) for 'uncontained' neutrinos (rock and/or ND hall interactions)
+      mutable int                    fLastFoundUncontTree;  ///< Index of tree in fUncontNuGTrees where last event was found
       const genie::NtpMCEventRecord * fGEvt;
   };
 }


### PR DESCRIPTION
A few important truth-matching updates to support 2x2 Minirun4:
* accept multiple GENIE .ghep files
* don't get duped by multiple particles with the same energy (e.g.: multiple muons from pion decay-at-rest) when matching to GENIE records