### PR TITLE
Eliminate truth-matching hacks

### DIFF
--- a/scripts/h5_to_cpp.py
+++ b/scripts/h5_to_cpp.py
@@ -16,6 +16,7 @@ numpy_to_hdf5 = {
     "i": "STD_I",
     "l": "STD_I",
     "B": "STD_U",
+    "L": "STD_I",
     "f": "IEEE_F",
     "d": "IEEE_F",
 }
@@ -332,6 +333,7 @@ class TypeSerializer:
             assert len(cpp_name) > 0, "Couldn't understand type name: '{0}'".format(typ.name)
 
         else:
+            print("typ.char =", typ.char)
             raise TypeError("Don't know how to handle type: " + str(typ))
 
         h5_name = h5_name.replace("H5T_", "")

--- a/src/CAF.cxx
+++ b/src/CAF.cxx
@@ -4,6 +4,8 @@
 
 #include "duneanaobj/StandardRecord/Flat/FlatRecord.h"
 
+#include "util/Logger.h"
+
 // fixme: once DIRT-II is done with its work, this will be re-enabled
 //#include "nusystematics/artless/response_helper.hh"
 
@@ -145,7 +147,7 @@ int CAF::StoreGENIEEvent(const genie::NtpMCEventRecord *evtIn)
     static bool warned = false;
     if (!warned)
     {
-      std::cerr << "WARNING: repeatedly reassigning the target pointer for output GENIE tree will result in significant performance penalty\n";
+      cafmaker::LOG_S().WARNING("CAF::StoreGENIEEvent()") << "Repeatedly reassigning the target pointer for output GENIE tree will result in significant performance degredation\n";
       warned = true;
     }
 

--- a/src/CAF.cxx
+++ b/src/CAF.cxx
@@ -147,7 +147,7 @@ int CAF::StoreGENIEEvent(const genie::NtpMCEventRecord *evtIn)
     static bool warned = false;
     if (!warned)
     {
-      cafmaker::LOG_S().WARNING("CAF::StoreGENIEEvent()") << "Repeatedly reassigning the target pointer for output GENIE tree will result in significant performance degredation\n";
+      cafmaker::LOG_S("CAF::StoreGENIEEvent()").WARNING() << "Repeatedly reassigning the target pointer for output GENIE tree will result in significant performance degredation\n";
       warned = true;
     }
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -36,7 +36,7 @@ all: $(BINS)
 test: $(BINDIR)/testHDF
 
 # make an object for any .cxx requested
-%.o : %.cxx %.h
+%.o : %.cxx $(if $(wildcard %.h),%.h,)
 	$(CXX) $(CXXFLAGS) $(ROOTFLAGS) $(INCLUDE) -fPIC $(SAND_OPT) -o $@ -c $< #compile
 
 # should *really* make a .d rule for the objects

--- a/src/Params.h
+++ b/src/Params.h
@@ -28,11 +28,8 @@ namespace cafmaker
   struct ControlConfig
   {
     // these are mandatory and have no default values
-    fhicl::OptionalSequence<std::string> contNuGHEPFiles     { fhicl::Name{"ContainedNuGHEPFiles"},   fhicl::Comment("Input .ghep (GENIE) file(s) for in-detector neutrinos") };
-//    fhicl::OptionalAtom<std::string> contNuGHEPFile     {fhicl::Name{"ContainedNuGHEPFile"},   fhicl::Comment("Input .ghep (GENIE) file for in-detector neutrinos") };
-    fhicl::OptionalSequence<std::string> uncontNuGHEPFiles   {fhicl::Name{"UncontainedNuGHEPFiles"}, fhicl::Comment("Input .ghep (GENIE) file(s) for rock/hall neutrinos") };
-//    fhicl::OptionalAtom<std::string> uncontNuGHEPFile   {fhicl::Name{"UncontainedNuGHEPFile"}, fhicl::Comment("Input .ghep (GENIE) file for rock/hall neutrinos") };
-    fhicl::Atom<std::string> outputFile                      { fhicl::Name{"OutputFile"},           fhicl::Comment("Filename for output CAF") };
+    fhicl::OptionalSequence<std::string> GHEPFiles     { fhicl::Name{"GHEPFiles"},   fhicl::Comment("Input .ghep (GENIE) file(s) for truth matching") };
+    fhicl::Atom<std::string>             outputFile    { fhicl::Name{"OutputFile"},  fhicl::Comment("Filename for output CAF") };
 
     // this one is mandatory but has a default.  (the 'fhicl.fcl' file is provided in the 'sim_inputs' directory).
     // fixme: this file is currently not used for anything, but will be once DIRT-II is done and re-enables the interaction systematics

--- a/src/makeCAF.C
+++ b/src/makeCAF.C
@@ -15,6 +15,9 @@
 #include "fhiclcpp/make_ParameterSet.h"
 #include "fhiclcpp/parse.h"
 
+// GENIE
+#include "Framework/Ntuple/NtpMCEventRecord.h"
+
 #include "CAF.h"
 #include "Params.h"
 #include "reco/MLNDLArRecoBranchFiller.h"
@@ -234,57 +237,16 @@ buildTriggerList(std::map<const cafmaker::IRecoBranchFiller*, std::deque<cafmake
 }
 
 // -------------------------------------------------
-
-struct GENIETree
-{
-  GENIETree(const std::string& fname)
-  : f(fname.empty() ? nullptr : std::make_unique<TFile>(fname.c_str())), tree(f ? dynamic_cast<TTree*>(f->Get("gtree")) : nullptr)
-  {
-    if (!fname.empty() && !tree)
-    {
-      cafmaker::LOG_S("main()").FATAL() << "Could not load TTree 'gtree' from supplied .ghep file: " << fname << "\n";
-      abort();
-    }
-  }
-
-  std::unique_ptr<TFile> f;
-  TTree * tree;
-
-};
-
-std::vector<TTree*> convertToBareTrees(const std::vector<GENIETree>& gtrees)
-{
-  std::vector<TTree*> ret;
-  std::transform(gtrees.begin(), gtrees.end(), std::back_inserter(ret), [](const GENIETree & gt) { return gt.tree; });
-  return ret;
-}
-
-// -------------------------------------------------
 // main loop function
 void loop(CAF &caf,
           cafmaker::Params &par,
-          std::vector<TTree *> && contGTrees,
-          std::vector<TTree *> && uncontGTrees,
+          const std::vector<std::string> & ghepFilenames,
           const std::vector<std::unique_ptr<cafmaker::IRecoBranchFiller>> &recoFillers)
 {
-
-  for (std::vector<TTree*>& treeCollection : std::vector<std::vector<TTree *>>{contGTrees, uncontGTrees})
-  {
-    for (TTree * tree : treeCollection)
-    {
-      if (!tree)
-        continue;
-
-      // yes, we're attaching all the trees to the same record.
-      // we'll never be using them at the same time, so it should be ok.
-      tree->SetBranchAddress("gmcrec", &caf.mcrec);
-    }
-  }
-
   // if this is a data file, there won't be any truth, of course,
   // but the TruthMatching knows not to try to do anything with a null gtree
   cafmaker::Logger::THRESHOLD thresh = cafmaker::Logger::parseStringThresh(par().cafmaker().verbosity());
-  cafmaker::TruthMatcher truthMatcher(contGTrees, uncontGTrees, caf.mcrec,
+  cafmaker::TruthMatcher truthMatcher(ghepFilenames, caf.mcrec,
                                       [&caf](const genie::NtpMCEventRecord* mcrec){ return caf.StoreGENIEEvent(mcrec); });
   truthMatcher.SetLogThrehsold(thresh);
 
@@ -356,21 +318,12 @@ int main( int argc, char const *argv[] )
   cafmaker::Logger::THRESHOLD logThresh = cafmaker::Logger::parseStringThresh(par().cafmaker().verbosity());
   cafmaker::LOG_S().SetThreshold(logThresh);
 
-  std::map<std::string, std::vector<GENIETree>> treeBundles;
-  std::vector<std::string> contNuGHEPFiles;
-  treeBundles["contained"], treeBundles["uncontained"]; // just make sure these vectors exist
-  for (const std::string & fname : (par().cafmaker().contNuGHEPFiles(contNuGHEPFiles) ? contNuGHEPFiles : std::vector<std::string>{}))
-    treeBundles["contained"].emplace_back(fname);
-  std::vector<std::string> uncontNuGHEPFiles;
-  for (const std::string & fname : (par().cafmaker().uncontNuGHEPFiles(uncontNuGHEPFiles) ? uncontNuGHEPFiles : std::vector<std::string>{}))
-    treeBundles["uncontained"].emplace_back(fname);
+  std::vector<std::string> GHEPFiles;
+  par().cafmaker().GHEPFiles(GHEPFiles);  // fills the vector in if the key is found
 
-  CAF caf(par().cafmaker().outputFile(), par().cafmaker().nusystsFcl(), par().cafmaker().makeFlatCAF(), !(treeBundles["contained"].empty() && treeBundles["uncontained"].empty()));
+  CAF caf(par().cafmaker().outputFile(), par().cafmaker().nusystsFcl(), par().cafmaker().makeFlatCAF(), !GHEPFiles.empty());
 
-  loop(caf, par,
-       convertToBareTrees(treeBundles.at("contained")),
-       convertToBareTrees(treeBundles.at("uncontained")),
-       getRecoFillers(par, logThresh));
+  loop(caf, par, GHEPFiles, getRecoFillers(par, logThresh));
 
   caf.version = 5;
   printf( "Run %d POT %g\n", caf.meta_run, caf.pot );

--- a/src/makeCAF.C
+++ b/src/makeCAF.C
@@ -99,8 +99,7 @@ fhicl::Table<cafmaker::FhiclConfig> parseConfig(const std::string & configFile, 
     provisional.put("nd_cafmaker.CAFMakerSettings.NumEvts", vm["numevts"].as<int>());
 
   // now that we've updated it, convert to actual ParameterSet
-  fhicl::ParameterSet pset;
-  fhicl::make_ParameterSet(provisional, pset);
+  fhicl::ParameterSet pset = fhicl::ParameterSet::make(provisional);
 
   // finally, convert to a table, which does the validation.
   // note that this usage insists the top-level config be named "nd_cafmaker".

--- a/src/reco/DLP_h5_classes.cxx
+++ b/src/reco/DLP_h5_classes.cxx
@@ -5,7 +5,7 @@
 //    
 //    The invocation that generated this file was:
 //
-//       ./h5_to_cpp.py -f /dune/data/users/skumara/Datafiles_2x2/MLreco_h5files/test_minirun4.h5 -o ../src/reco/DLP_h5_classes -ns cafmaker::types::dlp -d events -cn Event -d interactions -cn Interaction -d particles -cn Particle -d truth_interactions -cn TrueInteraction -d truth_particles -cn TrueParticle -d run_info -cn RunInfo
+//       ./h5_to_cpp.py -f /home/jeremy/data/dune/data/users/jwolcott/nd/nd-lar-reco/reco-out/PicoRun4_1E17_RHC.larnd.00003.reco.summary.h5 -o ../src/reco/DLP_h5_classes -ns cafmaker::types::dlp -d events -cn Event -d interactions -cn Interaction -d particles -cn Particle -d truth_interactions -cn TrueInteraction -d truth_particles -cn TrueParticle -d run_info -cn RunInfo
 //
 
 #include "DLP_h5_classes.h"
@@ -79,14 +79,14 @@ namespace cafmaker::types::dlp
   H5::CompType BuildCompType<Event>()
   {
     H5::CompType ctype(sizeof(Event));
-
+  
     ctype.insertMember("run_info", HOFFSET(Event, run_info), H5::PredType::STD_REF_DSETREG);
-    ctype.insertMember("index", HOFFSET(Event, index), H5::PredType::STD_REF_DSETREG);
     ctype.insertMember("meta", HOFFSET(Event, meta), H5::PredType::STD_REF_DSETREG);
-    ctype.insertMember("truth_particles", HOFFSET(Event, truth_particles), H5::PredType::STD_REF_DSETREG);
+    ctype.insertMember("index", HOFFSET(Event, index), H5::PredType::STD_REF_DSETREG);
     ctype.insertMember("particles", HOFFSET(Event, particles), H5::PredType::STD_REF_DSETREG);
-    ctype.insertMember("interactions", HOFFSET(Event, interactions), H5::PredType::STD_REF_DSETREG);
     ctype.insertMember("truth_interactions", HOFFSET(Event, truth_interactions), H5::PredType::STD_REF_DSETREG);
+    ctype.insertMember("truth_particles", HOFFSET(Event, truth_particles), H5::PredType::STD_REF_DSETREG);
+    ctype.insertMember("interactions", HOFFSET(Event, interactions), H5::PredType::STD_REF_DSETREG);
   
     return ctype;
   }
@@ -108,6 +108,7 @@ namespace cafmaker::types::dlp
     ctype.insertMember("id", HOFFSET(Interaction, id), H5::PredType::STD_I64LE);
     ctype.insertMember("image_id", HOFFSET(Interaction, image_id), H5::PredType::STD_I64LE);
     ctype.insertMember("is_contained", HOFFSET(Interaction, is_contained), H5::PredType::STD_U8LE);
+    ctype.insertMember("is_fiducial", HOFFSET(Interaction, is_fiducial), H5::PredType::STD_U8LE);
     ctype.insertMember("is_neutrino", HOFFSET(Interaction, is_neutrino), H5::PredType::STD_U8LE);
     ctype.insertMember("is_principal_match", HOFFSET(Interaction, is_principal_match), H5::PredType::STD_U8LE);
     ctype.insertMember("match", HOFFSET(Interaction, match_handle), H5::VarLenType(H5::PredType::STD_I64LE));
@@ -131,11 +132,11 @@ namespace cafmaker::types::dlp
     ctype.insertMember("units", HOFFSET(Interaction, units), units_strType);
     
     ctype.insertMember("vertex", HOFFSET(Interaction, vertex), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
-
+    
     H5::StrType vertex_mode_strType(H5::PredType::C_S1, H5T_VARIABLE);
     vertex_mode_strType.setCset(H5T_CSET_UTF8);
     ctype.insertMember("vertex_mode", HOFFSET(Interaction, vertex_mode), vertex_mode_strType);
-
+    
     ctype.insertMember("volume_id", HOFFSET(Interaction, volume_id), H5::PredType::STD_I64LE);
   
     return ctype;
@@ -150,8 +151,8 @@ namespace cafmaker::types::dlp
     ctype.insertMember("calo_ke", HOFFSET(Particle, calo_ke), H5::PredType::IEEE_F64LE);
     ctype.insertMember("csda_ke", HOFFSET(Particle, csda_ke), H5::PredType::IEEE_F64LE);
     ctype.insertMember("depositions_sum", HOFFSET(Particle, depositions_sum), H5::PredType::IEEE_F64LE);
-    ctype.insertMember("end_dir", HOFFSET(Particle, end_dir), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
-    ctype.insertMember("end_point", HOFFSET(Particle, end_point), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
+    ctype.insertMember("end_dir", HOFFSET(Particle, end_dir), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
+    ctype.insertMember("end_point", HOFFSET(Particle, end_point), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("fragment_ids", HOFFSET(Particle, fragment_ids_handle), H5::VarLenType(H5::PredType::STD_I64LE));
     ctype.insertMember("id", HOFFSET(Particle, id), H5::PredType::STD_I64LE);
     ctype.insertMember("image_id", HOFFSET(Particle, image_id), H5::PredType::STD_I64LE);
@@ -165,7 +166,7 @@ namespace cafmaker::types::dlp
     ctype.insertMember("match_overlap", HOFFSET(Particle, match_overlap_handle), H5::VarLenType(H5::PredType::IEEE_F32LE));
     ctype.insertMember("matched", HOFFSET(Particle, matched), H5::PredType::STD_U8LE);
     ctype.insertMember("mcs_ke", HOFFSET(Particle, mcs_ke), H5::PredType::IEEE_F64LE);
-    ctype.insertMember("momentum", HOFFSET(Particle, momentum), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
+    ctype.insertMember("momentum", HOFFSET(Particle, momentum), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("nu_id", HOFFSET(Particle, nu_id), H5::PredType::STD_I64LE);
     ctype.insertMember("num_fragments", HOFFSET(Particle, num_fragments), H5::PredType::STD_I64LE);
     ctype.insertMember("pdg_code", HOFFSET(Particle, pdg_code), H5::PredType::STD_I64LE);
@@ -180,7 +181,7 @@ namespace cafmaker::types::dlp
       pid_enum_val = 4; pid_enumtype.insert("Proton", &pid_enum_val);
     ctype.insertMember("pid", HOFFSET(Particle, pid), pid_enumtype);
     
-    ctype.insertMember("pid_scores", HOFFSET(Particle, pid_scores), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{5}[0]));
+    ctype.insertMember("pid_scores", HOFFSET(Particle, pid_scores), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{6}[0]));
     ctype.insertMember("primary_scores", HOFFSET(Particle, primary_scores), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{2}[0]));
     
     H5::EnumType semantic_type_enumtype(H5::PredType::STD_I64LE);
@@ -195,8 +196,8 @@ namespace cafmaker::types::dlp
     ctype.insertMember("semantic_type", HOFFSET(Particle, semantic_type), semantic_type_enumtype);
     
     ctype.insertMember("size", HOFFSET(Particle, size), H5::PredType::STD_I64LE);
-    ctype.insertMember("start_dir", HOFFSET(Particle, start_dir), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
-    ctype.insertMember("start_point", HOFFSET(Particle, start_point), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
+    ctype.insertMember("start_dir", HOFFSET(Particle, start_dir), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
+    ctype.insertMember("start_point", HOFFSET(Particle, start_point), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
     
     H5::StrType units_strType(H5::PredType::C_S1, H5T_VARIABLE);
     units_strType.setCset(H5T_CSET_UTF8);
@@ -224,6 +225,7 @@ namespace cafmaker::types::dlp
     ctype.insertMember("id", HOFFSET(TrueInteraction, id), H5::PredType::STD_I64LE);
     ctype.insertMember("image_id", HOFFSET(TrueInteraction, image_id), H5::PredType::STD_I64LE);
     ctype.insertMember("is_contained", HOFFSET(TrueInteraction, is_contained), H5::PredType::STD_U8LE);
+    ctype.insertMember("is_fiducial", HOFFSET(TrueInteraction, is_fiducial), H5::PredType::STD_U8LE);
     ctype.insertMember("is_neutrino", HOFFSET(TrueInteraction, is_neutrino), H5::PredType::STD_U8LE);
     ctype.insertMember("is_principal_match", HOFFSET(TrueInteraction, is_principal_match), H5::PredType::STD_U8LE);
     ctype.insertMember("match", HOFFSET(TrueInteraction, match_handle), H5::VarLenType(H5::PredType::STD_I64LE));
@@ -393,18 +395,18 @@ namespace cafmaker::types::dlp
     truth_topology_strType.setCset(H5T_CSET_UTF8);
     ctype.insertMember("truth_topology", HOFFSET(TrueInteraction, truth_topology), truth_topology_strType);
     
-    ctype.insertMember("truth_vertex", HOFFSET(TrueInteraction, truth_vertex), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
+    ctype.insertMember("truth_vertex", HOFFSET(TrueInteraction, truth_vertex), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
     
     H5::StrType units_strType(H5::PredType::C_S1, H5T_VARIABLE);
     units_strType.setCset(H5T_CSET_UTF8);
     ctype.insertMember("units", HOFFSET(TrueInteraction, units), units_strType);
     
     ctype.insertMember("vertex", HOFFSET(TrueInteraction, vertex), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
-
+    
     H5::StrType vertex_mode_strType(H5::PredType::C_S1, H5T_VARIABLE);
     vertex_mode_strType.setCset(H5T_CSET_UTF8);
     ctype.insertMember("vertex_mode", HOFFSET(TrueInteraction, vertex_mode), vertex_mode_strType);
-
+    
     ctype.insertMember("volume_id", HOFFSET(TrueInteraction, volume_id), H5::PredType::STD_I64LE);
   
     return ctype;
@@ -422,13 +424,13 @@ namespace cafmaker::types::dlp
     ctype.insertMember("ancestor_creation_process", HOFFSET(TrueParticle, ancestor_creation_process), ancestor_creation_process_strType);
     
     ctype.insertMember("ancestor_pdg_code", HOFFSET(TrueParticle, ancestor_pdg_code), H5::PredType::STD_I64LE);
-    ctype.insertMember("ancestor_position", HOFFSET(TrueParticle, ancestor_position_handle), H5::VarLenType(H5::PredType::IEEE_F64LE));
+    ctype.insertMember("ancestor_position", HOFFSET(TrueParticle, ancestor_position_handle), H5::VarLenType(H5::PredType::IEEE_F32LE));
     ctype.insertMember("ancestor_t", HOFFSET(TrueParticle, ancestor_t), H5::PredType::IEEE_F64LE);
     ctype.insertMember("ancestor_track_id", HOFFSET(TrueParticle, ancestor_track_id), H5::PredType::STD_I64LE);
     ctype.insertMember("calo_ke", HOFFSET(TrueParticle, calo_ke), H5::PredType::IEEE_F64LE);
     ctype.insertMember("calo_ke_tng", HOFFSET(TrueParticle, calo_ke_tng), H5::PredType::IEEE_F64LE);
     ctype.insertMember("children_counts", HOFFSET(TrueParticle, children_counts_handle), H5::VarLenType(H5::PredType::STD_I64LE));
-    ctype.insertMember("children_id", HOFFSET(TrueParticle, children_id_handle), H5::VarLenType(H5::PredType::IEEE_F64LE));
+    ctype.insertMember("children_id", HOFFSET(TrueParticle, children_id_handle), H5::VarLenType(H5::PredType::STD_I64LE));
     
     H5::StrType creation_process_strType(H5::PredType::C_S1, H5T_VARIABLE);
     creation_process_strType.setCset(H5T_CSET_UTF8);
@@ -439,12 +441,12 @@ namespace cafmaker::types::dlp
     ctype.insertMember("depositions_sum", HOFFSET(TrueParticle, depositions_sum), H5::PredType::IEEE_F64LE);
     ctype.insertMember("direction", HOFFSET(TrueParticle, direction_handle), H5::VarLenType(H5::PredType::IEEE_F64LE));
     ctype.insertMember("distance_travel", HOFFSET(TrueParticle, distance_travel), H5::PredType::IEEE_F64LE);
-    ctype.insertMember("end_dir", HOFFSET(TrueParticle, end_dir), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
-    ctype.insertMember("end_point", HOFFSET(TrueParticle, end_point), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
-    ctype.insertMember("end_position", HOFFSET(TrueParticle, end_position), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
+    ctype.insertMember("end_dir", HOFFSET(TrueParticle, end_dir), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
+    ctype.insertMember("end_point", HOFFSET(TrueParticle, end_point), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
+    ctype.insertMember("end_position", HOFFSET(TrueParticle, end_position), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("energy_deposit", HOFFSET(TrueParticle, energy_deposit), H5::PredType::IEEE_F64LE);
     ctype.insertMember("energy_init", HOFFSET(TrueParticle, energy_init), H5::PredType::IEEE_F64LE);
-    ctype.insertMember("first_step", HOFFSET(TrueParticle, first_step_handle), H5::VarLenType(H5::PredType::IEEE_F64LE));
+    ctype.insertMember("first_step", HOFFSET(TrueParticle, first_step_handle), H5::VarLenType(H5::PredType::IEEE_F32LE));
     ctype.insertMember("fragment_ids", HOFFSET(TrueParticle, fragment_ids_handle), H5::VarLenType(H5::PredType::STD_I64LE));
     ctype.insertMember("group_id", HOFFSET(TrueParticle, group_id), H5::PredType::STD_I64LE);
     ctype.insertMember("id", HOFFSET(TrueParticle, id), H5::PredType::STD_I64LE);
@@ -454,7 +456,7 @@ namespace cafmaker::types::dlp
     ctype.insertMember("is_contained", HOFFSET(TrueParticle, is_contained), H5::PredType::STD_U8LE);
     ctype.insertMember("is_primary", HOFFSET(TrueParticle, is_primary), H5::PredType::STD_U8LE);
     ctype.insertMember("is_principal_match", HOFFSET(TrueParticle, is_principal_match), H5::PredType::STD_U8LE);
-    ctype.insertMember("last_step", HOFFSET(TrueParticle, last_step_handle), H5::VarLenType(H5::PredType::IEEE_F64LE));
+    ctype.insertMember("last_step", HOFFSET(TrueParticle, last_step_handle), H5::VarLenType(H5::PredType::IEEE_F32LE));
     ctype.insertMember("length", HOFFSET(TrueParticle, length), H5::PredType::IEEE_F64LE);
     ctype.insertMember("length_tng", HOFFSET(TrueParticle, length_tng), H5::PredType::IEEE_F64LE);
     ctype.insertMember("match", HOFFSET(TrueParticle, match_handle), H5::VarLenType(H5::PredType::STD_I64LE));
@@ -476,7 +478,7 @@ namespace cafmaker::types::dlp
     
     ctype.insertMember("parent_id", HOFFSET(TrueParticle, parent_id), H5::PredType::STD_I64LE);
     ctype.insertMember("parent_pdg_code", HOFFSET(TrueParticle, parent_pdg_code), H5::PredType::STD_I64LE);
-    ctype.insertMember("parent_position", HOFFSET(TrueParticle, parent_position_handle), H5::VarLenType(H5::PredType::IEEE_F64LE));
+    ctype.insertMember("parent_position", HOFFSET(TrueParticle, parent_position_handle), H5::VarLenType(H5::PredType::IEEE_F32LE));
     ctype.insertMember("parent_t", HOFFSET(TrueParticle, parent_t), H5::PredType::IEEE_F64LE);
     ctype.insertMember("parent_track_id", HOFFSET(TrueParticle, parent_track_id), H5::PredType::STD_I64LE);
     ctype.insertMember("pdg_code", HOFFSET(TrueParticle, pdg_code), H5::PredType::STD_I64LE);
@@ -490,8 +492,8 @@ namespace cafmaker::types::dlp
       pid_enum_val = 3; pid_enumtype.insert("Pion", &pid_enum_val);
       pid_enum_val = 4; pid_enumtype.insert("Proton", &pid_enum_val);
     ctype.insertMember("pid", HOFFSET(TrueParticle, pid), pid_enumtype);
-
-    ctype.insertMember("position", HOFFSET(TrueParticle, position_handle), H5::VarLenType(H5::PredType::IEEE_F64LE));
+    
+    ctype.insertMember("position", HOFFSET(TrueParticle, position_handle), H5::VarLenType(H5::PredType::IEEE_F32LE));
     ctype.insertMember("sed_depositions_MeV_sum", HOFFSET(TrueParticle, sed_depositions_MeV_sum), H5::PredType::IEEE_F32LE);
     ctype.insertMember("sed_index", HOFFSET(TrueParticle, sed_index_handle), H5::VarLenType(H5::PredType::STD_I64LE));
     ctype.insertMember("sed_size", HOFFSET(TrueParticle, sed_size), H5::PredType::STD_I64LE);
@@ -509,8 +511,8 @@ namespace cafmaker::types::dlp
     
     ctype.insertMember("shape", HOFFSET(TrueParticle, shape), H5::PredType::STD_I64LE);
     ctype.insertMember("size", HOFFSET(TrueParticle, size), H5::PredType::STD_I64LE);
-    ctype.insertMember("start_dir", HOFFSET(TrueParticle, start_dir), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
-    ctype.insertMember("start_point", HOFFSET(TrueParticle, start_point), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
+    ctype.insertMember("start_dir", HOFFSET(TrueParticle, start_dir), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
+    ctype.insertMember("start_point", HOFFSET(TrueParticle, start_point), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("t", HOFFSET(TrueParticle, t), H5::PredType::IEEE_F64LE);
     ctype.insertMember("track_id", HOFFSET(TrueParticle, track_id), H5::PredType::STD_I64LE);
     ctype.insertMember("truth_depositions_MeV_sum", HOFFSET(TrueParticle, truth_depositions_MeV_sum), H5::PredType::IEEE_F32LE);

--- a/src/reco/DLP_h5_classes.h
+++ b/src/reco/DLP_h5_classes.h
@@ -5,7 +5,7 @@
 //    
 //    The invocation that generated this file was:
 //
-//       ./h5_to_cpp.py -f /dune/data/users/skumara/Datafiles_2x2/MLreco_h5files/test_minirun4.h5 -o ../src/reco/DLP_h5_classes -ns cafmaker::types::dlp -d events -cn Event -d interactions -cn Interaction -d particles -cn Particle -d truth_interactions -cn TrueInteraction -d truth_particles -cn TrueParticle -d run_info -cn RunInfo
+//       ./h5_to_cpp.py -f /dune/data/users/jwolcott/nd/nd-lar-reco/reco-out/PicoRun4_1E17_RHC.larnd.00003.reco.summary.h5 -o ../src/reco/DLP_h5_classes -ns cafmaker::types::dlp -d events -cn Event -d interactions -cn Interaction -d particles -cn Particle -d truth_interactions -cn TrueInteraction -d truth_particles -cn TrueParticle -d run_info -cn RunInfo
 //
 
 
@@ -200,12 +200,12 @@ namespace cafmaker::types::dlp
   struct Event
   {
     hdset_reg_ref_t run_info;
-    hdset_reg_ref_t index;
     hdset_reg_ref_t meta;
-    hdset_reg_ref_t truth_particles;
+    hdset_reg_ref_t index;
     hdset_reg_ref_t particles;
-    hdset_reg_ref_t interactions;
     hdset_reg_ref_t truth_interactions;
+    hdset_reg_ref_t truth_particles;
+    hdset_reg_ref_t interactions;
     
     void SyncVectors();
     
@@ -213,10 +213,10 @@ namespace cafmaker::types::dlp
     const hdset_reg_ref_t& GetRef() const
     {
       if constexpr(std::is_same_v<T, RunInfo>) return run_info;
-      else if(std::is_same_v<T, TrueParticle>) return truth_particles;
       else if(std::is_same_v<T, Particle>) return particles;
-      else if(std::is_same_v<T, Interaction>) return interactions;
       else if(std::is_same_v<T, TrueInteraction>) return truth_interactions;
+      else if(std::is_same_v<T, TrueParticle>) return truth_particles;
+      else if(std::is_same_v<T, Interaction>) return interactions;
     }
     
   };
@@ -235,6 +235,7 @@ namespace cafmaker::types::dlp
     int64_t id;
     int64_t image_id;
     bool is_contained;
+    bool is_fiducial;
     bool is_neutrino;
     bool is_principal_match;
     BufferView<int64_t> match;
@@ -274,8 +275,8 @@ namespace cafmaker::types::dlp
     double calo_ke;
     double csda_ke;
     double depositions_sum;
-    std::array<double, 3> end_dir;
-    std::array<double, 3> end_point;
+    std::array<float, 3> end_dir;
+    std::array<float, 3> end_point;
     BufferView<int64_t> fragment_ids;
     int64_t id;
     int64_t image_id;
@@ -289,17 +290,17 @@ namespace cafmaker::types::dlp
     BufferView<float> match_overlap;
     uint8_t matched;
     double mcs_ke;
-    std::array<double, 3> momentum;
+    std::array<float, 3> momentum;
     int64_t nu_id;
     int64_t num_fragments;
     int64_t pdg_code;
     Pid pid;
-    std::array<float, 5> pid_scores;
+    std::array<float, 6> pid_scores;
     std::array<float, 2> primary_scores;
     SemanticType semantic_type;
     int64_t size;
-    std::array<double, 3> start_dir;
-    std::array<double, 3> start_point;
+    std::array<float, 3> start_dir;
+    std::array<float, 3> start_point;
     char * units;
     int64_t volume_id;
     
@@ -333,6 +334,7 @@ namespace cafmaker::types::dlp
     int64_t id;
     int64_t image_id;
     bool is_contained;
+    bool is_fiducial;
     bool is_neutrino;
     bool is_principal_match;
     BufferView<int64_t> match;
@@ -355,7 +357,7 @@ namespace cafmaker::types::dlp
     BufferView<int64_t> truth_particle_counts;
     BufferView<int64_t> truth_primary_counts;
     char * truth_topology;
-    std::array<double, 3> truth_vertex;
+    std::array<float, 3> truth_vertex;
     char * units;
     std::array<float, 3> vertex;
     char * vertex_mode;
@@ -383,25 +385,25 @@ namespace cafmaker::types::dlp
   {
     char * ancestor_creation_process;
     int64_t ancestor_pdg_code;
-    BufferView<double> ancestor_position;
+    BufferView<float> ancestor_position;
     double ancestor_t;
     int64_t ancestor_track_id;
     double calo_ke;
     double calo_ke_tng;
     BufferView<int64_t> children_counts;
-    BufferView<double> children_id;
+    BufferView<uint64_t> children_id;
     char * creation_process;
     double csda_ke;
     double csda_ke_tng;
     double depositions_sum;
     BufferView<double> direction;
     double distance_travel;
-    std::array<double, 3> end_dir;
-    std::array<double, 3> end_point;
-    std::array<double, 3> end_position;
+    std::array<float, 3> end_dir;
+    std::array<float, 3> end_point;
+    std::array<float, 3> end_position;
     double energy_deposit;
     double energy_init;
-    BufferView<double> first_step;
+    BufferView<float> first_step;
     BufferView<int64_t> fragment_ids;
     int64_t group_id;
     int64_t id;
@@ -411,7 +413,7 @@ namespace cafmaker::types::dlp
     bool is_contained;
     bool is_primary;
     bool is_principal_match;
-    BufferView<double> last_step;
+    BufferView<float> last_step;
     double length;
     double length_tng;
     BufferView<int64_t> match;
@@ -429,20 +431,20 @@ namespace cafmaker::types::dlp
     char * parent_creation_process;
     int64_t parent_id;
     int64_t parent_pdg_code;
-    BufferView<double> parent_position;
+    BufferView<float> parent_position;
     double parent_t;
     int64_t parent_track_id;
     int64_t pdg_code;
     Pid pid;
-    BufferView<double> position;
+    BufferView<float> position;
     float sed_depositions_MeV_sum;
     BufferView<int64_t> sed_index;
     int64_t sed_size;
     SemanticType semantic_type;
     int64_t shape;
     int64_t size;
-    std::array<double, 3> start_dir;
-    std::array<double, 3> start_point;
+    std::array<float, 3> start_dir;
+    std::array<float, 3> start_point;
     double t;
     int64_t track_id;
     float truth_depositions_MeV_sum;

--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -208,9 +208,6 @@ namespace cafmaker
 
     const auto NaN = std::numeric_limits<float>::signaling_NaN();
 
-    // todo: once cafmaker::types::dlp::TrueInteraction::track_id actually has the unique neutrino ID in it, re-enable this
-//    ValidateOrCopy(ptTrueInt.track_id, srTrueInt.id, -1);
-
     ValidateOrCopy(ptTrueInt.vertex[0], srTrueInt.vtx.x, NaN);
     ValidateOrCopy(ptTrueInt.vertex[1], srTrueInt.vtx.y, NaN);
     ValidateOrCopy(ptTrueInt.vertex[2], srTrueInt.vtx.z, NaN);

--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -5,10 +5,6 @@
 // StandardRecord format
 #include "duneanaobj/StandardRecord/StandardRecord.h"
 
-// GENIE.  we only need these here because of hacks below...
-#include "Framework/Ntuple/NtpMCEventRecord.h"
-#include "Framework/GHEP/GHepParticle.h"
-
 // our headers
 #include "DLP_h5_classes.h"
 #include "Params.h"
@@ -332,26 +328,6 @@ namespace cafmaker
 
   namespace
   {
-    struct SRCmp
-    {
-      float lepE;
-      int   lepPDG;
-      bool operator()(const caf::SRTrueInteraction & ixn) const
-      {
-        return std::any_of(ixn.prim.begin(), ixn.prim.end(),
-                           [this](const caf::SRTrueParticle & part)
-                           {
-                             int abspdg = std::abs(part.pdg);
-                             if (abspdg >= 11 && abspdg <= 16)
-                             {
-                               if (std::abs(part.p.E - lepE) < 1e-6)
-                                 return true;
-                             }
-                             return false;
-                           });
-      }
-    };
-
     struct SRPartCmp
     {
       float E;
@@ -363,52 +339,6 @@ namespace cafmaker
         return part.p.E == E && (trkid < 0 || part.G4ID < 0 || trkid == part.G4ID);
       }
     };
-
-    struct GENIECmp
-    {
-      float lepE;
-      bool operator()(const genie::NtpMCEventRecord * gEvt) const
-      {
-//        LOG_S("GENIECmp").VERBOSE() << "  GENIE E = " << gEvt->event->FinalStatePrimaryLepton()->E() << ", lepE = " << lepE << " ";
-        return std::abs(static_cast<float>(gEvt->event->FinalStatePrimaryLepton()->E()) - lepE) < 1e-6;
-      }
-    };
-
-    void SetCmpLepE(const H5DataView <cafmaker::types::dlp::TrueParticle> &trueParticles,
-                    const cafmaker::types::dlp::TrueInteraction &trueIxnPassThrough,
-                    SRCmp &srCmp,
-                    GENIECmp &genieCmp)
-    {
-      float lepE = std::numeric_limits<float>::signaling_NaN();
-      int lepPDG = -1;
-
-      LOG_S("SetCmpLep()").VERBOSE() << "      pdgs, is_primary, energies of particles in interaction:\n";
-      for (long int partIdx : trueIxnPassThrough.particle_ids)
-      {
-        const cafmaker::types::dlp::TrueParticle &part = trueParticles[partIdx];
-        LOG_S("SetCmpLep()").VERBOSE()  << "         " << part.pdg_code << ", " << part.is_primary << ", " << part.energy_init/1000. << "\n";
-        long int abspdg = std::abs(part.pdg_code);
-
-        // rock muons are the only non-primaries we consider here
-        if ((part.is_primary && abspdg >= 11 && abspdg <= 16) || abspdg == 13)
-        {
-          lepE = part.energy_init;
-          lepPDG = part.pdg_code;
-          break;
-        }
-      }
-
-      // rock mus aren't "primary" for some reason,
-      // so we need to ensure we *did* find *some* primary
-      // before triggering this condition
-      if (std::isnan(lepE))
-        throw std::runtime_error("Couldn't find any lepton in true interaction!");
-
-      srCmp.lepE = genieCmp.lepE = lepE / 1000.;
-      srCmp.lepPDG = lepPDG;
-      LOG_S("SetCmpLep()").VERBOSE()  << "       --> found primary lepton with energy = " << srCmp.lepE << "\n";
-    }
-
   }
 
 
@@ -421,10 +351,6 @@ namespace cafmaker
   {
     sr.common.ixn.dlp.reserve(ixns.size());
     sr.common.ixn.ndlp = ixns.size();
-
-    // note: used in hack below
-    static SRCmp srCmp;
-    static GENIECmp genieCmp;
 
     LOG.DEBUG() << "Filling reco interactions...\n";
     for (const auto & ixn : ixns)
@@ -443,41 +369,7 @@ namespace cafmaker
 
           LOG.VERBOSE() << "  ** Finding matched true interaction with ML-reco ID = " << trueIxnPassThrough.id << "\n";
 
-          // todo: this hack exists for now because
-          //       we have no handle in cafmaker::types::dlp::TrueInteraction
-          //       containing the vertexID from upstream (which uniquely identifies the neutrino).
-          //       WIP...
-          // begin hack------------------------------------------------
-          try
-          {
-            SetCmpLepE(trueParticles, trueIxnPassThrough, srCmp, genieCmp);
-          }
-          catch (std::runtime_error & err)  // thrown if no lepton could be found
-          {
-            // if we couldn't find ANY lepton, there's no point continuing.
-            // we won't be able to match.
-            continue;
-          }
-
-          // first ask for the right truth match from the matcher.
-          // if we have GENIE info it'll come pre-filled with all its info & sub-particles
-          LOG.VERBOSE() << "  searching for SRTrueInteraction with primary lepton energy = " << srCmp.lepE << "\n";
-          caf::SRTrueInteraction & srTrueInt = truthMatch->GetTrueInteraction(sr, srCmp, genieCmp);
-
-          // if there's no GENIE info available, we won't get a SRTrueParticle in the stack
-          // with the lepton energy, which will make it impossible to match this interaction...
-          if (!truthMatch->HaveGENIE())
-          {
-            srTrueInt.prim.emplace_back();
-            srTrueInt.prim.back().pdg = srCmp.lepPDG;
-            srTrueInt.prim.back().p.E = srCmp.lepE;
-          }
-
-          // end hack -----------------------------------------------------------------------
-
-         // todo: re-enable when hack above no longer needed
-//          caf::SRTrueInteraction & srTrueInt = truthMatch->GetTrueInteraction(sr, trueIxnPassThrough.track_id);  // yes, track_id.  that's where the neutrino ID from edep-sim will be stored
-
+          caf::SRTrueInteraction & srTrueInt = truthMatch->GetTrueInteraction(sr, trueIxnPassThrough.truth_id);  // or 'track_id'? need to verify
 
           LOG.VERBOSE() << "    --> resulting SRTrueInteraction has the following particles in it:\n";
           for (const caf::SRTrueParticle & part : srTrueInt.prim)
@@ -521,8 +413,6 @@ namespace cafmaker
     LOG.DEBUG() << "Filling reco particles...\n";
 
     // note: used in the hack further below
-    static SRCmp srCmp;
-    static GENIECmp genieCmp;
     static SRPartCmp srPartCmp;
 
     //filling reco particles regardless of semantic type (track/shower)
@@ -535,25 +425,29 @@ namespace cafmaker
       reco_particle.start = caf::SRVector3D(part.start_point[0], part.start_point[1], part.start_point[2]);
       reco_particle.end = caf::SRVector3D(part.end_point[0], part.end_point[1], part.end_point[2]);
       if(part.semantic_type == types::dlp::SemanticType::kTrack){
-	if(reco_particle.contained){
+        if(reco_particle.contained)
+        {
            reco_particle.E = part.csda_ke/1000.;
            reco_particle.E_method = caf::PartEMethod::kRange;
-	}
-	else{
-      	   reco_particle.E = part.mcs_ke/1000.;
-    	   reco_particle.E_method = caf::PartEMethod::kMCS;
-	}
+        }
+        else
+        {
+          reco_particle.E = part.mcs_ke/1000.;
+          reco_particle.E_method = caf::PartEMethod::kMCS;
+        }
       }
-      else{
+      else
+      {
         reco_particle.E = part.calo_ke/1000.;
         reco_particle.E_method = caf::PartEMethod::kCalorimetry;
       }
       reco_particle.contained = part.is_contained; // this is not just the vertex, but all energies are contained
       if(part.is_contained) reco_particle.tgtA = 40;
       reco_particle.pdg = part.pdg_code;
-      reco_particle.p.x = part.momentum[0]/1000.;
-      reco_particle.p.y = part.momentum[1]/1000.;
-      reco_particle.p.z = part.momentum[2]/1000.;
+      reco_particle.p = caf::SRVector3D(part.momentum[0]/1000., part.momentum[1]/1000., part.momentum[2]/1000.);
+//      reco_particle.p.x = part.momentum[0]/1000.;
+//      reco_particle.p.y = part.momentum[1]/1000.;
+//      reco_particle.p.z = part.momentum[2]/1000.;
 
       if (part.matched)
       {
@@ -573,32 +467,7 @@ namespace cafmaker
           // if we have GENIE info it'll come pre-filled with all its info & sub-particles
           const cafmaker::types::dlp::TrueInteraction & trueIxn = trueInxns[truePartPassThrough.interaction_id];
 
-          // todo: this hack exists for now because
-          //       we have no handle in cafmaker::types::dlp::TrueInteraction
-          //       containing the vertexID from upstream (which uniquely identifies the neutrino).
-          //       WIP...
-          // begin hack------------------------------------------------
-          try
-          {
-            SetCmpLepE(trueParticles, trueIxn, srCmp, genieCmp);
-          }
-          catch (std::runtime_error & err)
-          {
-            // no lepton was found in the event.
-            // this interaction won't have been inserted
-            // (wouldn't be able to find the corresponding GENIE event)
-            // so we should just skip it.
-            // when we switch to the non-hack version of interaction finding
-            // this won't be an issue.
-            continue;
-          }
-
-          LOG.VERBOSE() << "        searching for its parent SRTrueInteraction.  should have primary lepton energy = " << srCmp.lepE << "\n";
-          caf::SRTrueInteraction & srTrueInt = truthMatch->GetTrueInteraction(sr, srCmp, genieCmp, false);
-          // end hack -----------------------------------------------------------------------
-
-          // non-hack version (needs cafmaker::types::dlp::TrueInteraction::track_id to be the edep-sim VertexID)
-          // caf::SRTrueInteraction & srTrueInt = truthMatch->GetTrueInteraction(sr, trueIxn.track_id, false);
+          caf::SRTrueInteraction & srTrueInt = truthMatch->GetTrueInteraction(sr, trueIxn.truth_id, false);
 
           // we need this below because caf::TrueParticleID wants the *index* of the SRTrueInteraction
           int srTrueIntIdx = std::distance(sr.mc.nu.begin(),

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -119,7 +119,7 @@ namespace cafmaker
                              const genie::NtpMCEventRecord *gEvt,
                              std::function<int(const genie::NtpMCEventRecord *)> genieFillerCallback)
     : cafmaker::Loggable("TruthMatcher"),
-      fGTrees(ghepFilenames),
+      fGTrees(ghepFilenames, gEvt),
       fGENIEWriterCallback(std::move(genieFillerCallback))
   {}
 

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -179,7 +179,7 @@ namespace cafmaker
     nu.genweight = event->Weight();
 
     // loop truth particles
-
+    int stablePartIdx=0;
     for (int j=0; j< event->GetEntries(); j++)
     {
       auto p = dynamic_cast<const genie::GHepParticle *>((*event)[j]);
@@ -188,6 +188,7 @@ namespace cafmaker
           && p->Status() != genie::EGHepStatus::kIStHadronInTheNucleus) continue;
 
       caf::SRTrueParticle part;
+      part.G4ID = (p->Status() == genie::EGHepStatus::kIStStableFinalState) ? stablePartIdx++ : -1;
       part.pdg = p->Pdg();
       part.interaction_id = nu.id;
       part.p = *p->P4();

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -403,7 +403,7 @@ namespace cafmaker
       }
       if (!tree || !hdr)
       {
-        cafmaker::LOG_S("main()").FATAL() << "Could not load TTree 'gtree' or associated header from supplied .ghep file: " << fname
+        LOG.FATAL() << "Could not load TTree 'gtree' or associated header from supplied .ghep file: " << fname
                                           << "\n";
         abort();
       }
@@ -412,7 +412,7 @@ namespace cafmaker
       if (run == 0)
       {
         // workaround for GENIE files where run number wasn't set
-        std::regex pattern(R"([rock|nu])\.(\d+)");
+        std::regex pattern("(rock|nu)\\.(\\d+)");
         std::smatch matches;
         std::regex_search(fname, matches, pattern);
         if (matches.size() == 3)
@@ -435,7 +435,10 @@ namespace cafmaker
         }
       }
 
-      tree->SetBranchAddress("evt", &fGEvt);
+      fGTrees[run] = tree;
+      tree->SetBranchAddress("gmcrec", &fGEvt);
+
+      LOG.INFO() << "Loaded TTree for run " << run << " from file: " << fname << "\n";
     }
   }
 

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -7,6 +7,7 @@
 
 #include "FillTruth.h"
 
+#include <map>
 #include <regex>
 
 // ROOT
@@ -365,9 +366,8 @@ namespace cafmaker
   // ------------------------------------------------------------
   bool TruthMatcher::HaveGENIE() const
   {
-    static auto isNull = [](const TTree* t) { return !t; };
-    return !std::all_of(fContNuGTrees.begin(), fContNuGTrees.end(), isNull)
-           || !std::all_of(fUncontNuGTrees.begin(), fUncontNuGTrees.end(), isNull);
+    static auto isNull = [](const std::pair<unsigned long int, const TTree*>& pair) -> bool { return !pair.second; };
+    return !std::all_of(fGTrees.begin(), fGTrees.end(), isNull);
   }
 
   // ------------------------------------------------------------

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -371,8 +371,15 @@ namespace cafmaker
   }
 
   // ------------------------------------------------------------
+  void TruthMatcher::SetLogThrehsold(cafmaker::Logger::THRESHOLD thresh)
+  {
+    Loggable::SetLogThrehsold(thresh);
+    fGTrees.SetLogThrehsold(thresh);
+  }
+
+  // ------------------------------------------------------------
   TruthMatcher::GTreeContainer::GTreeContainer(const vector<std::string> &filenames, const genie::NtpMCEventRecord * gEvt)
-    : fGEvt(gEvt)
+    : cafmaker::Loggable("GTreeContainer"), fGEvt(gEvt)
   {
     for (const auto & fname : filenames)
     {

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -416,5 +416,32 @@ namespace cafmaker
       tree->SetBranchAddress("evt", &fGEvt);
     }
   }
+
+  // ------------------------------------------------------------
+  const genie::NtpMCEventRecord * TruthMatcher::GTreeContainer::GEvt() const
+  {
+    return fGEvt;
+  }
+
+  // ------------------------------------------------------------
+  void TruthMatcher::GTreeContainer::SelectEvent(unsigned long runNum, unsigned int evtNum)
+  {
+    auto it_tree = fGTrees.find(runNum);
+    if (it_tree == fGTrees.end())
+    {
+      std::stringstream ss;
+      ss << "Run number " << runNum << " was not found in this collection of .ghep files\n";
+      LOG.FATAL() << ss.str();
+      throw std::range_error(ss.str());
+    }
+
+    it_tree->second->GetEntry(evtNum);
+  }
+
+  // ------------------------------------------------------------
+  void TruthMatcher::GTreeContainer::SetGEvtAddr(const genie::NtpMCEventRecord *evt)
+  {
+    fGEvt = evt;
+  }
 }
 

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -26,6 +26,7 @@
 // ND_CAFMaker
 #include "CAF.h"
 #include "Params.h"
+#include "util/FloatMath.h"
 
 /// duneanaobj not guaranteed to be the same as GENIE scattering types
 caf::ScatteringMode GENIE2CAF(genie::EScatteringType sc)
@@ -105,7 +106,8 @@ namespace cafmaker
   template <>
   void ValidateOrCopy<double, float>(const double & input, float & target, const float & unsetVal)
   {
-    const auto cmp = [](const double & a, const float &b) -> bool { return std::abs(static_cast<float>(a) - b) < 1e-6; };
+    const auto cmp = [](const double & a, const float &b) -> bool { return util::AreEqual(a, b); };
+
     const auto assgn = [](const double & a, float & b) {  b = a; };
     return ValidateOrCopy<double, float>(input, target, unsetVal, cmp, assgn);
   }

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -130,7 +130,8 @@ namespace cafmaker
     genie::EventRecord * event = gEvt->event;
     genie::Interaction * in = event->Summary();
 
-    nu.id = gEvt->hdr.ievent;  //todo: need to make sure this ID is the one we get all the way out the other end from det sim
+    // note that the nu.id and nu.genieIdx are filled in the calling function,
+    // because that info is not stored inside the GENIE event proper
 
     // todo: GENIE doesn't know about the detector geometry.  do we just leave these for the passthrough from G4?
 //    TLorentzVector vtx = *(event->Vertex());
@@ -347,8 +348,13 @@ namespace cafmaker
       ixn = &sr.mc.nu.back();
       if (HaveGENIE())
       {
-        LOG.VERBOSE() << "      --> GENIE record found.  copying...\n";
+        LOG.VERBOSE() << "      --> GENIE record found (" << fGTrees.GEvt() << ").  copying...\n";
+
+        // these two bits of info can't be extracted directly from the GENIE record,
+        // so we do them here
         ixn->genieIdx = fGENIEWriterCallback(fGTrees.GEvt());  // copy the GENIE event into the CAF output GENIE tree
+        ixn->id = ixnID;
+
         FillInteraction(*ixn, fGTrees.GEvt());  // copy values from the GENIE event into the StandardRecord
       }
       else

--- a/src/truth/FillTruth.h
+++ b/src/truth/FillTruth.h
@@ -180,14 +180,14 @@ namespace cafmaker
 
           /// Select the GENIE event in the known trees corresponding to a particular run and entry number.
           /// If no such event is found, throws an exception.
-          void SelectEvent(unsigned long int runNum, unsigned int evtNum) const;
+          void SelectEvent(unsigned long int runNum, unsigned int evtNum);
 
           const genie::NtpMCEventRecord * GEvt() const;
           void SetGEvtAddr(const genie::NtpMCEventRecord * evt);
 
         private:
           const genie::NtpMCEventRecord * fGEvt;
-          std::map<unsigned long int, const TTree*> fGTrees;
+          std::map<unsigned long int, TTree*> fGTrees;
           std::vector<std::unique_ptr<TFile>> fGFiles;
       };
 

--- a/src/truth/FillTruth.h
+++ b/src/truth/FillTruth.h
@@ -163,11 +163,13 @@ namespace cafmaker
 
       bool HaveGENIE() const;
 
+      void SetLogThrehsold(cafmaker::Logger::THRESHOLD thresh) override;
+
     private:
       static void FillInteraction(caf::SRTrueInteraction& nu, const genie::NtpMCEventRecord * gEvt);
 
       /// Internal class organizing the GENIE trees by run to make them more easily accessible
-      class GTreeContainer
+      class GTreeContainer : public cafmaker::Loggable
       {
         public:
           GTreeContainer(const std::vector<std::string> & filenames, const genie::NtpMCEventRecord * gEvt=nullptr);

--- a/src/truth/FillTruth.h
+++ b/src/truth/FillTruth.h
@@ -172,6 +172,10 @@ namespace cafmaker
         public:
           GTreeContainer(const std::vector<std::string> & filenames, const genie::NtpMCEventRecord * gEvt=nullptr);
 
+          // container interface
+          const auto begin()  { return fGTrees.begin(); }
+          const auto end()    { return fGTrees.end(); }
+
           /// Select the GENIE event in the known trees corresponding to a particular run and entry number.
           /// If no such event is found, throws an exception.
           void SelectEvent(unsigned long int runNum, unsigned int evtNum) const;

--- a/src/truth/FillTruth.h
+++ b/src/truth/FillTruth.h
@@ -192,12 +192,6 @@ namespace cafmaker
       };
 
       mutable GTreeContainer fGTrees;
-
-      mutable std::vector<TTree*>    fContNuGTrees;         ///< GENIE tree(s) for 'contained' neutrinos (near/inside the detector volumes)
-      mutable int                    fLastFoundContTree;    ///< Index of tree in fContNuGTrees where last event was found
-      mutable std::vector<TTree*>    fUncontNuGTrees;       ///< GENIE tree(s) for 'uncontained' neutrinos (rock and/or ND hall interactions)
-      mutable int                    fLastFoundUncontTree;  ///< Index of tree in fUncontNuGTrees where last event was found
-
       std::function<int(const genie::NtpMCEventRecord *)> fGENIEWriterCallback;  ///< Callback function that'll write a copy of a GENIE event out to storage
   };
 }

--- a/src/util/FloatMath.cxx
+++ b/src/util/FloatMath.cxx
@@ -1,0 +1,29 @@
+#include "FloatMath.h"
+
+#include <cmath>
+
+namespace cafmaker
+{
+  namespace util
+  {
+     bool AreEqual(double a, float b, double maxDiff, float maxRelDiff)
+     {
+       double A = a;
+       double B = b;  // promote the float to a double.  Guaranteed by IEEE standard that this will not lose any info.
+
+       // Check if the numbers are really close -- needed
+       // when comparing numbers near zero.
+       auto diff = std::abs(A - B);
+       if (diff <= maxDiff)
+         return true;
+
+       A = std::abs(A);
+       B = std::abs(B);
+       double largest = (B > A) ? B : A;
+
+       if (diff <= largest * maxRelDiff)
+         return true;
+       return false;
+     }
+  } // namespace util
+} // namespace cafmaker

--- a/src/util/FloatMath.h
+++ b/src/util/FloatMath.h
@@ -1,0 +1,16 @@
+#ifndef ND_CAFMAKER_FLOATMATH_H
+#define ND_CAFMAKER_FLOATMATH_H
+
+#include <limits>
+
+namespace cafmaker
+{
+  namespace util
+  {
+    /// Adapted from https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
+    /// See also https://github.com/randomascii/blogstuff/blob/main/FloatingPoint/CompareAsInt/CompareAsInt.cpp
+    bool AreEqual(double a, float b, double maxDiff = 1e-6, float maxRelDiff = 1e-5);
+  }
+}
+
+#endif //ND_CAFMAKER_FLOATMATH_H

--- a/src/util/GENIEBannerBypass.cxx
+++ b/src/util/GENIEBannerBypass.cxx
@@ -1,0 +1,28 @@
+/// \file GENIEBannerBypass.cxx
+///
+/// Work around the obnoxious GENIE splash screen
+///
+/// \author  J. Wolcott <jwolcott@fnal.gov>
+/// \date    Sep. 2023
+
+#include <string>
+
+typedef unsigned int UInt_t;
+
+using namespace std;
+
+namespace genie
+{
+  namespace utils
+  {
+    namespace print
+    {
+      /// Null implementation of the function that spits out the GENIE splash screen.
+      /// Because the CAFMaker library is loaded before the GENIE ones,
+      /// this implementation is discovered first and used instead of the official GENIE one.
+      /// This way, we don't get the GENIE printout cluttering our output.
+      void PrintBanner(string, UInt_t)
+      {}
+    }
+  }
+}

--- a/src/util/Loggable.h
+++ b/src/util/Loggable.h
@@ -23,7 +23,7 @@ namespace cafmaker
         : LOG(std::move(name), defaultThresh)
       {}
 
-      void SetLogThrehsold(cafmaker::Logger::THRESHOLD thresh) { LOG.SetThreshold(thresh); }
+      virtual void SetLogThrehsold(cafmaker::Logger::THRESHOLD thresh) { LOG.SetThreshold(thresh); }
 
       virtual ~Loggable() = default;
 

--- a/src/util/Logger.h
+++ b/src/util/Logger.h
@@ -37,6 +37,7 @@ namespace cafmaker
                       THRESHOLD thresh = THRESHOLD::INFO,
                       std::ostream& stream = std::cout);
 
+      const std::string & GetPreamble() const  { return fPreamble; }
       void SetPreamble(std::string preamble)   { fPreamble = std::move(preamble); }
 
       THRESHOLD GetThreshold() const           { return fThresh; }


### PR DESCRIPTION
As of PicoRun4, `vertexID`s are no longer rewritten to be consecutive, and the 2x2-MLReco pipeline is fully propagating `vertexID`s through it, so we no longer need the workarounds that we previously needed.  Remove them here.

This comes with some new code to match run and `vertexID` numbers and updates to the storage classes that hold onto the GENIE tree(s) once loaded.

I also snuck in a few small updates (bypassing the GENIE splash screen, fixing a 'deprecated method' warning from FHICL).

This PR depends on some others that are used in the input file preparation:
https://github.com/DeepLearnPhysics/larcv2/pull/43
https://github.com/DeepLearnPhysics/SuperaAtomic/pull/17
https://github.com/DeepLearnPhysics/larnd2supera/pull/3
