### PR TITLE
Use MLreco 'trigger info' stream for matching

### DIFF
--- a/scripts/h5_to_cpp.py
+++ b/scripts/h5_to_cpp.py
@@ -511,7 +511,7 @@ if __name__ == "__main__":
         datasets = []
         for ds in args.dataset:
             if ds not in f or not hasattr(f[ds], "dtype"):
-                print("Dataset '{0}' not found in file: {1}".format(ds, args.filename), file=sys.stderr)
+                print("Dataset '{0}' not found in file: {1}".format(ds, args.hdf5), file=sys.stderr)
                 sys.exit(1)
             datasets.append(f[ds])
 

--- a/src/reco/DLP_h5_classes.cxx
+++ b/src/reco/DLP_h5_classes.cxx
@@ -5,7 +5,7 @@
 //    
 //    The invocation that generated this file was:
 //
-//       ./h5_to_cpp.py -f /home/jeremy/data/dune/data/users/jwolcott/nd/nd-lar-reco/reco-out/PicoRun4_1E17_RHC.larnd.00003.reco.summary.h5 -o ../src/reco/DLP_h5_classes -ns cafmaker::types::dlp -d events -cn Event -d interactions -cn Interaction -d particles -cn Particle -d truth_interactions -cn TrueInteraction -d truth_particles -cn TrueParticle -d run_info -cn RunInfo
+//       ./h5_to_cpp.py -f /data/dune/data/users/jwolcott/nd/nd-lar-reco/reco-out/PicoRun4.1_1E17_RHC.larnd.00000.reco.summary.h5 -o ../src/reco/DLP_h5_classes -ns cafmaker::types::dlp -d events -cn Event -d interactions -cn Interaction -d particles -cn Particle -d truth_interactions -cn TrueInteraction -d truth_particles -cn TrueParticle -d run_info -cn RunInfo -d trigger -cn Trigger
 //
 
 #include "DLP_h5_classes.h"
@@ -42,6 +42,7 @@ namespace cafmaker::types::dlp
   {
     match.reset(&match_handle);
     match_overlap.reset(&match_overlap_handle);
+    nu_position.reset(&nu_position_handle);
     particle_ids.reset(&particle_ids_handle);
     truth_particle_counts.reset(&truth_particle_counts_handle);
     truth_primary_counts.reset(&truth_primary_counts_handle);
@@ -52,8 +53,6 @@ namespace cafmaker::types::dlp
   {
     ancestor_position.reset(&ancestor_position_handle);
     children_counts.reset(&children_counts_handle);
-    children_id.reset(&children_id_handle);
-    direction.reset(&direction_handle);
     first_step.reset(&first_step_handle);
     fragment_ids.reset(&fragment_ids_handle);
     index.reset(&index_handle);
@@ -63,13 +62,17 @@ namespace cafmaker::types::dlp
     parent_position.reset(&parent_position_handle);
     position.reset(&position_handle);
     sed_index.reset(&sed_index_handle);
-    truth_end_dir.reset(&truth_end_dir_handle);
     truth_index.reset(&truth_index_handle);
-    truth_start_dir.reset(&truth_start_dir_handle);
   }
   
   
   void RunInfo::SyncVectors()
+  {
+  
+  }
+  
+  
+  void Trigger::SyncVectors()
   {
   
   }
@@ -80,13 +83,14 @@ namespace cafmaker::types::dlp
   {
     H5::CompType ctype(sizeof(Event));
   
+    ctype.insertMember("index", HOFFSET(Event, index), H5::PredType::STD_REF_DSETREG);
     ctype.insertMember("run_info", HOFFSET(Event, run_info), H5::PredType::STD_REF_DSETREG);
     ctype.insertMember("meta", HOFFSET(Event, meta), H5::PredType::STD_REF_DSETREG);
-    ctype.insertMember("index", HOFFSET(Event, index), H5::PredType::STD_REF_DSETREG);
-    ctype.insertMember("particles", HOFFSET(Event, particles), H5::PredType::STD_REF_DSETREG);
+    ctype.insertMember("trigger", HOFFSET(Event, trigger), H5::PredType::STD_REF_DSETREG);
     ctype.insertMember("truth_interactions", HOFFSET(Event, truth_interactions), H5::PredType::STD_REF_DSETREG);
     ctype.insertMember("truth_particles", HOFFSET(Event, truth_particles), H5::PredType::STD_REF_DSETREG);
     ctype.insertMember("interactions", HOFFSET(Event, interactions), H5::PredType::STD_REF_DSETREG);
+    ctype.insertMember("particles", HOFFSET(Event, particles), H5::PredType::STD_REF_DSETREG);
   
     return ctype;
   }
@@ -97,16 +101,18 @@ namespace cafmaker::types::dlp
   {
     H5::CompType ctype(sizeof(Interaction));
   
+    ctype.insertMember("coffset", HOFFSET(Interaction, coffset), H5::PredType::IEEE_F64LE);
     ctype.insertMember("crthit_id", HOFFSET(Interaction, crthit_id), H5::PredType::STD_I64LE);
     ctype.insertMember("crthit_matched", HOFFSET(Interaction, crthit_matched), H5::PredType::STD_U8LE);
     ctype.insertMember("crthit_matched_particle_id", HOFFSET(Interaction, crthit_matched_particle_id), H5::PredType::STD_I64LE);
-    ctype.insertMember("flash_hypothesis", HOFFSET(Interaction, flash_hypothesis), H5::PredType::STD_I64LE);
+    ctype.insertMember("flash_hypothesis", HOFFSET(Interaction, flash_hypothesis), H5::PredType::IEEE_F64LE);
     ctype.insertMember("flash_id", HOFFSET(Interaction, flash_id), H5::PredType::STD_I64LE);
     ctype.insertMember("flash_time", HOFFSET(Interaction, flash_time), H5::PredType::IEEE_F64LE);
-    ctype.insertMember("flash_total_pE", HOFFSET(Interaction, flash_total_pE), H5::PredType::STD_I64LE);
+    ctype.insertMember("flash_total_pE", HOFFSET(Interaction, flash_total_pE), H5::PredType::IEEE_F64LE);
     ctype.insertMember("fmatched", HOFFSET(Interaction, fmatched), H5::PredType::STD_U8LE);
     ctype.insertMember("id", HOFFSET(Interaction, id), H5::PredType::STD_I64LE);
     ctype.insertMember("image_id", HOFFSET(Interaction, image_id), H5::PredType::STD_I64LE);
+    ctype.insertMember("is_ccrosser", HOFFSET(Interaction, is_ccrosser), H5::PredType::STD_U8LE);
     ctype.insertMember("is_contained", HOFFSET(Interaction, is_contained), H5::PredType::STD_U8LE);
     ctype.insertMember("is_fiducial", HOFFSET(Interaction, is_fiducial), H5::PredType::STD_U8LE);
     ctype.insertMember("is_neutrino", HOFFSET(Interaction, is_neutrino), H5::PredType::STD_U8LE);
@@ -117,9 +123,9 @@ namespace cafmaker::types::dlp
     ctype.insertMember("nu_id", HOFFSET(Interaction, nu_id), H5::PredType::STD_I64LE);
     ctype.insertMember("num_particles", HOFFSET(Interaction, num_particles), H5::PredType::STD_I64LE);
     ctype.insertMember("num_primaries", HOFFSET(Interaction, num_primaries), H5::PredType::STD_I64LE);
-    ctype.insertMember("particle_counts", HOFFSET(Interaction, particle_counts), H5::ArrayType(H5::PredType::STD_I64LE, 1, &std::array<hsize_t, 1>{6}[0]));
+    ctype.insertMember("particle_counts", HOFFSET(Interaction, particle_counts), H5::ArrayType(H5::PredType::STD_I64LE, 1, &std::array<hsize_t, 1>{7}[0]));
     ctype.insertMember("particle_ids", HOFFSET(Interaction, particle_ids_handle), H5::VarLenType(H5::PredType::STD_I64LE));
-    ctype.insertMember("primary_counts", HOFFSET(Interaction, primary_counts), H5::ArrayType(H5::PredType::STD_I64LE, 1, &std::array<hsize_t, 1>{6}[0]));
+    ctype.insertMember("primary_counts", HOFFSET(Interaction, primary_counts), H5::ArrayType(H5::PredType::STD_I64LE, 1, &std::array<hsize_t, 1>{7}[0]));
     ctype.insertMember("size", HOFFSET(Interaction, size), H5::PredType::STD_I64LE);
     
     H5::StrType topology_strType(H5::PredType::C_S1, H5T_VARIABLE);
@@ -149,6 +155,7 @@ namespace cafmaker::types::dlp
     H5::CompType ctype(sizeof(Particle));
   
     ctype.insertMember("calo_ke", HOFFSET(Particle, calo_ke), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("coffset", HOFFSET(Particle, coffset), H5::PredType::IEEE_F64LE);
     ctype.insertMember("csda_ke", HOFFSET(Particle, csda_ke), H5::PredType::IEEE_F64LE);
     ctype.insertMember("depositions_sum", HOFFSET(Particle, depositions_sum), H5::PredType::IEEE_F64LE);
     ctype.insertMember("end_dir", HOFFSET(Particle, end_dir), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
@@ -158,9 +165,12 @@ namespace cafmaker::types::dlp
     ctype.insertMember("image_id", HOFFSET(Particle, image_id), H5::PredType::STD_I64LE);
     ctype.insertMember("index", HOFFSET(Particle, index_handle), H5::VarLenType(H5::PredType::STD_I64LE));
     ctype.insertMember("interaction_id", HOFFSET(Particle, interaction_id), H5::PredType::STD_I64LE);
+    ctype.insertMember("is_ccrosser", HOFFSET(Particle, is_ccrosser), H5::PredType::STD_U8LE);
     ctype.insertMember("is_contained", HOFFSET(Particle, is_contained), H5::PredType::STD_U8LE);
     ctype.insertMember("is_primary", HOFFSET(Particle, is_primary), H5::PredType::STD_U8LE);
     ctype.insertMember("is_principal_match", HOFFSET(Particle, is_principal_match), H5::PredType::STD_U8LE);
+    ctype.insertMember("is_valid", HOFFSET(Particle, is_valid), H5::PredType::STD_U8LE);
+    ctype.insertMember("ke", HOFFSET(Particle, ke), H5::PredType::IEEE_F64LE);
     ctype.insertMember("length", HOFFSET(Particle, length), H5::PredType::IEEE_F64LE);
     ctype.insertMember("match", HOFFSET(Particle, match_handle), H5::VarLenType(H5::PredType::STD_I64LE));
     ctype.insertMember("match_overlap", HOFFSET(Particle, match_overlap_handle), H5::VarLenType(H5::PredType::IEEE_F32LE));
@@ -214,16 +224,18 @@ namespace cafmaker::types::dlp
   {
     H5::CompType ctype(sizeof(TrueInteraction));
   
+    ctype.insertMember("coffset", HOFFSET(TrueInteraction, coffset), H5::PredType::IEEE_F64LE);
     ctype.insertMember("crthit_id", HOFFSET(TrueInteraction, crthit_id), H5::PredType::STD_I64LE);
     ctype.insertMember("crthit_matched", HOFFSET(TrueInteraction, crthit_matched), H5::PredType::STD_U8LE);
     ctype.insertMember("crthit_matched_particle_id", HOFFSET(TrueInteraction, crthit_matched_particle_id), H5::PredType::STD_I64LE);
-    ctype.insertMember("flash_hypothesis", HOFFSET(TrueInteraction, flash_hypothesis), H5::PredType::STD_I64LE);
+    ctype.insertMember("flash_hypothesis", HOFFSET(TrueInteraction, flash_hypothesis), H5::PredType::IEEE_F64LE);
     ctype.insertMember("flash_id", HOFFSET(TrueInteraction, flash_id), H5::PredType::STD_I64LE);
     ctype.insertMember("flash_time", HOFFSET(TrueInteraction, flash_time), H5::PredType::IEEE_F64LE);
-    ctype.insertMember("flash_total_pE", HOFFSET(TrueInteraction, flash_total_pE), H5::PredType::STD_I64LE);
+    ctype.insertMember("flash_total_pE", HOFFSET(TrueInteraction, flash_total_pE), H5::PredType::IEEE_F64LE);
     ctype.insertMember("fmatched", HOFFSET(TrueInteraction, fmatched), H5::PredType::STD_U8LE);
     ctype.insertMember("id", HOFFSET(TrueInteraction, id), H5::PredType::STD_I64LE);
     ctype.insertMember("image_id", HOFFSET(TrueInteraction, image_id), H5::PredType::STD_I64LE);
+    ctype.insertMember("is_ccrosser", HOFFSET(TrueInteraction, is_ccrosser), H5::PredType::STD_U8LE);
     ctype.insertMember("is_contained", HOFFSET(TrueInteraction, is_contained), H5::PredType::STD_U8LE);
     ctype.insertMember("is_fiducial", HOFFSET(TrueInteraction, is_fiducial), H5::PredType::STD_U8LE);
     ctype.insertMember("is_neutrino", HOFFSET(TrueInteraction, is_neutrino), H5::PredType::STD_U8LE);
@@ -231,6 +243,12 @@ namespace cafmaker::types::dlp
     ctype.insertMember("match", HOFFSET(TrueInteraction, match_handle), H5::VarLenType(H5::PredType::STD_I64LE));
     ctype.insertMember("match_overlap", HOFFSET(TrueInteraction, match_overlap_handle), H5::VarLenType(H5::PredType::IEEE_F32LE));
     ctype.insertMember("matched", HOFFSET(TrueInteraction, matched), H5::PredType::STD_U8LE);
+    ctype.insertMember("nu_bjorken_x", HOFFSET(TrueInteraction, nu_bjorken_x), H5::PredType::IEEE_F64LE);
+    
+    H5::StrType nu_creation_process_strType(H5::PredType::C_S1, H5T_VARIABLE);
+    nu_creation_process_strType.setCset(H5T_CSET_UTF8);
+    ctype.insertMember("nu_creation_process", HOFFSET(TrueInteraction, nu_creation_process), nu_creation_process_strType);
+    
     
     H5::EnumType nu_current_type_enumtype(H5::PredType::STD_I64LE);
     int64_t nu_current_type_enum_val;
@@ -239,8 +257,12 @@ namespace cafmaker::types::dlp
       nu_current_type_enum_val = -1; nu_current_type_enumtype.insert("UnknownCurrent", &nu_current_type_enum_val);
     ctype.insertMember("nu_current_type", HOFFSET(TrueInteraction, nu_current_type), nu_current_type_enumtype);
     
+    ctype.insertMember("nu_distance_travel", HOFFSET(TrueInteraction, nu_distance_travel), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("nu_energy_deposit", HOFFSET(TrueInteraction, nu_energy_deposit), H5::PredType::IEEE_F64LE);
     ctype.insertMember("nu_energy_init", HOFFSET(TrueInteraction, nu_energy_init), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("nu_hadronic_invariant_mass", HOFFSET(TrueInteraction, nu_hadronic_invariant_mass), H5::PredType::IEEE_F64LE);
     ctype.insertMember("nu_id", HOFFSET(TrueInteraction, nu_id), H5::PredType::STD_I64LE);
+    ctype.insertMember("nu_inelasticity", HOFFSET(TrueInteraction, nu_inelasticity), H5::PredType::IEEE_F64LE);
     
     H5::EnumType nu_interaction_mode_enumtype(H5::PredType::STD_I64LE);
     int64_t nu_interaction_mode_enum_val;
@@ -375,12 +397,26 @@ namespace cafmaker::types::dlp
       nu_interaction_type_enum_val = 13; nu_interaction_type_enumtype.insert("WeakMix", &nu_interaction_type_enum_val);
     ctype.insertMember("nu_interaction_type", HOFFSET(TrueInteraction, nu_interaction_type), nu_interaction_type_enumtype);
     
+    ctype.insertMember("nu_lepton_track_id", HOFFSET(TrueInteraction, nu_lepton_track_id), H5::PredType::STD_I64LE);
+    ctype.insertMember("nu_mcst_index", HOFFSET(TrueInteraction, nu_mcst_index), H5::PredType::STD_I64LE);
+    ctype.insertMember("nu_mct_index", HOFFSET(TrueInteraction, nu_mct_index), H5::PredType::STD_I64LE);
+    ctype.insertMember("nu_momentum_transfer", HOFFSET(TrueInteraction, nu_momentum_transfer), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("nu_nucleon", HOFFSET(TrueInteraction, nu_nucleon), H5::PredType::STD_I64LE);
+    ctype.insertMember("nu_num_voxels", HOFFSET(TrueInteraction, nu_num_voxels), H5::PredType::STD_I64LE);
+    ctype.insertMember("nu_p", HOFFSET(TrueInteraction, nu_p), H5::PredType::IEEE_F64LE);
     ctype.insertMember("nu_pdg_code", HOFFSET(TrueInteraction, nu_pdg_code), H5::PredType::STD_I64LE);
+    ctype.insertMember("nu_position", HOFFSET(TrueInteraction, nu_position_handle), H5::VarLenType(H5::PredType::IEEE_F32LE));
+    ctype.insertMember("nu_quark", HOFFSET(TrueInteraction, nu_quark), H5::PredType::STD_I64LE);
+    ctype.insertMember("nu_t", HOFFSET(TrueInteraction, nu_t), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("nu_target", HOFFSET(TrueInteraction, nu_target), H5::PredType::STD_I64LE);
+    ctype.insertMember("nu_theta", HOFFSET(TrueInteraction, nu_theta), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("nu_track_id", HOFFSET(TrueInteraction, nu_track_id), H5::PredType::STD_I64LE);
+    ctype.insertMember("nu_truth_id", HOFFSET(TrueInteraction, nu_truth_id), H5::PredType::STD_I64LE);
     ctype.insertMember("num_particles", HOFFSET(TrueInteraction, num_particles), H5::PredType::STD_I64LE);
     ctype.insertMember("num_primaries", HOFFSET(TrueInteraction, num_primaries), H5::PredType::STD_I64LE);
-    ctype.insertMember("particle_counts", HOFFSET(TrueInteraction, particle_counts), H5::ArrayType(H5::PredType::STD_I64LE, 1, &std::array<hsize_t, 1>{6}[0]));
+    ctype.insertMember("particle_counts", HOFFSET(TrueInteraction, particle_counts), H5::ArrayType(H5::PredType::STD_I64LE, 1, &std::array<hsize_t, 1>{7}[0]));
     ctype.insertMember("particle_ids", HOFFSET(TrueInteraction, particle_ids_handle), H5::VarLenType(H5::PredType::STD_I64LE));
-    ctype.insertMember("primary_counts", HOFFSET(TrueInteraction, primary_counts), H5::ArrayType(H5::PredType::STD_I64LE, 1, &std::array<hsize_t, 1>{6}[0]));
+    ctype.insertMember("primary_counts", HOFFSET(TrueInteraction, primary_counts), H5::ArrayType(H5::PredType::STD_I64LE, 1, &std::array<hsize_t, 1>{7}[0]));
     ctype.insertMember("size", HOFFSET(TrueInteraction, size), H5::PredType::STD_I64LE);
     
     H5::StrType topology_strType(H5::PredType::C_S1, H5T_VARIABLE);
@@ -430,7 +466,7 @@ namespace cafmaker::types::dlp
     ctype.insertMember("calo_ke", HOFFSET(TrueParticle, calo_ke), H5::PredType::IEEE_F64LE);
     ctype.insertMember("calo_ke_tng", HOFFSET(TrueParticle, calo_ke_tng), H5::PredType::IEEE_F64LE);
     ctype.insertMember("children_counts", HOFFSET(TrueParticle, children_counts_handle), H5::VarLenType(H5::PredType::STD_I64LE));
-    ctype.insertMember("children_id", HOFFSET(TrueParticle, children_id_handle), H5::VarLenType(H5::PredType::STD_I64LE));
+    ctype.insertMember("coffset", HOFFSET(TrueParticle, coffset), H5::PredType::IEEE_F64LE);
     
     H5::StrType creation_process_strType(H5::PredType::C_S1, H5T_VARIABLE);
     creation_process_strType.setCset(H5T_CSET_UTF8);
@@ -439,7 +475,6 @@ namespace cafmaker::types::dlp
     ctype.insertMember("csda_ke", HOFFSET(TrueParticle, csda_ke), H5::PredType::IEEE_F64LE);
     ctype.insertMember("csda_ke_tng", HOFFSET(TrueParticle, csda_ke_tng), H5::PredType::IEEE_F64LE);
     ctype.insertMember("depositions_sum", HOFFSET(TrueParticle, depositions_sum), H5::PredType::IEEE_F64LE);
-    ctype.insertMember("direction", HOFFSET(TrueParticle, direction_handle), H5::VarLenType(H5::PredType::IEEE_F64LE));
     ctype.insertMember("distance_travel", HOFFSET(TrueParticle, distance_travel), H5::PredType::IEEE_F64LE);
     ctype.insertMember("end_dir", HOFFSET(TrueParticle, end_dir), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("end_point", HOFFSET(TrueParticle, end_point), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
@@ -453,9 +488,12 @@ namespace cafmaker::types::dlp
     ctype.insertMember("image_id", HOFFSET(TrueParticle, image_id), H5::PredType::STD_I64LE);
     ctype.insertMember("index", HOFFSET(TrueParticle, index_handle), H5::VarLenType(H5::PredType::STD_I64LE));
     ctype.insertMember("interaction_id", HOFFSET(TrueParticle, interaction_id), H5::PredType::STD_I64LE);
+    ctype.insertMember("is_ccrosser", HOFFSET(TrueParticle, is_ccrosser), H5::PredType::STD_U8LE);
     ctype.insertMember("is_contained", HOFFSET(TrueParticle, is_contained), H5::PredType::STD_U8LE);
     ctype.insertMember("is_primary", HOFFSET(TrueParticle, is_primary), H5::PredType::STD_U8LE);
     ctype.insertMember("is_principal_match", HOFFSET(TrueParticle, is_principal_match), H5::PredType::STD_U8LE);
+    ctype.insertMember("is_valid", HOFFSET(TrueParticle, is_valid), H5::PredType::STD_U8LE);
+    ctype.insertMember("ke", HOFFSET(TrueParticle, ke), H5::PredType::IEEE_F64LE);
     ctype.insertMember("last_step", HOFFSET(TrueParticle, last_step_handle), H5::VarLenType(H5::PredType::IEEE_F32LE));
     ctype.insertMember("length", HOFFSET(TrueParticle, length), H5::PredType::IEEE_F64LE);
     ctype.insertMember("length_tng", HOFFSET(TrueParticle, length_tng), H5::PredType::IEEE_F64LE);
@@ -466,7 +504,7 @@ namespace cafmaker::types::dlp
     ctype.insertMember("mcs_ke_tng", HOFFSET(TrueParticle, mcs_ke_tng), H5::PredType::IEEE_F64LE);
     ctype.insertMember("mcst_index", HOFFSET(TrueParticle, mcst_index), H5::PredType::STD_I64LE);
     ctype.insertMember("mct_index", HOFFSET(TrueParticle, mct_index), H5::PredType::STD_I64LE);
-    ctype.insertMember("momentum", HOFFSET(TrueParticle, momentum), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
+    ctype.insertMember("momentum", HOFFSET(TrueParticle, momentum), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("nu_id", HOFFSET(TrueParticle, nu_id), H5::PredType::STD_I64LE);
     ctype.insertMember("num_fragments", HOFFSET(TrueParticle, num_fragments), H5::PredType::STD_I64LE);
     ctype.insertMember("num_voxels", HOFFSET(TrueParticle, num_voxels), H5::PredType::STD_I64LE);
@@ -517,11 +555,10 @@ namespace cafmaker::types::dlp
     ctype.insertMember("track_id", HOFFSET(TrueParticle, track_id), H5::PredType::STD_I64LE);
     ctype.insertMember("truth_depositions_MeV_sum", HOFFSET(TrueParticle, truth_depositions_MeV_sum), H5::PredType::IEEE_F32LE);
     ctype.insertMember("truth_depositions_sum", HOFFSET(TrueParticle, truth_depositions_sum), H5::PredType::IEEE_F64LE);
-    ctype.insertMember("truth_end_dir", HOFFSET(TrueParticle, truth_end_dir_handle), H5::VarLenType(H5::PredType::IEEE_F64LE));
-    ctype.insertMember("truth_id", HOFFSET(TrueParticle, truth_id), H5::PredType::STD_I64LE);
     ctype.insertMember("truth_index", HOFFSET(TrueParticle, truth_index_handle), H5::VarLenType(H5::PredType::STD_I64LE));
+    ctype.insertMember("truth_momentum", HOFFSET(TrueParticle, truth_momentum), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("truth_size", HOFFSET(TrueParticle, truth_size), H5::PredType::STD_I64LE);
-    ctype.insertMember("truth_start_dir", HOFFSET(TrueParticle, truth_start_dir_handle), H5::VarLenType(H5::PredType::IEEE_F64LE));
+    ctype.insertMember("truth_start_dir", HOFFSET(TrueParticle, truth_start_dir), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
     
     H5::StrType units_strType(H5::PredType::C_S1, H5T_VARIABLE);
     units_strType.setCset(H5T_CSET_UTF8);
@@ -541,6 +578,20 @@ namespace cafmaker::types::dlp
     ctype.insertMember("run", HOFFSET(RunInfo, run), H5::PredType::STD_I64LE);
     ctype.insertMember("subrun", HOFFSET(RunInfo, subrun), H5::PredType::STD_I64LE);
     ctype.insertMember("event", HOFFSET(RunInfo, event), H5::PredType::STD_I64LE);
+  
+    return ctype;
+  }
+  
+  
+  template <>
+  H5::CompType BuildCompType<Trigger>()
+  {
+    H5::CompType ctype(sizeof(Trigger));
+  
+    ctype.insertMember("id", HOFFSET(Trigger, id), H5::PredType::STD_I64LE);
+    ctype.insertMember("time_ns", HOFFSET(Trigger, time_ns), H5::PredType::STD_I64LE);
+    ctype.insertMember("time_s", HOFFSET(Trigger, time_s), H5::PredType::STD_I64LE);
+    ctype.insertMember("type", HOFFSET(Trigger, type), H5::PredType::STD_I64LE);
   
     return ctype;
   }

--- a/src/reco/DLP_h5_classes.h
+++ b/src/reco/DLP_h5_classes.h
@@ -5,7 +5,7 @@
 //    
 //    The invocation that generated this file was:
 //
-//       ./h5_to_cpp.py -f /dune/data/users/jwolcott/nd/nd-lar-reco/reco-out/PicoRun4_1E17_RHC.larnd.00003.reco.summary.h5 -o ../src/reco/DLP_h5_classes -ns cafmaker::types::dlp -d events -cn Event -d interactions -cn Interaction -d particles -cn Particle -d truth_interactions -cn TrueInteraction -d truth_particles -cn TrueParticle -d run_info -cn RunInfo
+//       ./h5_to_cpp.py -f /home/jeremy/data/dune/data/users/jwolcott/nd/nd-lar-reco/reco-out/PicoRun4.1_1E17_RHC.larnd.00000.reco.summary.h5 -o ../src/reco/DLP_h5_classes -ns cafmaker::types::dlp -d events -cn Event -d interactions -cn Interaction -d particles -cn Particle -d truth_interactions -cn TrueInteraction -d truth_particles -cn TrueParticle -d run_info -cn RunInfo -d trigger -cn Trigger
 //
 
 
@@ -196,16 +196,18 @@ namespace cafmaker::types::dlp
   struct TrueInteraction;
   struct TrueParticle;
   struct RunInfo;
+  struct Trigger;
   
   struct Event
   {
+    hdset_reg_ref_t index;
     hdset_reg_ref_t run_info;
     hdset_reg_ref_t meta;
-    hdset_reg_ref_t index;
-    hdset_reg_ref_t particles;
+    hdset_reg_ref_t trigger;
     hdset_reg_ref_t truth_interactions;
     hdset_reg_ref_t truth_particles;
     hdset_reg_ref_t interactions;
+    hdset_reg_ref_t particles;
     
     void SyncVectors();
     
@@ -213,10 +215,11 @@ namespace cafmaker::types::dlp
     const hdset_reg_ref_t& GetRef() const
     {
       if constexpr(std::is_same_v<T, RunInfo>) return run_info;
-      else if(std::is_same_v<T, Particle>) return particles;
+      else if(std::is_same_v<T, Trigger>) return trigger;
       else if(std::is_same_v<T, TrueInteraction>) return truth_interactions;
       else if(std::is_same_v<T, TrueParticle>) return truth_particles;
       else if(std::is_same_v<T, Interaction>) return interactions;
+      else if(std::is_same_v<T, Particle>) return particles;
     }
     
   };
@@ -224,16 +227,18 @@ namespace cafmaker::types::dlp
   
   struct Interaction
   {
+    double coffset;
     int64_t crthit_id;
     uint8_t crthit_matched;
     int64_t crthit_matched_particle_id;
-    int64_t flash_hypothesis;
+    double flash_hypothesis;
     int64_t flash_id;
     double flash_time;
-    int64_t flash_total_pE;
+    double flash_total_pE;
     uint8_t fmatched;
     int64_t id;
     int64_t image_id;
+    bool is_ccrosser;
     bool is_contained;
     bool is_fiducial;
     bool is_neutrino;
@@ -244,9 +249,9 @@ namespace cafmaker::types::dlp
     int64_t nu_id;
     int64_t num_particles;
     int64_t num_primaries;
-    std::array<int64_t, 6> particle_counts;
+    std::array<int64_t, 7> particle_counts;
     BufferView<int64_t> particle_ids;
-    std::array<int64_t, 6> primary_counts;
+    std::array<int64_t, 7> primary_counts;
     int64_t size;
     char * topology;
     char * units;
@@ -273,6 +278,7 @@ namespace cafmaker::types::dlp
   struct Particle
   {
     double calo_ke;
+    double coffset;
     double csda_ke;
     double depositions_sum;
     std::array<float, 3> end_dir;
@@ -282,9 +288,12 @@ namespace cafmaker::types::dlp
     int64_t image_id;
     BufferView<int64_t> index;
     int64_t interaction_id;
+    bool is_ccrosser;
     bool is_contained;
     bool is_primary;
     bool is_principal_match;
+    bool is_valid;
+    double ke;
     double length;
     BufferView<int64_t> match;
     BufferView<float> match_overlap;
@@ -323,16 +332,18 @@ namespace cafmaker::types::dlp
   
   struct TrueInteraction
   {
+    double coffset;
     int64_t crthit_id;
     uint8_t crthit_matched;
     int64_t crthit_matched_particle_id;
-    int64_t flash_hypothesis;
+    double flash_hypothesis;
     int64_t flash_id;
     double flash_time;
-    int64_t flash_total_pE;
+    double flash_total_pE;
     uint8_t fmatched;
     int64_t id;
     int64_t image_id;
+    bool is_ccrosser;
     bool is_contained;
     bool is_fiducial;
     bool is_neutrino;
@@ -340,17 +351,37 @@ namespace cafmaker::types::dlp
     BufferView<int64_t> match;
     BufferView<float> match_overlap;
     uint8_t matched;
+    double nu_bjorken_x;
+    char * nu_creation_process;
     NuCurrentType nu_current_type;
+    double nu_distance_travel;
+    double nu_energy_deposit;
     double nu_energy_init;
+    double nu_hadronic_invariant_mass;
     int64_t nu_id;
+    double nu_inelasticity;
     NuInteractionMode nu_interaction_mode;
     NuInteractionType nu_interaction_type;
+    int64_t nu_lepton_track_id;
+    int64_t nu_mcst_index;
+    int64_t nu_mct_index;
+    double nu_momentum_transfer;
+    int64_t nu_nucleon;
+    int64_t nu_num_voxels;
+    double nu_p;
     int64_t nu_pdg_code;
+    BufferView<float> nu_position;
+    int64_t nu_quark;
+    double nu_t;
+    int64_t nu_target;
+    double nu_theta;
+    int64_t nu_track_id;
+    int64_t nu_truth_id;
     int64_t num_particles;
     int64_t num_primaries;
-    std::array<int64_t, 6> particle_counts;
+    std::array<int64_t, 7> particle_counts;
     BufferView<int64_t> particle_ids;
-    std::array<int64_t, 6> primary_counts;
+    std::array<int64_t, 7> primary_counts;
     int64_t size;
     char * topology;
     int64_t truth_id;
@@ -375,6 +406,7 @@ namespace cafmaker::types::dlp
     
     hvl_t match_handle;
     hvl_t match_overlap_handle;
+    hvl_t nu_position_handle;
     hvl_t particle_ids_handle;
     hvl_t truth_particle_counts_handle;
     hvl_t truth_primary_counts_handle;
@@ -391,12 +423,11 @@ namespace cafmaker::types::dlp
     double calo_ke;
     double calo_ke_tng;
     BufferView<int64_t> children_counts;
-    BufferView<uint64_t> children_id;
+    double coffset;
     char * creation_process;
     double csda_ke;
     double csda_ke_tng;
     double depositions_sum;
-    BufferView<double> direction;
     double distance_travel;
     std::array<float, 3> end_dir;
     std::array<float, 3> end_point;
@@ -410,9 +441,12 @@ namespace cafmaker::types::dlp
     int64_t image_id;
     BufferView<int64_t> index;
     int64_t interaction_id;
+    bool is_ccrosser;
     bool is_contained;
     bool is_primary;
     bool is_principal_match;
+    bool is_valid;
+    double ke;
     BufferView<float> last_step;
     double length;
     double length_tng;
@@ -423,7 +457,7 @@ namespace cafmaker::types::dlp
     double mcs_ke_tng;
     int64_t mcst_index;
     int64_t mct_index;
-    std::array<double, 3> momentum;
+    std::array<float, 3> momentum;
     int64_t nu_id;
     int64_t num_fragments;
     int64_t num_voxels;
@@ -449,11 +483,10 @@ namespace cafmaker::types::dlp
     int64_t track_id;
     float truth_depositions_MeV_sum;
     double truth_depositions_sum;
-    BufferView<double> truth_end_dir;
-    int64_t truth_id;
     BufferView<int64_t> truth_index;
+    std::array<double, 3> truth_momentum;
     int64_t truth_size;
-    BufferView<double> truth_start_dir;
+    std::array<double, 3> truth_start_dir;
     char * units;
     int64_t volume_id;
     
@@ -469,8 +502,6 @@ namespace cafmaker::types::dlp
     
     hvl_t ancestor_position_handle;
     hvl_t children_counts_handle;
-    hvl_t children_id_handle;
-    hvl_t direction_handle;
     hvl_t first_step_handle;
     hvl_t fragment_ids_handle;
     hvl_t index_handle;
@@ -480,9 +511,7 @@ namespace cafmaker::types::dlp
     hvl_t parent_position_handle;
     hvl_t position_handle;
     hvl_t sed_index_handle;
-    hvl_t truth_end_dir_handle;
     hvl_t truth_index_handle;
-    hvl_t truth_start_dir_handle;
   };
   
   
@@ -491,6 +520,17 @@ namespace cafmaker::types::dlp
     int64_t run;
     int64_t subrun;
     int64_t event;
+    
+    void SyncVectors();
+  };
+  
+  
+  struct Trigger
+  {
+    int64_t id;
+    int64_t time_ns;
+    int64_t time_s;
+    int64_t type;
     
     void SyncVectors();
   };
@@ -518,6 +558,10 @@ namespace cafmaker::types::dlp
   
   template <>
   H5::CompType BuildCompType<RunInfo>();
+  
+  
+  template <>
+  H5::CompType BuildCompType<Trigger>();
   
 
 }


### PR DESCRIPTION
Replace the placeholder code doing trigger matching for ML-reco with actual trigger info propagated through the stack.  Requires upstream files generated with [appropriate LArCV product](https://github.com/DeepLearnPhysics/larcv2/pull/45) and processed with lartpc_mlreco3d outputting a `trigger` product into output files.