### PR TITLE
Use true trajectory index from GENIE, where it exists

### DIFF
--- a/src/reco/DLP_h5_classes.cxx
+++ b/src/reco/DLP_h5_classes.cxx
@@ -5,7 +5,7 @@
 //    
 //    The invocation that generated this file was:
 //
-//       ./h5_to_cpp.py -f /data/dune/data/users/jwolcott/nd/nd-lar-reco/reco-out/PicoRun4.1_1E17_RHC.larnd.00000.reco.summary.h5 -o ../src/reco/DLP_h5_classes -ns cafmaker::types::dlp -d events -cn Event -d interactions -cn Interaction -d particles -cn Particle -d truth_interactions -cn TrueInteraction -d truth_particles -cn TrueParticle -d run_info -cn RunInfo -d trigger -cn Trigger
+//       ./h5_to_cpp.py -f /dune/data/users/jwolcott/nd/nd-lar-reco/reco-out/PicoRun4.1_1E17_RHC.larnd.00000.reco.summary.h5 -o ../src/reco/DLP_h5_classes -ns cafmaker::types::dlp -d events -cn Event -d interactions -cn Interaction -d particles -cn Particle -d truth_interactions -cn TrueInteraction -d truth_particles -cn TrueParticle -d run_info -cn RunInfo -d trigger -cn Trigger
 //
 
 #include "DLP_h5_classes.h"
@@ -53,6 +53,7 @@ namespace cafmaker::types::dlp
   {
     ancestor_position.reset(&ancestor_position_handle);
     children_counts.reset(&children_counts_handle);
+    children_id.reset(&children_id_handle);
     first_step.reset(&first_step_handle);
     fragment_ids.reset(&fragment_ids_handle);
     index.reset(&index_handle);
@@ -83,13 +84,13 @@ namespace cafmaker::types::dlp
   {
     H5::CompType ctype(sizeof(Event));
   
-    ctype.insertMember("index", HOFFSET(Event, index), H5::PredType::STD_REF_DSETREG);
-    ctype.insertMember("run_info", HOFFSET(Event, run_info), H5::PredType::STD_REF_DSETREG);
     ctype.insertMember("meta", HOFFSET(Event, meta), H5::PredType::STD_REF_DSETREG);
+    ctype.insertMember("index", HOFFSET(Event, index), H5::PredType::STD_REF_DSETREG);
     ctype.insertMember("trigger", HOFFSET(Event, trigger), H5::PredType::STD_REF_DSETREG);
-    ctype.insertMember("truth_interactions", HOFFSET(Event, truth_interactions), H5::PredType::STD_REF_DSETREG);
-    ctype.insertMember("truth_particles", HOFFSET(Event, truth_particles), H5::PredType::STD_REF_DSETREG);
+    ctype.insertMember("run_info", HOFFSET(Event, run_info), H5::PredType::STD_REF_DSETREG);
     ctype.insertMember("interactions", HOFFSET(Event, interactions), H5::PredType::STD_REF_DSETREG);
+    ctype.insertMember("truth_particles", HOFFSET(Event, truth_particles), H5::PredType::STD_REF_DSETREG);
+    ctype.insertMember("truth_interactions", HOFFSET(Event, truth_interactions), H5::PredType::STD_REF_DSETREG);
     ctype.insertMember("particles", HOFFSET(Event, particles), H5::PredType::STD_REF_DSETREG);
   
     return ctype;
@@ -466,6 +467,7 @@ namespace cafmaker::types::dlp
     ctype.insertMember("calo_ke", HOFFSET(TrueParticle, calo_ke), H5::PredType::IEEE_F64LE);
     ctype.insertMember("calo_ke_tng", HOFFSET(TrueParticle, calo_ke_tng), H5::PredType::IEEE_F64LE);
     ctype.insertMember("children_counts", HOFFSET(TrueParticle, children_counts_handle), H5::VarLenType(H5::PredType::STD_I64LE));
+    ctype.insertMember("children_id", HOFFSET(TrueParticle, children_id_handle), H5::VarLenType(H5::PredType::STD_I64LE));
     ctype.insertMember("coffset", HOFFSET(TrueParticle, coffset), H5::PredType::IEEE_F64LE);
     
     H5::StrType creation_process_strType(H5::PredType::C_S1, H5T_VARIABLE);
@@ -483,6 +485,7 @@ namespace cafmaker::types::dlp
     ctype.insertMember("energy_init", HOFFSET(TrueParticle, energy_init), H5::PredType::IEEE_F64LE);
     ctype.insertMember("first_step", HOFFSET(TrueParticle, first_step_handle), H5::VarLenType(H5::PredType::IEEE_F32LE));
     ctype.insertMember("fragment_ids", HOFFSET(TrueParticle, fragment_ids_handle), H5::VarLenType(H5::PredType::STD_I64LE));
+    ctype.insertMember("gen_id", HOFFSET(TrueParticle, gen_id), H5::PredType::STD_I64LE);
     ctype.insertMember("group_id", HOFFSET(TrueParticle, group_id), H5::PredType::STD_I64LE);
     ctype.insertMember("id", HOFFSET(TrueParticle, id), H5::PredType::STD_I64LE);
     ctype.insertMember("image_id", HOFFSET(TrueParticle, image_id), H5::PredType::STD_I64LE);
@@ -555,6 +558,7 @@ namespace cafmaker::types::dlp
     ctype.insertMember("track_id", HOFFSET(TrueParticle, track_id), H5::PredType::STD_I64LE);
     ctype.insertMember("truth_depositions_MeV_sum", HOFFSET(TrueParticle, truth_depositions_MeV_sum), H5::PredType::IEEE_F32LE);
     ctype.insertMember("truth_depositions_sum", HOFFSET(TrueParticle, truth_depositions_sum), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("truth_id", HOFFSET(TrueParticle, truth_id), H5::PredType::STD_I64LE);
     ctype.insertMember("truth_index", HOFFSET(TrueParticle, truth_index_handle), H5::VarLenType(H5::PredType::STD_I64LE));
     ctype.insertMember("truth_momentum", HOFFSET(TrueParticle, truth_momentum), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("truth_size", HOFFSET(TrueParticle, truth_size), H5::PredType::STD_I64LE);

--- a/src/reco/DLP_h5_classes.h
+++ b/src/reco/DLP_h5_classes.h
@@ -5,7 +5,7 @@
 //    
 //    The invocation that generated this file was:
 //
-//       ./h5_to_cpp.py -f /home/jeremy/data/dune/data/users/jwolcott/nd/nd-lar-reco/reco-out/PicoRun4.1_1E17_RHC.larnd.00000.reco.summary.h5 -o ../src/reco/DLP_h5_classes -ns cafmaker::types::dlp -d events -cn Event -d interactions -cn Interaction -d particles -cn Particle -d truth_interactions -cn TrueInteraction -d truth_particles -cn TrueParticle -d run_info -cn RunInfo -d trigger -cn Trigger
+//       ./h5_to_cpp.py -f /dune/data/users/jwolcott/nd/nd-lar-reco/reco-out/PicoRun4.1_1E17_RHC.larnd.00000.reco.summary.h5 -o ../src/reco/DLP_h5_classes -ns cafmaker::types::dlp -d events -cn Event -d interactions -cn Interaction -d particles -cn Particle -d truth_interactions -cn TrueInteraction -d truth_particles -cn TrueParticle -d run_info -cn RunInfo -d trigger -cn Trigger
 //
 
 
@@ -200,13 +200,13 @@ namespace cafmaker::types::dlp
   
   struct Event
   {
-    hdset_reg_ref_t index;
-    hdset_reg_ref_t run_info;
     hdset_reg_ref_t meta;
+    hdset_reg_ref_t index;
     hdset_reg_ref_t trigger;
-    hdset_reg_ref_t truth_interactions;
-    hdset_reg_ref_t truth_particles;
+    hdset_reg_ref_t run_info;
     hdset_reg_ref_t interactions;
+    hdset_reg_ref_t truth_particles;
+    hdset_reg_ref_t truth_interactions;
     hdset_reg_ref_t particles;
     
     void SyncVectors();
@@ -214,11 +214,11 @@ namespace cafmaker::types::dlp
     template <typename T>
     const hdset_reg_ref_t& GetRef() const
     {
-      if constexpr(std::is_same_v<T, RunInfo>) return run_info;
-      else if(std::is_same_v<T, Trigger>) return trigger;
-      else if(std::is_same_v<T, TrueInteraction>) return truth_interactions;
-      else if(std::is_same_v<T, TrueParticle>) return truth_particles;
+      if constexpr(std::is_same_v<T, Trigger>) return trigger;
+      else if(std::is_same_v<T, RunInfo>) return run_info;
       else if(std::is_same_v<T, Interaction>) return interactions;
+      else if(std::is_same_v<T, TrueParticle>) return truth_particles;
+      else if(std::is_same_v<T, TrueInteraction>) return truth_interactions;
       else if(std::is_same_v<T, Particle>) return particles;
     }
     
@@ -423,6 +423,7 @@ namespace cafmaker::types::dlp
     double calo_ke;
     double calo_ke_tng;
     BufferView<int64_t> children_counts;
+    BufferView<uint64_t> children_id;
     double coffset;
     char * creation_process;
     double csda_ke;
@@ -436,6 +437,7 @@ namespace cafmaker::types::dlp
     double energy_init;
     BufferView<float> first_step;
     BufferView<int64_t> fragment_ids;
+    int64_t gen_id;
     int64_t group_id;
     int64_t id;
     int64_t image_id;
@@ -483,6 +485,7 @@ namespace cafmaker::types::dlp
     int64_t track_id;
     float truth_depositions_MeV_sum;
     double truth_depositions_sum;
+    int64_t truth_id;
     BufferView<int64_t> truth_index;
     std::array<double, 3> truth_momentum;
     int64_t truth_size;
@@ -502,6 +505,7 @@ namespace cafmaker::types::dlp
     
     hvl_t ancestor_position_handle;
     hvl_t children_counts_handle;
+    hvl_t children_id_handle;
     hvl_t first_step_handle;
     hvl_t fragment_ids_handle;
     hvl_t index_handle;

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -105,12 +105,12 @@ caf::ScatteringMode GENIE2CAF(genie::EScatteringType sc)
 namespace cafmaker
 {
   template <>
-  void ValidateOrCopy<double, float>(const double & input, float & target, const float & unsetVal)
+  void ValidateOrCopy<double, float>(const double & input, float & target, const float & unsetVal, const std::string & fieldName)
   {
     const auto cmp = [](const double & a, const float &b) -> bool { return util::AreEqual(a, b); };
 
     const auto assgn = [](const double & a, float & b) {  b = a; };
-    return ValidateOrCopy<double, float>(input, target, unsetVal, cmp, assgn);
+    return ValidateOrCopy<double, float>(input, target, unsetVal, cmp, assgn, fieldName);
   }
 
 

--- a/src/truth/FillTruth.h
+++ b/src/truth/FillTruth.h
@@ -14,6 +14,7 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <sstream>
 
 #include "fwd.h"
 #include "util/Loggable.h"
@@ -99,8 +100,10 @@ namespace cafmaker
 
     // if neither of the above conditions were met,
     // we have a discrepancy.  bail loudly
-    LOG_S("ValidateOrCopy()").FATAL() << "Mismatch between branch value (" << target << ") and supplied value (" << input << ")!  Abort.\n";
-    abort();
+    std::stringstream ss;
+    ss << (!fieldName.empty() ? "For field name '" + fieldName + "': " : "")
+       << "Mismatch between branch value (" << target << ") and supplied value (" << input << ")!  Abort.\n";
+    throw std::runtime_error(ss.str());
   }
 
   // --------------------------------------------------------------

--- a/src/truth/FillTruth.h
+++ b/src/truth/FillTruth.h
@@ -47,12 +47,12 @@ namespace cafmaker
   /// \param target    The destination value
   /// \param unsetVal  The default value expected
   template <typename InputType, typename OutputType>
-  void ValidateOrCopy(const InputType & input, OutputType & target, const OutputType & unsetVal)
+  void ValidateOrCopy(const InputType & input, OutputType & target, const OutputType & unsetVal, const std::string & fieldName="")
   {
     const auto defaultComp = [](const decltype(input) & a,
                                 const decltype(target) &b) -> bool { return static_cast<OutputType>(a) == b; };
     const auto defaultAssgn = [](const decltype(input) & a, decltype(target) &b) {  b = a; };
-    return ValidateOrCopy(input, target, unsetVal, defaultComp, defaultAssgn);
+    return ValidateOrCopy(input, target, unsetVal, defaultComp, defaultAssgn, fieldName);
   }
 
  // --------------------------------------------------------------
@@ -68,9 +68,11 @@ namespace cafmaker
   template <typename InputType, typename OutputType>
   void ValidateOrCopy(const InputType & input, OutputType & target, const OutputType & unsetVal,
                       std::function<bool(const decltype(input) &, const decltype(target) &)> compFn,
-                      std::function<void(const decltype(input) &, decltype(target) &)> assgnFn)
+                      std::function<void(const decltype(input) &, decltype(target) &)> assgnFn,
+                      const std::string & fieldName="")
   {
-    LOG_S("ValidateOrCopy()").VERBOSE() << "     supplied val=" << input << "; previous branch val=" << target << "; default=" << unsetVal << "\n";
+    LOG_S("ValidateOrCopy()").VERBOSE() << "     " << (!fieldName.empty() ? "field='" + fieldName + "';" : "")
+                                        << " supplied val=" << input << "; previous branch val=" << target << "; default=" << unsetVal << "\n";
 
     // vals match?  nothing more to do
     if (compFn(input, target))
@@ -105,7 +107,7 @@ namespace cafmaker
   // specialize the template for double-> float conversions, which we do a lot,
   // and which have roundoff problems in the comparison operator otherwise
   template <>
-  void ValidateOrCopy<double, float>(const double & input, float & target, const float & unsetVal);
+  void ValidateOrCopy<double, float>(const double & input, float & target, const float & unsetVal, const std::string& fieldName);
 
   // --------------------------------------------------------------
 


### PR DESCRIPTION
As it stands right now, the true trajectory id passed through edep-sim is always rewritten to be unique within a spill.  This makes matching to the original GENIE particles difficult, because the mapping is lost.

We now pass the original trajectory id, `local_traj_id` from edep-sim, as an extra field through the MLreco chain.  This PR uses that to match to GENIE, when it's available.