### PR TITLE
More truth matching fixes

### DIFF
--- a/ndcaf_setup.sh
+++ b/ndcaf_setup.sh
@@ -9,7 +9,7 @@ setup genie_xsec   v3_04_00 -q AR2320i00000:e1000:k250
 setup genie_phyopt v3_04_00 -q dkcharmtau
 setup jobsub_client
 setup eigen v3_3_5
-setup duneanaobj v03_01_00 -q e20:prof
+setup duneanaobj v03_02_01 -q e20:prof
 setup hdf5 v1_10_5a -q e20
 setup fhiclcpp v4_15_03 -q debug:e20
 

--- a/src/reco/MINERvARecoBranchFiller.cxx
+++ b/src/reco/MINERvARecoBranchFiller.cxx
@@ -347,10 +347,12 @@ namespace cafmaker
     caf::SRTrueParticle & srTruePart = is_primary ? truthMatch->GetTrueParticle(sr, srTrueInt, edepsim_track_id, true, false)
                                                     : truthMatch->GetTrueParticle(sr, srTrueInt, edepsim_track_id, false, true);
 
-    sh.truth.ixn = truthVecIdx;
-    sh.truth.type = is_primary ? caf::TrueParticleID::kPrimary
-   				 : caf::TrueParticleID::kSecondary;
-    sh.truth.part = edepsim_track_id;
+    caf::TrueParticleID truePartID;
+    truePartID.ixn = truthVecIdx;
+    truePartID.type = is_primary ? caf::TrueParticleID::kPrimary
+                                 : caf::TrueParticleID::kSecondary;
+    truePartID.part = edepsim_track_id;
+    sh.truth.push_back(std::move(truePartID));
 
     FillTrueParticle(srTruePart, max_trkid);
 
@@ -412,10 +414,13 @@ namespace cafmaker
                                                     : truthMatch->GetTrueParticle(sr, srTrueInt, edepsim_track_id, false, true);
 
 
-    t.truth.ixn = truthVecIdx;
-    t.truth.type = is_primary ? caf::TrueParticleID::kPrimary
+    caf::TrueParticleID truePartID;
+    truePartID.ixn = truthVecIdx;
+    truePartID.type = is_primary ? caf::TrueParticleID::kPrimary
                                  : caf::TrueParticleID::kSecondary;
-    t.truth.part = edepsim_track_id;
+    truePartID.part = edepsim_track_id;
+    t.truth.push_back(std::move(truePartID));
+
 
     FillTrueParticle(srTruePart,max_trkid);
 

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -190,6 +190,12 @@ namespace cafmaker
       if( p->Status() != genie::EGHepStatus::kIStStableFinalState
           && p->Status() != genie::EGHepStatus::kIStHadronInTheNucleus) continue;
 
+      if ( p->Pdg() == 2000000101 )
+      {
+        LOG_S("TruthMatcher::FillInteraction").VERBOSE() << "      Skipping GENIE 'bindino' at GENIE index " << j << "\n";
+        continue;
+      }
+
       caf::SRTrueParticle part;
       part.G4ID = (p->Status() == genie::EGHepStatus::kIStStableFinalState) ? stablePartIdx++ : -1;
       part.pdg = p->Pdg();


### PR DESCRIPTION
A few truth matching fixups:
* Use newest `duneanaobj` (which stores multiple contributors to reco objs)
* Update MINERvA matcher to store true contributors to reco obj in a vector per previous item
* Discard GENIE 'bindino' particles for the purposes of matching, since they don't propagate through GEANT