### PR TITLE
Add temporary machinery for filling POT info

### DIFF
--- a/cfg/NDCAFMaker.fcl
+++ b/cfg/NDCAFMaker.fcl
@@ -6,6 +6,7 @@ standard_nd_cafmaker: {
    RunParams: {
      Run: 1
      Subrun: 0
+     POTPerSpill: 5  # e13
 
      IsFHC: true
      IsGasTPC: false

--- a/src/Params.h
+++ b/src/Params.h
@@ -18,6 +18,9 @@ namespace cafmaker
     fhicl::Atom<int> run    { fhicl::Name("Run"),    fhicl::Comment("Run number"), 1 };    // CAFAna doesn't like run number 0
     fhicl::Atom<int> subrun { fhicl::Name("Subrun"), fhicl::Comment("Subrun number"), 0 };
 
+    // fixme: placeholder.  won't work for data, which will need to either pass through from upstream or interface to POT database here
+    fhicl::Atom<float> POTPerSpill { fhicl::Name("POTPerSpill"), fhicl::Comment("Fixed POT per spill (units of 10^13).")};
+
     fhicl::Atom<bool> fhc        { fhicl::Name("IsFHC"),    fhicl::Comment("Is this an FHC run?"), true };
     fhicl::Atom<bool> IsGasTPC   { fhicl::Name("IsGasTPC"), fhicl::Comment("Was GArTPC geometry used? (If not, TMS)"), false };
 

--- a/src/makeCAF.C
+++ b/src/makeCAF.C
@@ -324,6 +324,12 @@ void loop(CAF &caf,
     // reset (the default constructor initializes its variables)
     caf.setToBS();
 
+    double pot = par().runInfo().POTPerSpill() * 1e13;
+    if (std::isnan(caf.pot))
+      caf.pot = 0;
+    caf.pot += pot;
+    caf.sr.beam.pulsepot = pot;
+    caf.sr.beam.ismc = true;  // when we have data, we won't be able to use this "POT from config" approach anyway
 
     // hand off to the correct reco filler(s).
     for (const auto & fillerTrigPair : groupedTriggers[ii])


### PR DESCRIPTION
For the moment, we introduce a config parameter that can be used to specify POT per spill in the simulation.  This is not a full solution for #36 however, since when we have data it will need to be retrieved from a spill database somewhere (and we expect it will be handed off from upstream in that case).