### PR TITLE
Pull truth vertex info from GENIE instead of ML-reco

### DIFF
--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -209,9 +209,11 @@ namespace cafmaker
 
     const auto NaN = std::numeric_limits<float>::signaling_NaN();
 
-    ValidateOrCopy(ptTrueInt.vertex[0], srTrueInt.vtx.x, NaN, "SRTrueInteraction::vtx::x");
-    ValidateOrCopy(ptTrueInt.vertex[1], srTrueInt.vtx.y, NaN, "SRTrueInteraction::vtx::y");
-    ValidateOrCopy(ptTrueInt.vertex[2], srTrueInt.vtx.z, NaN, "SRTrueInteraction::vtx::z");
+    // vertices from ML-reco are adjusted to the edge of the sensitive detector volume
+    // if they originate from outside it, so we can't use them
+//    ValidateOrCopy(ptTrueInt.vertex[0], srTrueInt.vtx.x, NaN, "SRTrueInteraction::vtx::x");
+//    ValidateOrCopy(ptTrueInt.vertex[1], srTrueInt.vtx.y, NaN, "SRTrueInteraction::vtx::y");
+//    ValidateOrCopy(ptTrueInt.vertex[2], srTrueInt.vtx.z, NaN, "SRTrueInteraction::vtx::z");
 
     const std::function<bool(const NuCurrentType &, const bool &)> nuCurrComp =
     [](const NuCurrentType & inCurr, const bool & outCurr)

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -133,10 +133,17 @@ namespace cafmaker
     // note that the nu.id and nu.genieIdx are filled in the calling function,
     // because that info is not stored inside the GENIE event proper
 
-    // todo: GENIE doesn't know about the detector geometry.  do we just leave these for the passthrough from G4?
-//    TLorentzVector vtx = *(event->Vertex());
-//    nu.vtx = vtx.Vect();
-//      nu.isvtxcont =
+    // coordinates in GENIE sim are in different units from edep-sim... :-|
+    TLorentzVector vtx = *(event->Vertex());
+    TVector3 nu_vtx = vtx.Vect();
+    const float m_to_cm = 100;
+    nu_vtx *= m_to_cm;
+    LOG_S("TruthMatcher::FillInteraction").VERBOSE() << "Modifying GENIE vertex from (" << vtx.X() << "," << vtx.Y() << "," << vtx.Z() << ")"
+                                                     << " to (" << nu_vtx.X() << "," << nu_vtx.Y() << "," << nu_vtx.Z() << ")"
+                                                     << " to account for change in units from m to cm\n";
+//    nu.vtx = nu_vtx;
+
+    // we can't fill the time, however, because that's changed by spill building
 //    nu.time = vtx.T();
 
     nu.pdg = in->InitState().ProbePdg();
@@ -370,7 +377,8 @@ namespace cafmaker
       ixn->id = ixnID;
       if (HaveGENIE())
       {
-        LOG.VERBOSE() << "      --> GENIE record found (" << fGTrees.GEvt() << ").  copying...\n";
+        LOG.VERBOSE() << "      --> GENIE record found (" << fGTrees.GEvt() << "; dump follows).  copying...\n";
+        fGTrees.GEvt()->PrintToStream(const_cast<ostream&>(LOG.VERBOSE().GetStream()));
 
         // this bit of info can't be extracted directly from the GENIE record,
         // so we do it here

--- a/src/util/Logger.h
+++ b/src/util/Logger.h
@@ -43,6 +43,9 @@ namespace cafmaker
       THRESHOLD GetThreshold() const           { return fThresh; }
       void      SetThreshold(THRESHOLD thresh) { fThresh = thresh; }
 
+      std::ostream & GetStream()             { return fStream; }
+      const std::ostream & GetStream() const { return fStream; }
+
       /// Force a write to the output.
       template <typename T>
       const Logger & operator<<(const T & obj) const


### PR DESCRIPTION
ML-reco's truth vertex locations have a known issue (in Supera particle edges are moved to the edge of the sensitive volume to aid in labeling for PPN, and the interaction vertex is inferred from those).  Stop using those.  Switch to GENIE instead.  

To verify: does this match MINERvA?