### PR TITLE
Obtain true vertex info from GENIE files & compare to MINERvA

### DIFF
--- a/src/reco/MINERvARecoBranchFiller.cxx
+++ b/src/reco/MINERvARecoBranchFiller.cxx
@@ -126,12 +126,31 @@ namespace cafmaker
     void MINERvARecoBranchFiller::FillTrueParticle(caf::SRTrueParticle & srTruePart,
                                                  int max_trkid) const
   {
-    //const auto NaN = std::numeric_limits<float>::signaling_NaN();
+    const auto NaN = std::numeric_limits<float>::signaling_NaN();
     ValidateOrCopy(mc_traj_pdg[max_trkid], srTruePart.pdg, 0, "pdg_code");
 
     ValidateOrCopy(mc_traj_edepsim_trkid[max_trkid], srTruePart.G4ID, -1, "SRTrueParticle::track_id");
     ValidateOrCopy(mc_traj_parentid[max_trkid], srTruePart.parent, -1, "SRTrueParticle::parent");
+    ValidateOrCopy(mc_traj_point_px[max_trkid][0]/1000., srTruePart.p.px, NaN, "SRTrueParticle::p.px"); 
+    ValidateOrCopy(mc_traj_point_py[max_trkid][0]/1000., srTruePart.p.py, NaN, "SRTrueParticle::p.py");
+    ValidateOrCopy(mc_traj_point_pz[max_trkid][0]/1000., srTruePart.p.pz, NaN, "SRTrueParticle::p.pz");
 
+    try
+    {
+      ValidateOrCopy(mc_traj_point_E[max_trkid][0] / 1000., srTruePart.p.E, NaN, "SRTrueParticle::p.E");
+    }
+    catch (std::runtime_error & e)
+    {
+      auto diff = (mc_traj_point_E[max_trkid][0] / 1000. - srTruePart.p.E);
+      if (diff < 1) // < 1 MeV
+      {
+        LOG.WARNING() << "True particle energy (track id=" << srTruePart.G4ID << ", pdg=" << srTruePart.pdg << ", stored E=" << srTruePart.p.E << ")"
+                      << " differs by " << diff << " MeV between stored (GENIE?) and ML-reco pass-through values";
+      }
+      else
+        throw e;
+    }
+ 
     // todo: Things do not match yet the exact Genie output, need to work on the Minerva reconstruction output. 
     // For now will assume that if it's a primary and we gor the eventID and trackid right, Genie will have fill it properly
     // And if it's an important secondary shared by both detectors, MLReco will have filled it.

--- a/src/reco/MINERvARecoBranchFiller.cxx
+++ b/src/reco/MINERvARecoBranchFiller.cxx
@@ -111,6 +111,8 @@ namespace cafmaker
       MnvRecoTree->SetBranchAddress("mc_id_mchit_dE", mc_id_mchit_dE);
 
       MnvRecoTree->SetBranchAddress("mc_int_vtx", mc_int_vtx);
+      MnvRecoTree->SetBranchAddress("n_interactions", &n_interactions);
+      MnvRecoTree->SetBranchAddress("mc_int_edepsimId", mc_int_edepsimId);
 
 
       MnvRecoTree->GetEntry(0);

--- a/src/reco/MINERvARecoBranchFiller.cxx
+++ b/src/reco/MINERvARecoBranchFiller.cxx
@@ -80,6 +80,9 @@ namespace cafmaker
       MnvRecoTree->SetBranchAddress("blob_id_startpoint_x", blob_id_startpoint_x);
       MnvRecoTree->SetBranchAddress("blob_id_startpoint_y", blob_id_startpoint_y);
       MnvRecoTree->SetBranchAddress("blob_id_startpoint_z", blob_id_startpoint_z);
+      MnvRecoTree->SetBranchAddress("blob_id_centroid_x", blob_id_centroid_x);
+      MnvRecoTree->SetBranchAddress("blob_id_centroid_y", blob_id_centroid_y);
+      MnvRecoTree->SetBranchAddress("blob_id_centroid_z", blob_id_centroid_z);
       MnvRecoTree->SetBranchAddress("blob_id_clus_idx", blob_id_clus_idx);
 
 

--- a/src/reco/MINERvARecoBranchFiller.cxx
+++ b/src/reco/MINERvARecoBranchFiller.cxx
@@ -188,9 +188,10 @@ namespace cafmaker
 
     const auto NaN = std::numeric_limits<float>::signaling_NaN();
 
-    ValidateOrCopy(mc_int_vtx[int_id][0], srTrueInt.vtx.x, NaN, "SRTrueInteraction::vtx::x");
-    ValidateOrCopy(mc_int_vtx[int_id][1], srTrueInt.vtx.y, NaN, "SRTrueInteraction::vtx::y");
-    ValidateOrCopy(mc_int_vtx[int_id][2], srTrueInt.vtx.z, NaN, "SRTrueInteraction::vtx::z");
+    // here we are converting from mm (units from MINERvA) to cm
+    ValidateOrCopy(mc_int_vtx[int_id][0]/10., srTrueInt.vtx.x, NaN, "SRTrueInteraction::vtx::x");
+    ValidateOrCopy(mc_int_vtx[int_id][1]/10., srTrueInt.vtx.y, NaN, "SRTrueInteraction::vtx::y");
+    ValidateOrCopy(mc_int_vtx[int_id][2]/10., srTrueInt.vtx.z, NaN, "SRTrueInteraction::vtx::z");
 
 
   }

--- a/src/reco/MINERvARecoBranchFiller.h
+++ b/src/reco/MINERvARecoBranchFiller.h
@@ -50,7 +50,10 @@ namespace cafmaker
 
       void FindTruthShower(caf::StandardRecord &sr, caf::SRShower & sh, int shower_id, const TruthMatcher *truthMatch) const;
       void FindTruthTrack(caf::StandardRecord &sr, caf::SRTrack & t, int track_id, const TruthMatcher *truthMatch) const;
-      void FillTrueInteraction(caf::StandardRecord &sr) const;
+
+      void FillTrueInteraction(caf::SRTrueInteraction & srTrueInt, int int_id) const;
+      void FillInteractions(const TruthMatcher * truthMatch, caf::StandardRecord &sr) const;
+      
       void FillTrueParticle(caf::SRTrueParticle & srTruePart, int max_trkid) const;
       TFile *fMnvRecoFile;
       TTree *MnvRecoTree;
@@ -133,6 +136,12 @@ namespace cafmaker
       Int_t           mc_id_mchit_trkid[50000][2];   //[n_mc_id_digits]
       Double_t        mc_id_mchit_dE[50000][2];   //[n_mc_id_digits]
 
+      Double_t        mc_int_vtx[200][4];   //[n_interactions]
+      Long64_t        mc_int_edepsimId[200];   //[n_interactions]
+      int             n_interactions;
+
+
+      bool is_data;
       mutable std::vector<cafmaker::Trigger> fTriggers;
       mutable decltype(fTriggers)::const_iterator  fLastTriggerReqd;    ///< the last trigger requested using _FillRecoBranches()
   };

--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -653,9 +653,13 @@ namespace cafmaker
           srPartCmp.trkid = is_primary
                             ? truePartPassThrough.gen_id
                             : truePartPassThrough.track_id;
-          caf::SRTrueParticle & srTruePart = is_primary ? truthMatch->GetTrueParticle(sr, srTrueInt, srPartCmp, true, !truthMatch->HaveGENIE())
-                                                        : truthMatch->GetTrueParticle(sr, srTrueInt, srPartCmp, false, true);
 
+          // we want to make sure the particle is created, if it isn't there,
+          // but we won't do anything further with it, so we throw the return value away
+          if (is_primary)
+            truthMatch->GetTrueParticle(sr, srTrueInt, srPartCmp, true, !truthMatch->HaveGENIE());
+          else
+            truthMatch->GetTrueParticle(sr, srTrueInt, srPartCmp, false, true);
 
           // the particle idx is within the GENIE vector, which may not be the same as the index in the vector here
           // first find the interaction that it goes with

--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -209,9 +209,11 @@ namespace cafmaker
 
     const auto NaN = std::numeric_limits<float>::signaling_NaN();
 
-    ValidateOrCopy(ptTrueInt.vertex[0], srTrueInt.vtx.x, NaN, "SRTrueInteraction::vtx::x");
-    ValidateOrCopy(ptTrueInt.vertex[1], srTrueInt.vtx.y, NaN, "SRTrueInteraction::vtx::y");
-    ValidateOrCopy(ptTrueInt.vertex[2], srTrueInt.vtx.z, NaN, "SRTrueInteraction::vtx::z");
+    // vertices from ML-reco are adjusted to the edge of the sensitive detector volume
+    // if they originate from outside it, so we can't use them
+//    ValidateOrCopy(ptTrueInt.vertex[0], srTrueInt.vtx.x, NaN, "SRTrueInteraction::vtx::x");
+//    ValidateOrCopy(ptTrueInt.vertex[1], srTrueInt.vtx.y, NaN, "SRTrueInteraction::vtx::y");
+//    ValidateOrCopy(ptTrueInt.vertex[2], srTrueInt.vtx.z, NaN, "SRTrueInteraction::vtx::z");
 
     const std::function<bool(const NuCurrentType &, const bool &)> nuCurrComp =
     [](const NuCurrentType & inCurr, const bool & outCurr)

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -133,10 +133,17 @@ namespace cafmaker
     // note that the nu.id and nu.genieIdx are filled in the calling function,
     // because that info is not stored inside the GENIE event proper
 
-    // todo: GENIE doesn't know about the detector geometry.  do we just leave these for the passthrough from G4?
-//    TLorentzVector vtx = *(event->Vertex());
-//    nu.vtx = vtx.Vect();
-//      nu.isvtxcont =
+    // coordinates in GENIE sim are in different units from edep-sim... :-|
+    TLorentzVector vtx = *(event->Vertex());
+    TVector3 nu_vtx = vtx.Vect();
+    const float m_to_cm = 100;
+    nu_vtx *= m_to_cm;
+    LOG_S("TruthMatcher::FillInteraction").VERBOSE() << "Modifying GENIE vertex from (" << vtx.X() << "," << vtx.Y() << "," << vtx.Z() << ")"
+                                                     << " to (" << nu_vtx.X() << "," << nu_vtx.Y() << "," << nu_vtx.Z() << ")"
+                                                     << " to account for change in units from m to cm\n";
+//    nu.vtx = nu_vtx;
+
+    // we can't fill the time, however, because that's changed by spill building
 //    nu.time = vtx.T();
 
     nu.pdg = in->InitState().ProbePdg();
@@ -370,7 +377,8 @@ namespace cafmaker
       ixn->id = ixnID;
       if (HaveGENIE())
       {
-        LOG.VERBOSE() << "      --> GENIE record found (" << fGTrees.GEvt() << ").  copying...\n";
+        LOG.VERBOSE() << "      --> GENIE record found (" << fGTrees.GEvt() << "; dump follows).  copying...\n";
+        fGTrees.GEvt()->PrintToStream(const_cast<ostream&>(LOG.VERBOSE().GetStream()));
 
         // this bit of info can't be extracted directly from the GENIE record,
         // so we do it here

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -378,7 +378,8 @@ namespace cafmaker
       if (HaveGENIE())
       {
         LOG.VERBOSE() << "      --> GENIE record found (" << fGTrees.GEvt() << "; dump follows).  copying...\n";
-        fGTrees.GEvt()->PrintToStream(const_cast<ostream&>(LOG.VERBOSE().GetStream()));
+        if (LOG.GetThreshold() <= Logger::THRESHOLD::VERBOSE)
+          fGTrees.GEvt()->PrintToStream(const_cast<ostream&>(LOG.VERBOSE().GetStream()));
 
         // this bit of info can't be extracted directly from the GENIE record,
         // so we do it here

--- a/src/truth/FillTruth.h
+++ b/src/truth/FillTruth.h
@@ -51,10 +51,10 @@ namespace cafmaker
   template <typename InputType, typename OutputType>
   void ValidateOrCopy(const InputType & input, OutputType & target, const OutputType & unsetVal, const std::string & fieldName="")
   {
-    const auto defaultComp = [](const decltype(input) & a,
-                                const decltype(target) &b) -> bool { return static_cast<OutputType>(a) == b; };
-    const auto defaultAssgn = [](const decltype(input) & a, decltype(target) &b) {  b = a; };
-    return ValidateOrCopy(input, target, unsetVal, defaultComp, defaultAssgn, fieldName);
+    const auto defaultComp = [](std::add_const_t<std::remove_reference_t<decltype(input)>> & a,
+                                std::add_const_t<std::remove_reference_t<decltype(target)>> &b) -> bool { return static_cast<OutputType>(a) == b; };
+    const auto defaultAssgn = [](std::add_const_t<std::remove_reference_t<decltype(input)>> & a, decltype(target) &b) {  b = a; };
+    ValidateOrCopy(input, target, unsetVal, defaultComp, defaultAssgn, fieldName);
   }
 
  // --------------------------------------------------------------
@@ -69,8 +69,10 @@ namespace cafmaker
   /// \param assgnFn   Function that assigns the value of input to target
   template <typename InputType, typename OutputType>
   void ValidateOrCopy(const InputType & input, OutputType & target, const OutputType & unsetVal,
-                      std::function<bool(const decltype(input) &, const decltype(target) &)> compFn,
-                      std::function<void(const decltype(input) &, decltype(target) &)> assgnFn,
+                      std::function<bool(std::add_const_t<std::remove_reference_t<decltype(input)>> &,
+                                         std::add_const_t<std::remove_reference_t<decltype(target)>> &)> compFn,
+                      std::function<void(std::add_const_t<std::remove_reference_t<decltype(input)>> &,
+                                         decltype(target) &)> assgnFn,
                       const std::string & fieldName="")
   {
     LOG_S("ValidateOrCopy()").VERBOSE() << "     " << (!fieldName.empty() ? "field='" + fieldName + "';" : "")

--- a/src/truth/FillTruth.h
+++ b/src/truth/FillTruth.h
@@ -78,15 +78,17 @@ namespace cafmaker
     LOG_S("ValidateOrCopy()").VERBOSE() << "     " << (!fieldName.empty() ? "field='" + fieldName + "';" : "")
                                         << " supplied val=" << input << "; previous branch val=" << target << "; default=" << unsetVal << "\n";
 
-    // vals match?  nothing more to do
-    if (compFn(input, target))
+    // is the target value already the desired value?
+    // or was the supplied value the default value (which implies nothing should be set)?
+    // then nothing more to do.
+    if (compFn(input, target) || compFn(input, unsetVal))
      return;
 
     // note that NaN and inf aren't equal to anything, even themselves, so we have check that differently
     if constexpr (std::numeric_limits<InputType>::has_signaling_NaN && std::numeric_limits<OutputType>::has_signaling_NaN)
-      if (std::isnan(input) && std::isnan(target)) return;
+      if ( (std::isnan(input) && std::isnan(target)) || (std::isnan(input) && std::isnan(unsetVal)) ) return;
     if constexpr ( std::numeric_limits<InputType>::has_infinity && std::numeric_limits<OutputType>::has_infinity )
-      if (std::isinf(input) && std::isinf(target)) return;
+      if ( (std::isinf(input) && std::isinf(target)) || (std::isinf(input) && std::isinf(unsetVal)) ) return;
 
     // is this the default val?
     bool isNanInf = false;

--- a/src/util/Logger.h
+++ b/src/util/Logger.h
@@ -43,6 +43,9 @@ namespace cafmaker
       THRESHOLD GetThreshold() const           { return fThresh; }
       void      SetThreshold(THRESHOLD thresh) { fThresh = thresh; }
 
+      std::ostream & GetStream()             { return fStream; }
+      const std::ostream & GetStream() const { return fStream; }
+
       /// Force a write to the output.
       template <typename T>
       const Logger & operator<<(const T & obj) const


### PR DESCRIPTION
ML-reco's truth vertex locations have a known issue (in Supera particle edges are moved to the edge of the sensitive volume to aid in labeling for PPN, and the interaction vertex is inferred from those). Stop using those. Switch to GENIE instead.  Also enable passing of true vertex info through MINERvA and ensure that matches GENIE.

Supersedes #54.