### PR TITLE
uncommented truth GENIE vertex

### DIFF
--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -141,7 +141,7 @@ namespace cafmaker
     LOG_S("TruthMatcher::FillInteraction").VERBOSE() << "Modifying GENIE vertex from (" << vtx.X() << "," << vtx.Y() << "," << vtx.Z() << ")"
                                                      << " to (" << nu_vtx.X() << "," << nu_vtx.Y() << "," << nu_vtx.Z() << ")"
                                                      << " to account for change in units from m to cm\n";
-//    nu.vtx = nu_vtx;
+   nu.vtx = nu_vtx;
 
     // we can't fill the time, however, because that's changed by spill building
 //    nu.time = vtx.T();


### PR DESCRIPTION
Just uncommented the Genie filling of the vertex positions. You can see the difference before/after here. 
![vtx_x_old](https://github.com/DUNE/ND_CAFMaker/assets/28730995/78028565-210c-459f-99ef-987406568d8a)
![image](https://github.com/DUNE/ND_CAFMaker/assets/28730995/374e9646-731a-42d6-94ed-59befe7d3457)


An interesting point is that we see that the vertex/neutrino filling is only done when "things" are reconstructed in any of the two detectors. the 1st event doesn't have any reconstructed objects in liquid argon and no showers/tracks in MINERvA, so no vertex is filled. Maybe we want to change that at some point?