### PR TITLE
Trigger erasing fix proposition

### DIFF
--- a/src/makeCAF.C
+++ b/src/makeCAF.C
@@ -276,7 +276,7 @@ buildTriggerList(std::map<const cafmaker::IRecoBranchFiller*, std::deque<cafmake
       // if there are no more elements in this reco filler stream,
       // remove it from consideration
       if (fillerTrigPair.second.empty())
-		  keysToRemove.push_back(fillerTrigPair.first);
+        trigStreamsToRemove.push_back(fillerTrigPair.first);
     } // for (fillerTrigPair)
   // Erase the marked keys from the map
   for (const auto &key : keysToRemove) triggersByFiller.erase(key);

--- a/src/makeCAF.C
+++ b/src/makeCAF.C
@@ -243,11 +243,10 @@ buildTriggerList(std::map<const cafmaker::IRecoBranchFiller*, std::deque<cafmake
 
     // now consider the other reco filler streams.
     // do they have any events in them that should go in this group?
+    std::vector<decltype(triggersByFiller)::key_type> trigStreamsToRemove;  // since we can't edit the `triggersByFiller` group without invalidating its iterators
     std::vector<std::pair<const cafmaker::IRecoBranchFiller*, cafmaker::Trigger>> & trigGroup = ret.back();
     const cafmaker::Trigger & trigSeed = trigGroup.front().second;
     LOG().VERBOSE() << "    Considering other triggers:\n";
-	// Create a list to store keys to erase
-	std::vector<decltype(triggersByFiller)::key_type> keysToRemove;
     for (auto & fillerTrigPair : triggersByFiller)
     {
       std::stringstream ss;

--- a/src/makeCAF.C
+++ b/src/makeCAF.C
@@ -246,6 +246,8 @@ buildTriggerList(std::map<const cafmaker::IRecoBranchFiller*, std::deque<cafmake
     std::vector<std::pair<const cafmaker::IRecoBranchFiller*, cafmaker::Trigger>> & trigGroup = ret.back();
     const cafmaker::Trigger & trigSeed = trigGroup.front().second;
     LOG().VERBOSE() << "    Considering other triggers:\n";
+	// Create a list to store keys to erase
+	std::vector<decltype(triggersByFiller)::key_type> keysToRemove;
     for (auto & fillerTrigPair : triggersByFiller)
     {
       std::stringstream ss;
@@ -275,9 +277,10 @@ buildTriggerList(std::map<const cafmaker::IRecoBranchFiller*, std::deque<cafmake
       // if there are no more elements in this reco filler stream,
       // remove it from consideration
       if (fillerTrigPair.second.empty())
-        triggersByFiller.erase(fillerTrigPair.first);
-
+		  keysToRemove.push_back(fillerTrigPair.first);
     } // for (fillerTrigPair)
+  // Erase the marked keys from the map
+  for (const auto &key : keysToRemove) triggersByFiller.erase(key);
   } // while (!triggersByFiller.empty())
 
   LOG().DEBUG() << "Final trigger list\n";

--- a/src/makeCAF.C
+++ b/src/makeCAF.C
@@ -278,8 +278,9 @@ buildTriggerList(std::map<const cafmaker::IRecoBranchFiller*, std::deque<cafmake
       if (fillerTrigPair.second.empty())
         trigStreamsToRemove.push_back(fillerTrigPair.first);
     } // for (fillerTrigPair)
-  // Erase the marked keys from the map
-  for (const auto &key : keysToRemove) triggersByFiller.erase(key);
+
+    // Erase the marked reco filler(s) from the map
+    for (const auto & trigStream : trigStreamsToRemove) triggersByFiller.erase(trigStream);
   } // while (!triggersByFiller.empty())
 
   LOG().DEBUG() << "Final trigger list\n";


### PR DESCRIPTION
Some Minirun4.5 jobs were failing at the trigger filling procedure, on test I've run, it seems that it happens even more with MINERvA only events.  

As I understand it, the erase statement in the trigger matching for loop seem to remove an element we try to access to afterwards https://github.com/DUNE/ND_CAFMaker/blob/main/src/makeCAF.C#L278

Modify with storing the keys to erase and remove them outside the for loop that contains the map. 
On tests, I see the same number of triggers and files that crashed don't crash anymore.

Joint here are two valgrind files running on the same files to make CAFs. I'm not a valgrind expert but the `==4445== Invalid read of size 8`  that seem to be associated to `buildTriggerList` have disapeared in the postfix version, so I assume that fixed some memory issue somewhere?
[logfile_valigrind_postfix.txt](https://github.com/DUNE/ND_CAFMaker/files/14226581/logfile_valigrind_postfix.txt)
[logfile_valigrind_prefix.txt](https://github.com/DUNE/ND_CAFMaker/files/14226582/logfile_valigrind_prefix.txt)
