### PR TITLE
Bugfix/minerva max traj

### DIFF
--- a/src/reco/MINERvARecoBranchFiller.cxx
+++ b/src/reco/MINERvARecoBranchFiller.cxx
@@ -399,14 +399,14 @@ namespace cafmaker
 
     //Create the possible SRTrueParticle that correspond to the shower
     if (max_trkid >= n_mc_trajectories) // We want to access a trajectory that was not stored, set particle to kUnknown, will not be able to match the true particle
-		{
-			caf::TrueParticleID truePartID;
-			truePartID.ixn = -1; //Should be the default for a new TrueParticleID but wanna make sure of it
-			truePartID.type = caf::TrueParticleID::kUnknown;
-			truePartID.part = -1;
-			sh.truth.push_back(std::move(truePartID));
-		  return;	
-		}
+    {
+      caf::TrueParticleID truePartID;
+      truePartID.ixn = -1; //Should be the default for a new TrueParticleID but wanna make sure of it
+      truePartID.type = caf::TrueParticleID::kUnknown;
+      truePartID.part = -1;
+      sh.truth.push_back(std::move(truePartID));
+      return;
+    }
 
     Long_t neutrino_event_id = mc_traj_edepsim_eventid[max_trkid];
     std::size_t truthVecIdx = std::distance(sr.mc.nu.begin(),

--- a/src/reco/MINERvARecoBranchFiller.cxx
+++ b/src/reco/MINERvARecoBranchFiller.cxx
@@ -398,7 +398,16 @@ namespace cafmaker
     }
 
     //Create the possible SRTrueParticle that correspond to the shower
-    
+    if (max_trkid >= n_mc_trajectories) // We want to access a trajectory that was not stored, set particle to kUnknown, will not be able to match the true particle
+		{
+			caf::TrueParticleID truePartID;
+			truePartID.ixn = -1; //Should be the default for a new TrueParticleID but wanna make sure of it
+			truePartID.type = caf::TrueParticleID::kUnknown;
+			truePartID.part = -1;
+			sh.truth.push_back(std::move(truePartID));
+		  return;	
+		}
+
     Long_t neutrino_event_id = mc_traj_edepsim_eventid[max_trkid];
     std::size_t truthVecIdx = std::distance(sr.mc.nu.begin(),
                                                   std::find_if(sr.mc.nu.begin(),
@@ -430,7 +439,6 @@ namespace cafmaker
     sh.truth.push_back(std::move(truePartID));
 
     FillTrueParticle(srTruePart, max_trkid);
-
   }
 
   void MINERvARecoBranchFiller::FindTruthTrack(caf::StandardRecord &sr, caf::SRTrack &t, int track_id, const TruthMatcher *truthMatch) const
@@ -468,6 +476,16 @@ namespace cafmaker
     }
 
     //Once the true particle has been found, loop over the truthBranch to find the corresponding truth interraction
+    if (max_trkid >= n_mc_trajectories) // We want to access a trajectory that was not stored, set particle to kUnknown, will not be able to match the true particle
+    {
+      caf::TrueParticleID truePartID;
+      truePartID.ixn = -1; //Should be the default for a new TrueParticleID but wanna make sure of it
+      truePartID.type = caf::TrueParticleID::kUnknown;
+      truePartID.part = -1;
+      t.truth.push_back(std::move(truePartID));
+      return;
+    }
+
     Long_t neutrino_event_id = mc_traj_edepsim_eventid[max_trkid];
     caf::SRTrueInteraction & srTrueInt = truthMatch->GetTrueInteraction(sr, neutrino_event_id, true);
     //Find the position of the interaction corresponding to the track in the interaction vector


### PR DESCRIPTION
We store only `n_mc_trajectories` in the MINERvA dst file (10000 for now). In less than 1% spills, there are trajectories that go above that number. That lead to some CAFs making crashes for large number of CAFs.  Until we get a smarter way to store trajectories in the dst files, we just don't look for the true trajectory of that. specific track or shower and setting tthe type to kUnknown. 

linked are the error message we were getting for a specific file and the same run after the fix + the scan of that specific track that was creating an issue (with type == 0 now) 

![bug_runnumber](https://github.com/DUNE/ND_CAFMaker/assets/28730995/fba80f43-076c-4792-9000-4f6d0d2dd276)
![bug_runnumber_fixed](https://github.com/DUNE/ND_CAFMaker/assets/28730995/44d69bf3-7561-424a-88c1-d513c74fba44)
![bug_runnumber_type](https://github.com/DUNE/ND_CAFMaker/assets/28730995/2ec251da-f815-4c18-97cf-67ab09b643ef)
