### PR TITLE
Added updated TMS Reco CAF fillers

### DIFF
--- a/src/reco/TMSRecoBranchFiller.cxx
+++ b/src/reco/TMSRecoBranchFiller.cxx
@@ -37,7 +37,7 @@ namespace cafmaker
       TMSRecoTree->SetBranchAddress("nHits",                 _nHitsInTrack);
       TMSRecoTree->SetBranchAddress("Length",                _TrackLength);
       TMSRecoTree->SetBranchAddress("Charge",                _TrackCharge);
-      TMSRecoTree->SetBranchAddress("EnergyRange",                _TrackTotalEnergy);
+      TMSRecoTree->SetBranchAddress("EnergyRange",           _TrackTotalEnergy);
       TMSRecoTree->SetBranchAddress("EnergyDeposit",         _TrackEnergyDeposit);
       TMSRecoTree->SetBranchAddress("Occupancy",             _Occupancy);
 

--- a/src/reco/TMSRecoBranchFiller.cxx
+++ b/src/reco/TMSRecoBranchFiller.cxx
@@ -37,7 +37,7 @@ namespace cafmaker
       TMSRecoTree->SetBranchAddress("nHits",                 _nHitsInTrack);
       TMSRecoTree->SetBranchAddress("Length",                _TrackLength);
       TMSRecoTree->SetBranchAddress("Charge",                _TrackCharge);
-      TMSRecoTree->SetBranchAddress("Energy",                _TrackTotalEnergy);
+      TMSRecoTree->SetBranchAddress("EnergyRange",                _TrackTotalEnergy);
       TMSRecoTree->SetBranchAddress("EnergyDeposit",         _TrackEnergyDeposit);
       TMSRecoTree->SetBranchAddress("Occupancy",             _Occupancy);
 

--- a/src/reco/TMSRecoBranchFiller.h
+++ b/src/reco/TMSRecoBranchFiller.h
@@ -3,6 +3,8 @@
 /// \author  J. Wolcott <jwolcott@fnal.gov> & F. Akbar <fakbar@ur.rochester.edu>
 /// \date    Nov. 2021
 
+// Adapted from MINERvA version by Liam O'Sullivan <liam.osullivan@uni-mainz.de>
+
 #ifndef ND_CAFMAKER_TMSRECOBRANCHFILLER_H
 #define ND_CAFMAKER_TMSRECOBRANCHFILLER_H
 
@@ -18,7 +20,6 @@
 
 // The duneanaobj includes
 #include "duneanaobj/StandardRecord/StandardRecord.h"
-//#include "duneanaobj/StandardRecord/SRTrack.h"
 
 namespace cafmaker
 {
@@ -26,15 +27,10 @@ namespace cafmaker
   {
     public:
       TMSRecoBranchFiller(const std::string & tmsRecoFilename);
-      ~TMSRecoBranchFiller() {
-        delete TMSRecoTree;
-        fTMSRecoFile->Close();
-        delete fTMSRecoFile;
-        TMSRecoTree = NULL;
-        fTMSRecoFile = NULL;
-      }
 
       std::deque<Trigger> GetTriggers(int triggerType) const override;
+
+      ~TMSRecoBranchFiller();
 
     private:
       void _FillRecoBranches(const Trigger &trigger,
@@ -47,17 +43,34 @@ namespace cafmaker
 
       // Save the branches that we're reading in
       int _nLines;
-      // [10] should match TMS reco output
+      int _EventNo;
+      int _SliceNo;
+      int _SpillNo;
+
+      int _nTracks;
       int _nHitsInTrack[10];
       float _TrackLength[10];
-      float _TotalTrackEnergy[10];
+      float _TrackCharge[10];
+      float _TrackTotalEnergy[10];
+      float _TrackEnergyDeposit[10];
+      float _TrackStartPos[10][3];
+      float _TrackEndPos[10][3];
+      float _TrackDirection[10][3];
       float _Occupancy[10];
+
       float _DirectionX_Downstream[10];
       float _DirectionZ_Downstream[10];
       float _DirectionX_Upstream[10];
       float _DirectionZ_Upstream[10];
+
       // [10][200][2] needs to match TMS reco output (check file if in doubt)
       float _TrackHitPos[10][200][2];
+      float _TrackRecoHitPos[10][200][2];
+
+      bool is_data;
+      mutable std::vector<cafmaker::Trigger> fTriggers;
+      mutable decltype(fTriggers)::const_iterator  fLastTriggerReqd;    ///< the last trigger requested using _FillRecoBranches()
+
   };
 
 }


### PR DESCRIPTION
Full spill structure not yet accounted for, but it's also not fully ready on the TMS side either.
Includes relevant reco information included in StandardRecord 3 for TMS, no truth yet as I haven't had any GENIE files to work with; these should be available Soon™.

If you would like to test this I have some dune-tms reco output at `/exp/dune/data/users/losulliv/Jan2024_NERSC_MiniProd_Sample/tms-reco` in the RecoCandidates_Hough files, generated from the corresponding files in `../edep-sim` relative to previous.