### PR TITLE
MiniRun5 beta1 

### DIFF
--- a/src/reco/DLP_h5_classes.cxx
+++ b/src/reco/DLP_h5_classes.cxx
@@ -5,7 +5,7 @@
 //    
 //    The invocation that generated this file was:
 //
-//       ./h5_to_cpp.py -f /dune/data/users/jwolcott/nd/nd-lar-reco/reco-out/PicoRun4.1_1E17_RHC.larnd.00000.reco.summary.h5 -o ../src/reco/DLP_h5_classes -ns cafmaker::types::dlp -d events -cn Event -d interactions -cn Interaction -d particles -cn Particle -d truth_interactions -cn TrueInteraction -d truth_particles -cn TrueParticle -d run_info -cn RunInfo -d trigger -cn Trigger
+//       h5_to_cpp.py -f MiniRun5_1E19_RHC.mlreco_analysis.0001023.MLRECO_ANA.hdf5 -o DLP_h5_classes -ns cafmaker::types::dlp -d events -cn Event -d interactions -cn Interaction -d particles -cn Particle -d truth_interactions -cn TrueInteraction -d truth_particles -cn TrueParticle -d run_info -cn RunInfo -d trigger -cn Trigger
 //
 
 #include "DLP_h5_classes.h"
@@ -89,8 +89,8 @@ namespace cafmaker::types::dlp
     ctype.insertMember("trigger", HOFFSET(Event, trigger), H5::PredType::STD_REF_DSETREG);
     ctype.insertMember("run_info", HOFFSET(Event, run_info), H5::PredType::STD_REF_DSETREG);
     ctype.insertMember("interactions", HOFFSET(Event, interactions), H5::PredType::STD_REF_DSETREG);
-    ctype.insertMember("truth_particles", HOFFSET(Event, truth_particles), H5::PredType::STD_REF_DSETREG);
     ctype.insertMember("truth_interactions", HOFFSET(Event, truth_interactions), H5::PredType::STD_REF_DSETREG);
+    ctype.insertMember("truth_particles", HOFFSET(Event, truth_particles), H5::PredType::STD_REF_DSETREG);
     ctype.insertMember("particles", HOFFSET(Event, particles), H5::PredType::STD_REF_DSETREG);
   
     return ctype;
@@ -406,7 +406,7 @@ namespace cafmaker::types::dlp
     ctype.insertMember("nu_num_voxels", HOFFSET(TrueInteraction, nu_num_voxels), H5::PredType::STD_I64LE);
     ctype.insertMember("nu_p", HOFFSET(TrueInteraction, nu_p), H5::PredType::IEEE_F64LE);
     ctype.insertMember("nu_pdg_code", HOFFSET(TrueInteraction, nu_pdg_code), H5::PredType::STD_I64LE);
-    ctype.insertMember("nu_position", HOFFSET(TrueInteraction, nu_position_handle), H5::VarLenType(H5::PredType::IEEE_F32LE));
+    ctype.insertMember("nu_position", HOFFSET(TrueInteraction, nu_position_handle), H5::VarLenType(H5::PredType::IEEE_F64LE));
     ctype.insertMember("nu_quark", HOFFSET(TrueInteraction, nu_quark), H5::PredType::STD_I64LE);
     ctype.insertMember("nu_t", HOFFSET(TrueInteraction, nu_t), H5::PredType::IEEE_F64LE);
     ctype.insertMember("nu_target", HOFFSET(TrueInteraction, nu_target), H5::PredType::STD_I64LE);
@@ -497,6 +497,7 @@ namespace cafmaker::types::dlp
     ctype.insertMember("is_principal_match", HOFFSET(TrueParticle, is_principal_match), H5::PredType::STD_U8LE);
     ctype.insertMember("is_valid", HOFFSET(TrueParticle, is_valid), H5::PredType::STD_U8LE);
     ctype.insertMember("ke", HOFFSET(TrueParticle, ke), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("ke_init", HOFFSET(TrueParticle, ke_init), H5::PredType::IEEE_F64LE);
     ctype.insertMember("last_step", HOFFSET(TrueParticle, last_step_handle), H5::VarLenType(H5::PredType::IEEE_F32LE));
     ctype.insertMember("length", HOFFSET(TrueParticle, length), H5::PredType::IEEE_F64LE);
     ctype.insertMember("length_tng", HOFFSET(TrueParticle, length_tng), H5::PredType::IEEE_F64LE);
@@ -558,8 +559,10 @@ namespace cafmaker::types::dlp
     ctype.insertMember("track_id", HOFFSET(TrueParticle, track_id), H5::PredType::STD_I64LE);
     ctype.insertMember("truth_depositions_MeV_sum", HOFFSET(TrueParticle, truth_depositions_MeV_sum), H5::PredType::IEEE_F32LE);
     ctype.insertMember("truth_depositions_sum", HOFFSET(TrueParticle, truth_depositions_sum), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("truth_end_momentum", HOFFSET(TrueParticle, truth_end_momentum), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("truth_id", HOFFSET(TrueParticle, truth_id), H5::PredType::STD_I64LE);
     ctype.insertMember("truth_index", HOFFSET(TrueParticle, truth_index_handle), H5::VarLenType(H5::PredType::STD_I64LE));
+    ctype.insertMember("truth_interaction_id", HOFFSET(TrueParticle, truth_interaction_id), H5::PredType::STD_I64LE);
     ctype.insertMember("truth_momentum", HOFFSET(TrueParticle, truth_momentum), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("truth_size", HOFFSET(TrueParticle, truth_size), H5::PredType::STD_I64LE);
     ctype.insertMember("truth_start_dir", HOFFSET(TrueParticle, truth_start_dir), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));

--- a/src/reco/DLP_h5_classes.h
+++ b/src/reco/DLP_h5_classes.h
@@ -5,7 +5,7 @@
 //    
 //    The invocation that generated this file was:
 //
-//       ./h5_to_cpp.py -f /dune/data/users/jwolcott/nd/nd-lar-reco/reco-out/PicoRun4.1_1E17_RHC.larnd.00000.reco.summary.h5 -o ../src/reco/DLP_h5_classes -ns cafmaker::types::dlp -d events -cn Event -d interactions -cn Interaction -d particles -cn Particle -d truth_interactions -cn TrueInteraction -d truth_particles -cn TrueParticle -d run_info -cn RunInfo -d trigger -cn Trigger
+//       h5_to_cpp.py -f MiniRun5_1E19_RHC.mlreco_analysis.0001023.MLRECO_ANA.hdf5 -o DLP_h5_classes -ns cafmaker::types::dlp -d events -cn Event -d interactions -cn Interaction -d particles -cn Particle -d truth_interactions -cn TrueInteraction -d truth_particles -cn TrueParticle -d run_info -cn RunInfo -d trigger -cn Trigger
 //
 
 
@@ -205,8 +205,8 @@ namespace cafmaker::types::dlp
     hdset_reg_ref_t trigger;
     hdset_reg_ref_t run_info;
     hdset_reg_ref_t interactions;
-    hdset_reg_ref_t truth_particles;
     hdset_reg_ref_t truth_interactions;
+    hdset_reg_ref_t truth_particles;
     hdset_reg_ref_t particles;
     
     void SyncVectors();
@@ -217,8 +217,8 @@ namespace cafmaker::types::dlp
       if constexpr(std::is_same_v<T, Trigger>) return trigger;
       else if(std::is_same_v<T, RunInfo>) return run_info;
       else if(std::is_same_v<T, Interaction>) return interactions;
-      else if(std::is_same_v<T, TrueParticle>) return truth_particles;
       else if(std::is_same_v<T, TrueInteraction>) return truth_interactions;
+      else if(std::is_same_v<T, TrueParticle>) return truth_particles;
       else if(std::is_same_v<T, Particle>) return particles;
     }
     
@@ -370,7 +370,7 @@ namespace cafmaker::types::dlp
     int64_t nu_num_voxels;
     double nu_p;
     int64_t nu_pdg_code;
-    BufferView<float> nu_position;
+    BufferView<double> nu_position;
     int64_t nu_quark;
     double nu_t;
     int64_t nu_target;
@@ -449,6 +449,7 @@ namespace cafmaker::types::dlp
     bool is_principal_match;
     bool is_valid;
     double ke;
+    double ke_init;
     BufferView<float> last_step;
     double length;
     double length_tng;
@@ -485,8 +486,10 @@ namespace cafmaker::types::dlp
     int64_t track_id;
     float truth_depositions_MeV_sum;
     double truth_depositions_sum;
+    std::array<double, 3> truth_end_momentum;
     int64_t truth_id;
     BufferView<int64_t> truth_index;
+    int64_t truth_interaction_id;
     std::array<double, 3> truth_momentum;
     int64_t truth_size;
     std::array<double, 3> truth_start_dir;

--- a/src/reco/MINERvARecoBranchFiller.cxx
+++ b/src/reco/MINERvARecoBranchFiller.cxx
@@ -431,14 +431,22 @@ namespace cafmaker
     caf::SRTrueParticle & srTruePart = is_primary ? truthMatch->GetTrueParticle(sr, srTrueInt, edepsim_track_id, true, false)
                                                     : truthMatch->GetTrueParticle(sr, srTrueInt, edepsim_track_id, false, true);
 
-    caf::TrueParticleID truePartID;
-    truePartID.ixn = truthVecIdx;
+
+    caf::TrueParticleID truePartID;                                                                                                                                                              truePartID.ixn = truthVecIdx;
     truePartID.type = is_primary ? caf::TrueParticleID::kPrimary
                                  : caf::TrueParticleID::kSecondary;
-    truePartID.part = edepsim_track_id;
+
+    FillTrueParticle(srTruePart,max_trkid);
+
+
+    if (truePartID.type == caf::TrueParticleID::kPrimary) truePartID.part = edepsim_track_id;
+    else
+    {
+      truePartID.part = std::distance(srTrueInt.sec.begin(), std::find_if(srTrueInt.sec.begin(), srTrueInt.sec.end(), [edepsim_track_id](const caf::SRTrueParticle& part) { return part.G4ID
+== edepsim_track_id; })); // we just filled it so it should be fine
+    }
     sh.truth.push_back(std::move(truePartID));
 
-    FillTrueParticle(srTruePart, max_trkid);
   }
 
   void MINERvARecoBranchFiller::FindTruthTrack(caf::StandardRecord &sr, caf::SRTrack &t, int track_id, const TruthMatcher *truthMatch) const
@@ -511,11 +519,16 @@ namespace cafmaker
     truePartID.ixn = truthVecIdx;
     truePartID.type = is_primary ? caf::TrueParticleID::kPrimary
                                  : caf::TrueParticleID::kSecondary;
-    truePartID.part = edepsim_track_id;
+
+    FillTrueParticle(srTruePart,max_trkid);                                                                                                                                                  
+
+
+    if (truePartID.type == caf::TrueParticleID::kPrimary) truePartID.part = edepsim_track_id;
+    else
+    {
+      truePartID.part = std::distance(srTrueInt.sec.begin(), std::find_if(srTrueInt.sec.begin(), srTrueInt.sec.end(), [edepsim_track_id](const caf::SRTrueParticle& part) { return part.G4ID == edepsim_track_id; })); // we just filled it so it should be fine
+    }
     t.truth.push_back(std::move(truePartID));
-
-
-    FillTrueParticle(srTruePart,max_trkid);
 
   }
 


### PR DESCRIPTION
- Update the ML-Reco classes to match the most recent updates.
- Fix the way we're matching the MINERvA secondaries (the truth.part variable was not set properly for secondaries and we did not get the right secondary in analyses, see joint image). 
- The remaining fix to secondaries will be to get the same G4ID for ML-Reco and MINERvA and that should be comming in the next spin of production.

[fixed_secondaries_minerva.pdf](https://github.com/DUNE/ND_CAFMaker/files/14886881/fixed_secondaries_minerva.pdf)
