### PR TITLE
Bugfix: Issue 63 - Flat cafs trees not filled correctly

### DIFF
--- a/src/CAF.cxx
+++ b/src/CAF.cxx
@@ -13,6 +13,8 @@ CAF::CAF(const std::string &filename, const std::string &rw_fhicl_filename, bool
   : pot(std::numeric_limits<decltype(pot)>::signaling_NaN()),  rh(rw_fhicl_filename)
 {
   cafFile = new TFile( filename.c_str(), "RECREATE" );
+  gDirectory->cd("Rint:/");
+
   cafSR = new TTree("cafTree", "cafTree");
   cafSRGlobal = new TTree("globalTree", "globalTree");
   cafMVA = new TTree("mvaTree", "mvaTree");
@@ -103,8 +105,8 @@ void CAF::write()
     {
       if (!tree)
         continue;
-
-      tree->Write();
+      auto clone_tree = (TTree*)tree->Clone();  
+      clone_tree->Write();
 
       // don't let it get stuck attached to only this file in case we need it again below
       tree->LoadBaskets();

--- a/src/CAF.cxx
+++ b/src/CAF.cxx
@@ -13,7 +13,6 @@ CAF::CAF(const std::string &filename, const std::string &rw_fhicl_filename, bool
   : pot(std::numeric_limits<decltype(pot)>::signaling_NaN()),  rh(rw_fhicl_filename)
 {
   cafFile = new TFile( filename.c_str(), "RECREATE" );
-  gDirectory->cd("Rint:/");
 
   cafSR = new TTree("cafTree", "cafTree");
   cafSRGlobal = new TTree("globalTree", "globalTree");
@@ -97,6 +96,20 @@ void CAF::fillPOT()
 
 void CAF::write()
 {
+
+  if(flatCAFFile){
+    flatCAFFile->cd();
+
+    for (auto tree : {cafSRGlobal, cafMVA, cafPOT, genie })
+    {
+      if (!tree)
+        continue;
+      auto clone_tree = (TTree*)tree->Clone();
+      clone_tree->Write();
+    }
+    flatCAFFile->Close();
+  }
+
   if(cafFile){
     cafFile->cd();
     cafSR->Write();
@@ -105,9 +118,7 @@ void CAF::write()
     {
       if (!tree)
         continue;
-      auto clone_tree = (TTree*)tree->Clone();  
-      clone_tree->Write();
-
+      tree->Write();
       // don't let it get stuck attached to only this file in case we need it again below
       tree->LoadBaskets();
       tree->SetDirectory(nullptr);
@@ -115,18 +126,6 @@ void CAF::write()
     cafFile->Close();
   }
 
-  if(flatCAFFile){
-    flatCAFFile->cd();
-    flatCAFTree->Write();
-    cafSRGlobal->Write();
-    cafMVA->Write();
-    cafPOT->Write();
-
-    if (genie)
-      genie->Write();
-
-    flatCAFFile->Close();
-  }
 }
 
 

--- a/src/CAF.cxx
+++ b/src/CAF.cxx
@@ -99,6 +99,7 @@ void CAF::write()
 
   if(flatCAFFile){
     flatCAFFile->cd();
+    flatCAFTree->Write();
 
     for (auto tree : {cafSRGlobal, cafMVA, cafPOT, genie })
     {


### PR DESCRIPTION
As discussed [in this issue](https://github.com/DUNE/ND_CAFMaker/issues/62), it seems to be an issue with ROOT when we want to write the same tree with two opened files. I've added two minimal example scripts, one with the current way we fill the CAFs (test_bad.cpp) and one with the fix I propose in this PR.


After the fix we get for the FLAT CAF:

``` 
root [0]
Attaching file test_cafs3.flat.root as _file0...
(TFile *) 0x29dd0e0
root [1] meta->Scan()
************************************************************
*    Row   *   pot.pot *   run.run * subrun.su * version.v *
************************************************************
*        0 * 1.015e+16 *         1 *         0 *         5 *
************************************************************
``` 
And for the CAF:
```
Attaching file test_cafs3.root as _file0...
(TFile *) 0x3a43120
root [1] meta->Scan()
************************************************************
*    Row   *   pot.pot *   run.run * subrun.su * version.v *
************************************************************
*        0 * 1.015e+16 *         1 *         0 *         5 *
************************************************************
```

[test.txt](https://github.com/DUNE/ND_CAFMaker/files/15183423/test.txt)
[test_bad.txt](https://github.com/DUNE/ND_CAFMaker/files/15183424/test_bad.txt)
