### PR TITLE
Some minor MLreco changes for Minirun5 beta2 production

### DIFF
--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -228,9 +228,8 @@ namespace cafmaker
     };
 
     // todo: these need us to propagate nu info through Supera.  WIP
-//    ValidateOrCopy(ptTrueInt.nu_current_type, srTrueInt.iscc, false,
-//                   nuCurrComp, nuCurrSet);
-//    ValidateOrCopy(ptTrueInt.nu_energy_init, srTrueInt.E, NaN);
+    //ValidateOrCopy(ptTrueInt.nu_current_type, srTrueInt.iscc, false, nuCurrComp, nuCurrSet); //this is currently filled with -1 for iscc
+//    ValidateOrCopy(ptTrueInt.nu_energy_init/1000., srTrueInt.E, NaN); //this is currently filled with many -inf
 //    ValidateOrCopy(ptTrueInt.nu_interaction_mode, srTrueInt.mode, caf::ScatteringMode::kUnknownMode,
 //                   [](const NuInteractionMode & inCurr, const caf::ScatteringMode & outCurr)
 //                   {
@@ -304,17 +303,17 @@ namespace cafmaker
                    ancestorTypeComp, ancestorTypeAssgn, "SRTrueParticle::ancestor_id.type");
 
    // The parent track_id is filled with the unique track_id variable and the ancestor track_id is filled with the internal MLreco id variable. So we have to retrive the genid based on these
-    for (const auto & part : trueParticles)
+    /*for (const auto & part : trueParticles)
     {
-      if(part.track_id == truePartPassthrough.parent_track_id) ValidateOrCopy(part.gen_id, srTruePart.parent, -1, "SRTrueParticle::parent");
+      if(part.track_id == truePartPassthrough.parent_track_id){truePartPassthrough.gen_id < 1000000000 ?  ValidateOrCopy(part.gen_id, srTruePart.parent, -1, "SRTrueParticle::parent") : ValidateOrCopy(part.track_id, srTruePart.parent, -1, "SRTrueParticle::parent");
       if(part.id == truePartPassthrough.ancestor_track_id){
-     	 ValidateOrCopy(part.gen_id, srTruePart.ancestor_id.part, -1, "SRTrueParticle::ancestor_id.part");
+     	 truePartPassthrough.gen_id < 1000000000 ? ValidateOrCopy(part.gen_id, srTruePart.ancestor_id.part, -1, "SRTrueParticle::ancestor_id.part") : ValidateOrCopy(part.track_id, srTruePart.ancestor_id.part, -1, "SRTrueParticle::ancestor_id.part");
          ValidateOrCopy(part.truth_interaction_id, srTruePart.ancestor_id.ixn, -1, "SRTrueParticle::ancestor_id.ixn");
       }
     }
+*/
     // todo: need to figure out how to translate "1::91" etc. to the enums...
 //    ValidateOrCopy(truePartPassthrough.creation_process, srTruePart.start_process)
-
     ValidateOrCopy(truePartPassthrough.position[0], srTruePart.start_pos.x, NaN, "SRTrueParticle::start_pos.x");
     ValidateOrCopy(truePartPassthrough.position[1], srTruePart.start_pos.y, NaN, "SRTrueParticle::start_pos.y");
     ValidateOrCopy(truePartPassthrough.position[2], srTruePart.start_pos.z, NaN, "SRTrueParticle::start_pos.z");
@@ -530,8 +529,9 @@ namespace cafmaker
                                            std::find_if(sr.mc.nu.begin(),
                                                         sr.mc.nu.end(),
                                                         [&srTrueInt](const caf::SRTrueInteraction& ixn) {return ixn.id == srTrueInt.id;}));
+	  std::size_t truthPartIdx = std::distance(srTrueInt.prim.begin(), std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(), [&srTrueInt, &truePartPassThrough](const caf::SRTrueParticle& part) { return part.G4ID == truePartPassThrough.gen_id; }));
+          bool is_primary = truthPartIdx != srTrueInt.prim.size();
 
-          bool is_primary = truePartPassThrough.gen_id < 100000000;
           srPartCmp.trkid = is_primary
                             ? truePartPassThrough.gen_id
                             : truePartPassThrough.track_id;
@@ -642,8 +642,9 @@ namespace cafmaker
                                            std::find_if(sr.mc.nu.begin(),
                                                         sr.mc.nu.end(),
                                                         [&srTrueInt](const caf::SRTrueInteraction& ixn) {return ixn.id == srTrueInt.id;}));
+	  std::size_t truthPartIdx = std::distance(srTrueInt.prim.begin(), std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(), [&srTrueInt, &truePartPassThrough](const caf::SRTrueParticle& part) { return part.G4ID == truePartPassThrough.gen_id; }));
+          bool is_primary = truthPartIdx != srTrueInt.prim.size();
 
-          bool is_primary = truePartPassThrough.gen_id < 100000000;
           srPartCmp.trkid = is_primary
                             ? truePartPassThrough.gen_id
                             : truePartPassThrough.track_id;
@@ -746,7 +747,8 @@ namespace cafmaker
                                                         sr.mc.nu.end(),
                                                         [&srTrueInt](const caf::SRTrueInteraction& ixn) {return ixn.id == srTrueInt.id;}));
 
-          bool is_primary = truePartPassThrough.gen_id < 100000000;
+	  std::size_t truthPartIdx = std::distance(srTrueInt.prim.begin(), std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(), [&srTrueInt, &truePartPassThrough](const caf::SRTrueParticle& part) { return part.G4ID == truePartPassThrough.gen_id; }));
+          bool is_primary = truthPartIdx != srTrueInt.prim.size();
           srPartCmp.trkid = is_primary
                             ? truePartPassThrough.gen_id
                             : truePartPassThrough.track_id;

--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -282,10 +282,7 @@ namespace cafmaker
                    -1,
                    "SRTrueParticle::track_id");
 
-    // note: cafmaker::types::dlp::TrueParticle::interaction_id refers to the id in the MLReco stack.
-    //        it does NOT give the GENIE interaction ID, which is what SRTrueParticle wants
-    //ValidateOrCopy(truePartPassthrough.truth_interaction_id, srTruePart.interaction_id, -1, "SRTrueParticle::interaction_id");
-//    ValidateOrCopy(truePartPassthrough.ancestor_track_id, srTruePart.ancestor_id.ixn, -1, "SRTrueParticle::ancestor_id.ixn");
+    ValidateOrCopy(truePartPassthrough.truth_interaction_id, srTruePart.interaction_id, -1L, "SRTrueParticle::interaction_id");
 
     const auto ancestorTypeComp = [](const char* inProc, const caf::TrueParticleID::PartType & outType)
     {
@@ -310,7 +307,10 @@ namespace cafmaker
     for (const auto & part : trueParticles)
     {
       if(part.track_id == truePartPassthrough.parent_track_id) ValidateOrCopy(part.gen_id, srTruePart.parent, -1, "SRTrueParticle::parent");
-      if(part.id == truePartPassthrough.ancestor_track_id) ValidateOrCopy(part.gen_id, srTruePart.ancestor_id.part, -1, "SRTrueParticle::ancestor_id.part");
+      if(part.id == truePartPassthrough.ancestor_track_id){
+     	 ValidateOrCopy(part.gen_id, srTruePart.ancestor_id.part, -1, "SRTrueParticle::ancestor_id.part");
+         ValidateOrCopy(part.truth_interaction_id, srTruePart.ancestor_id.ixn, -1, "SRTrueParticle::ancestor_id.ixn");
+      }
     }
     // todo: need to figure out how to translate "1::91" etc. to the enums...
 //    ValidateOrCopy(truePartPassthrough.creation_process, srTruePart.start_process)

--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -325,9 +325,9 @@ namespace cafmaker
     // we will rely on TruthMatcher to set all the primary particle momenta.
     // todo: what about secondary particles?
     //       MINERvA passes them through correctly but that won't catch all secondaries
-//    ValidateOrCopy(truePartPassthrough.momentum[0]/1000., srTruePart.p.px, NaN, "SRTrueParticle::p.px");
-//    ValidateOrCopy(truePartPassthrough.momentum[1]/1000., srTruePart.p.py, NaN, "SRTrueParticle::p.py");
-//    ValidateOrCopy(truePartPassthrough.momentum[2]/1000., srTruePart.p.pz, NaN, "SRTrueParticle::p.pz");
+    ValidateOrCopy(truePartPassthrough.truth_momentum[0]/1000., srTruePart.p.px, NaN, "SRTrueParticle::p.px");
+    ValidateOrCopy(truePartPassthrough.truth_momentum[1]/1000., srTruePart.p.py, NaN, "SRTrueParticle::p.py");
+    ValidateOrCopy(truePartPassthrough.truth_momentum[2]/1000., srTruePart.p.pz, NaN, "SRTrueParticle::p.pz");
 
     try
     {

--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -211,9 +211,9 @@ namespace cafmaker
 
     // vertices from ML-reco are adjusted to the edge of the sensitive detector volume
     // if they originate from outside it, so we can't use them
-//    ValidateOrCopy(ptTrueInt.vertex[0], srTrueInt.vtx.x, NaN, "SRTrueInteraction::vtx::x");
-//    ValidateOrCopy(ptTrueInt.vertex[1], srTrueInt.vtx.y, NaN, "SRTrueInteraction::vtx::y");
-  //  ValidateOrCopy(ptTrueInt.vertex[2], srTrueInt.vtx.z, NaN, "SRTrueInteraction::vtx::z");
+    //ValidateOrCopy(ptTrueInt.truth_vertex[0], srTrueInt.vtx.x, NaN, "SRTrueInteraction::vtx::x");
+    //ValidateOrCopy(ptTrueInt.truth_vertex[1], srTrueInt.vtx.y, NaN, "SRTrueInteraction::vtx::y");
+    //ValidateOrCopy(ptTrueInt.truth_vertex[2], srTrueInt.vtx.z, NaN, "SRTrueInteraction::vtx::z");
 
     const std::function<bool(const NuCurrentType &, const bool &)> nuCurrComp =
     [](const NuCurrentType & inCurr, const bool & outCurr)
@@ -275,11 +275,7 @@ namespace cafmaker
   {
     const auto NaN = std::numeric_limits<float>::signaling_NaN();
     ValidateOrCopy(truePartPassthrough.pdg_code, srTruePart.pdg, 0, "pdg_code");
-   // fixme once is_primary field is propagated correctly 
-    ValidateOrCopy(truePartPassthrough.gen_id < 1000000000 ? truePartPassthrough.gen_id : truePartPassthrough.track_id,
-                   srTruePart.G4ID,
-                   -1,
-                   "SRTrueParticle::track_id");
+    ValidateOrCopy(truePartPassthrough.gen_id, srTruePart.G4ID, -1,"SRTrueParticle::track_id");
 
     ValidateOrCopy(truePartPassthrough.truth_interaction_id, srTruePart.interaction_id, -1L, "SRTrueParticle::interaction_id");
 
@@ -303,15 +299,15 @@ namespace cafmaker
                    ancestorTypeComp, ancestorTypeAssgn, "SRTrueParticle::ancestor_id.type");
 
    // The parent track_id is filled with the unique track_id variable and the ancestor track_id is filled with the internal MLreco id variable. So we have to retrive the genid based on these
-    /*for (const auto & part : trueParticles)
+    for (const auto & part : trueParticles)
     {
-      if(part.track_id == truePartPassthrough.parent_track_id){truePartPassthrough.gen_id < 1000000000 ?  ValidateOrCopy(part.gen_id, srTruePart.parent, -1, "SRTrueParticle::parent") : ValidateOrCopy(part.track_id, srTruePart.parent, -1, "SRTrueParticle::parent");
+      if(part.track_id == truePartPassthrough.parent_track_id) 
+	ValidateOrCopy(part.gen_id, srTruePart.parent, -1, "SRTrueParticle::parent");
       if(part.id == truePartPassthrough.ancestor_track_id){
-     	 truePartPassthrough.gen_id < 1000000000 ? ValidateOrCopy(part.gen_id, srTruePart.ancestor_id.part, -1, "SRTrueParticle::ancestor_id.part") : ValidateOrCopy(part.track_id, srTruePart.ancestor_id.part, -1, "SRTrueParticle::ancestor_id.part");
-         ValidateOrCopy(part.truth_interaction_id, srTruePart.ancestor_id.ixn, -1, "SRTrueParticle::ancestor_id.ixn");
+     	ValidateOrCopy(part.gen_id, srTruePart.ancestor_id.part, -1, "SRTrueParticle::ancestor_id.part");
+        ValidateOrCopy(part.truth_interaction_id, srTruePart.ancestor_id.ixn, -1, "SRTrueParticle::ancestor_id.ixn");
       }
     }
-*/
     // todo: need to figure out how to translate "1::91" etc. to the enums...
 //    ValidateOrCopy(truePartPassthrough.creation_process, srTruePart.start_process)
     ValidateOrCopy(truePartPassthrough.position[0], srTruePart.start_pos.x, NaN, "SRTrueParticle::start_pos.x");

--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -313,13 +313,13 @@ namespace cafmaker
     // todo: need to figure out how to translate "1::91" etc. to the enums...
 //    ValidateOrCopy(truePartPassthrough.creation_process, srTruePart.start_process)
 
-    ValidateOrCopy(truePartPassthrough.start_point[0], srTruePart.start_pos.x, NaN, "SRTrueParticle::start_pos.x");
-    ValidateOrCopy(truePartPassthrough.start_point[1], srTruePart.start_pos.y, NaN, "SRTrueParticle::start_pos.y");
-    ValidateOrCopy(truePartPassthrough.start_point[2], srTruePart.start_pos.z, NaN, "SRTrueParticle::start_pos.z");
+    ValidateOrCopy(truePartPassthrough.position[0], srTruePart.start_pos.x, NaN, "SRTrueParticle::start_pos.x");
+    ValidateOrCopy(truePartPassthrough.position[1], srTruePart.start_pos.y, NaN, "SRTrueParticle::start_pos.y");
+    ValidateOrCopy(truePartPassthrough.position[2], srTruePart.start_pos.z, NaN, "SRTrueParticle::start_pos.z");
 
-    ValidateOrCopy(truePartPassthrough.end_point[0], srTruePart.end_pos.x, NaN, "SRTrueParticle::end_pos.x");
-    ValidateOrCopy(truePartPassthrough.end_point[1], srTruePart.end_pos.y, NaN, "SRTrueParticle::end_pos.y");
-    ValidateOrCopy(truePartPassthrough.end_point[2], srTruePart.end_pos.z, NaN, "SRTrueParticle::end_pos.z");
+    ValidateOrCopy(truePartPassthrough.end_position[0], srTruePart.end_pos.x, NaN, "SRTrueParticle::end_pos.x");
+    ValidateOrCopy(truePartPassthrough.end_position[1], srTruePart.end_pos.y, NaN, "SRTrueParticle::end_pos.y");
+    ValidateOrCopy(truePartPassthrough.end_position[2], srTruePart.end_pos.z, NaN, "SRTrueParticle::end_pos.z");
 
     // sadly GENIE's px, py, pz are in a different coordinate system, so they won't match.
     // we will rely on TruthMatcher to set all the primary particle momenta.

--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -525,7 +525,7 @@ namespace cafmaker
                                            std::find_if(sr.mc.nu.begin(),
                                                         sr.mc.nu.end(),
                                                         [&srTrueInt](const caf::SRTrueInteraction& ixn) {return ixn.id == srTrueInt.id;}));
-    bool is_primary = std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(), 
+          bool is_primary = std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(), 
                                    [&srTrueInt, &truePartPassThrough](const caf::SRTrueParticle& part) { return part.G4ID == truePartPassThrough.gen_id; }) == srTrueInt.prim.end();
 
           srPartCmp.trkid = is_primary
@@ -638,7 +638,7 @@ namespace cafmaker
                                            std::find_if(sr.mc.nu.begin(),
                                                         sr.mc.nu.end(),
                                                         [&srTrueInt](const caf::SRTrueInteraction& ixn) {return ixn.id == srTrueInt.id;}));
-    bool is_primary = std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(), 
+    	  bool is_primary = std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(), 
                                    [&srTrueInt, &truePartPassThrough](const caf::SRTrueParticle& part) { return part.G4ID == truePartPassThrough.gen_id; }) == srTrueInt.prim.end();
 
           srPartCmp.trkid = is_primary
@@ -743,8 +743,8 @@ namespace cafmaker
                                                         sr.mc.nu.end(),
                                                         [&srTrueInt](const caf::SRTrueInteraction& ixn) {return ixn.id == srTrueInt.id;}));
 
-	  std::size_t truthPartIdx = std::distance(srTrueInt.prim.begin(), std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(), [&srTrueInt, &truePartPassThrough](const caf::SRTrueParticle& part) { return part.G4ID == truePartPassThrough.gen_id; }));
-          bool is_primary = truthPartIdx != srTrueInt.prim.size();
+    	  bool is_primary = std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(), 
+                                   [&srTrueInt, &truePartPassThrough](const caf::SRTrueParticle& part) { return part.G4ID == truePartPassThrough.gen_id; }) == srTrueInt.prim.end();
           srPartCmp.trkid = is_primary
                             ? truePartPassThrough.gen_id
                             : truePartPassThrough.track_id;

--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -638,8 +638,8 @@ namespace cafmaker
                                            std::find_if(sr.mc.nu.begin(),
                                                         sr.mc.nu.end(),
                                                         [&srTrueInt](const caf::SRTrueInteraction& ixn) {return ixn.id == srTrueInt.id;}));
-	  std::size_t truthPartIdx = std::distance(srTrueInt.prim.begin(), std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(), [&srTrueInt, &truePartPassThrough](const caf::SRTrueParticle& part) { return part.G4ID == truePartPassThrough.gen_id; }));
-          bool is_primary = truthPartIdx != srTrueInt.prim.size();
+    bool is_primary = std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(), 
+                                   [&srTrueInt, &truePartPassThrough](const caf::SRTrueParticle& part) { return part.G4ID == truePartPassThrough.gen_id; }) == srTrueInt.prim.end();
 
           srPartCmp.trkid = is_primary
                             ? truePartPassThrough.gen_id

--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -525,8 +525,8 @@ namespace cafmaker
                                            std::find_if(sr.mc.nu.begin(),
                                                         sr.mc.nu.end(),
                                                         [&srTrueInt](const caf::SRTrueInteraction& ixn) {return ixn.id == srTrueInt.id;}));
-	  std::size_t truthPartIdx = std::distance(srTrueInt.prim.begin(), std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(), [&srTrueInt, &truePartPassThrough](const caf::SRTrueParticle& part) { return part.G4ID == truePartPassThrough.gen_id; }));
-          bool is_primary = truthPartIdx != srTrueInt.prim.size();
+    bool is_primary = std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(), 
+                                   [&srTrueInt, &truePartPassThrough](const caf::SRTrueParticle& part) { return part.G4ID == truePartPassThrough.gen_id; }) == srTrueInt.prim.end();
 
           srPartCmp.trkid = is_primary
                             ? truePartPassThrough.gen_id

--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -525,9 +525,9 @@ namespace cafmaker
                                            std::find_if(sr.mc.nu.begin(),
                                                         sr.mc.nu.end(),
                                                         [&srTrueInt](const caf::SRTrueInteraction& ixn) {return ixn.id == srTrueInt.id;}));
-          bool is_primary = std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(), 
-                                   [&srTrueInt, &truePartPassThrough](const caf::SRTrueParticle& part) { return part.G4ID == truePartPassThrough.gen_id; }) == srTrueInt.prim.end();
 
+          bool is_primary = std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(), 
+                                   [&srTrueInt, &truePartPassThrough](const caf::SRTrueParticle& part) { return part.G4ID == truePartPassThrough.gen_id; }) != srTrueInt.prim.end();
           srPartCmp.trkid = is_primary
                             ? truePartPassThrough.gen_id
                             : truePartPassThrough.track_id;
@@ -638,8 +638,10 @@ namespace cafmaker
                                            std::find_if(sr.mc.nu.begin(),
                                                         sr.mc.nu.end(),
                                                         [&srTrueInt](const caf::SRTrueInteraction& ixn) {return ixn.id == srTrueInt.id;}));
-    	  bool is_primary = std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(), 
-                                   [&srTrueInt, &truePartPassThrough](const caf::SRTrueParticle& part) { return part.G4ID == truePartPassThrough.gen_id; }) == srTrueInt.prim.end();
+    	  
+           
+          bool is_primary = std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(), 
+                                   [&srTrueInt, &truePartPassThrough](const caf::SRTrueParticle& part) { return part.G4ID == truePartPassThrough.gen_id; }) != srTrueInt.prim.end();
 
           srPartCmp.trkid = is_primary
                             ? truePartPassThrough.gen_id
@@ -744,7 +746,7 @@ namespace cafmaker
                                                         [&srTrueInt](const caf::SRTrueInteraction& ixn) {return ixn.id == srTrueInt.id;}));
 
     	  bool is_primary = std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(), 
-                                   [&srTrueInt, &truePartPassThrough](const caf::SRTrueParticle& part) { return part.G4ID == truePartPassThrough.gen_id; }) == srTrueInt.prim.end();
+                                   [&srTrueInt, &truePartPassThrough](const caf::SRTrueParticle& part) { return part.G4ID == truePartPassThrough.gen_id; }) != srTrueInt.prim.end();
           srPartCmp.trkid = is_primary
                             ? truePartPassThrough.gen_id
                             : truePartPassThrough.track_id;

--- a/src/reco/MLNDLArRecoBranchFiller.h
+++ b/src/reco/MLNDLArRecoBranchFiller.h
@@ -64,7 +64,8 @@ namespace cafmaker
                          caf::StandardRecord &sr) const;
 
       void FillTrueParticle(caf::SRTrueParticle & srTruePart,
-                            const cafmaker::types::dlp::TrueParticle & truePartPassthrough) const;
+                            const cafmaker::types::dlp::TrueParticle & truePartPassthrough,
+                            const H5DataView<cafmaker::types::dlp::TrueParticle> &trueParticles) const;
 
       void FillTrueInteraction(caf::SRTrueInteraction & srTrueInt,
                                const cafmaker::types::dlp::TrueInteraction & trueIntPassthrough) const;

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -112,6 +112,14 @@ namespace cafmaker
     const auto assgn = [](const double & a, float & b) {  b = a; };
     return ValidateOrCopy<double, float>(input, target, unsetVal, cmp, assgn, fieldName);
   }
+  template <>
+  void ValidateOrCopy<int, long int>(const int & input, long int & target, const long int & unsetVal, const std::string & fieldName)
+  {
+    const auto cmp = [](const int & a, const long int &b) -> bool { return a == b; };
+
+    const auto assgn = [](const int & a, long int & b) {  b = static_cast<long int>(a); };
+    return ValidateOrCopy<int, long int>(input, target, unsetVal, cmp, assgn, fieldName);
+  }  
 
 
 // ------------------------------------------------------------

--- a/src/truth/FillTruth.h
+++ b/src/truth/FillTruth.h
@@ -116,6 +116,10 @@ namespace cafmaker
   // and which have roundoff problems in the comparison operator otherwise
   template <>
   void ValidateOrCopy<double, float>(const double & input, float & target, const float & unsetVal, const std::string& fieldName);
+  
+  //same for long int and int (true interaction id)
+  template <>
+  void ValidateOrCopy<int, long int>(const int & input, long int & target, const long int & unsetVal, const std::string & fieldName);
 
   // --------------------------------------------------------------
 


### PR DESCRIPTION
1. MC truth start/end positions are now saved with position variables instead of start/end points ([issue #64](https://github.com/DUNE/ND_CAFMaker/issues/64)) 
2. True momentum is saved in MLreco files, so have added that to ValidateorCopy
3. Propagate the correct true `interaction_id` for true particles and ancestors
4. Propagate `genid ` for secondaries and determine if a particle is true primary in truth matching by looking for `genid` in the primary particle collection ([issue #66](https://github.com/DUNE/ND_CAFMaker/issues/66)) 
5. Parents and ancestors need to have their `genid `propagated instead of `trackid` for matching ([issue #67](https://github.com/DUNE/ND_CAFMaker/issues/67)). MLreco assigns the unique `trackid` as `parent_trackid` and `id` (unique within an event) as the `ancestor_trackid`. So this is done by looping over the particles to retrieve the `genid ` by matching the other two variables. 