### PR TITLE
Add PandoraLArRecoNDBranchFiller

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,23 +6,7 @@ FORCE=no
 if [[ $# == 1 && x$1 == x-f ]]; then FORCE=yes; fi
 
 # set up software
-source /cvmfs/dune.opensciencegrid.org/products/dune/setup_dune.sh
-setup cmake v3_22_2
-setup gcc v9_3_0
-setup pycurl
-setup ifdhc
-setup geant4 v4_11_0_p01c -q e20:debug
-setup dk2nugenie   v01_10_01k -q debug:e20
-setup genie_xsec   v3_04_00 -q AR2320i00000:e1000:k250
-setup genie_phyopt v3_04_00 -q dkcharmtau
-setup jobsub_client
-setup eigen v3_3_5
-setup duneanaobj v03_01_00 -q e20:prof
-setup hdf5 v1_12_0b -q e20:prof
-
-# edep-sim needs to know where a certain GEANT .cmake file is...
-G4_cmake_file=`find ${GEANT4_FQ_DIR}/lib -name 'Geant4Config.cmake'`
-export Geant4_DIR=`dirname $G4_cmake_file`
+source ndcaf_setup.sh
 
 # Just use the edep-sim UPS product, don't clone master branch off repos!
 # Get edep-sim and build it
@@ -74,6 +58,6 @@ cd ${TOPDIR}
 export PYTHONPATH=${PYTHONPATH}:${TOPDIR}/DUNE_ND_GeoEff/lib/
 
 # make tarballs of edep-sim and nusystematics for grid jobs
-tar -zcf edep-sim.tar.gz edep-sim
+#tar -zcf edep-sim.tar.gz edep-sim
 #tar -zcf nusystematics.tar.gz nusystematics
 tar -zcf DUNE_ND_GeoEff.tar.gz DUNE_ND_GeoEff

--- a/cfg/pandora.fcl
+++ b/cfg/pandora.fcl
@@ -1,0 +1,7 @@
+#include "NDCAFMaker.fcl"
+nd_cafmaker: @local::standard_nd_cafmaker
+nd_cafmaker.CAFMakerSettings.GHEPFiles: ["/exp/dune/data/users/jback/ND_CAFs/MiniRun5/MiniRun5_1E19_RHC.genie.nu.0000001.GHEP.root"]
+nd_cafmaker.CAFMakerSettings.PandoraLArRecoNDFile: "/exp/dune/data/users/jback/ND_CAFs/MiniRun5/LArRecoND_MR5_0000001.root"
+nd_cafmaker.CAFMakerSettings.OutputFile: "CAF_MR5_0000001.root"
+nd_cafmaker.CAFMakerSettings.Verbosity: VERBOSE
+nd_cafmaker.CAFMakerSettings.NumEvts: -1

--- a/ndcaf_setup.sh
+++ b/ndcaf_setup.sh
@@ -12,10 +12,11 @@ setup eigen v3_3_5
 setup duneanaobj v03_05_00 -q debug:e26
 setup hdf5 v1_10_5a -q e20
 setup fhiclcpp v4_18_04 -q debug:e26
-
+setup root v6_28_12 -q e26:p3915:prof
+setup genie v3_04_02 -q e26:prof
 
 # edep-sim needs to know where a certain GEANT .cmake file is...
-G4_cmake_file=`find ${GEANT4_FQ_DIR}/lib -name 'Geant4Config.cmake'`
+G4_cmake_file=`find ${GEANT4_FQ_DIR}/lib64 -name 'Geant4Config.cmake'`
 export Geant4_DIR=`dirname $G4_cmake_file`
 
 # edep-sim needs to have the GEANT bin directory in the path

--- a/src/Params.h
+++ b/src/Params.h
@@ -43,6 +43,7 @@ namespace cafmaker
     fhicl::OptionalAtom<std::string> tmsRecoFile  { fhicl::Name{"TMSRecoFile"}, fhicl::Comment("Input TMS reco .root file") };
     fhicl::OptionalAtom<std::string> sandRecoFile  { fhicl::Name{"SANDRecoFile"}, fhicl::Comment("Input SAND reco .root file") };
     fhicl::OptionalAtom<std::string> minervaRecoFile  { fhicl::Name{"MINERVARecoFile"}, fhicl::Comment("Input MINERVA reco .root file") };
+    fhicl::OptionalAtom<std::string> pandoraLArRecoNDFile  { fhicl::Name{"PandoraLArRecoNDFile"}, fhicl::Comment("Input Pandora LArRecoND .root file") };
 
     // this is optional by way of the default value. Will result in an extra output file if enabled
     fhicl::Atom<bool> makeFlatCAF { fhicl::Name{"MakeFlatCAF"}, fhicl::Comment("Make 'flat' CAF in addition to structured CAF?"), true };

--- a/src/makeCAF.C
+++ b/src/makeCAF.C
@@ -26,6 +26,7 @@
 #include "reco/NDLArTMSMatchRecoFiller.h"
 #include "reco/SANDRecoBranchFiller.h"
 #include "reco/MINERvARecoBranchFiller.h"
+#include "reco/PandoraLArRecoNDBranchFiller.h"
 #include "truth/FillTruth.h"
 #include "util/GENIEQuiet.h"
 #include "util/Logger.h"
@@ -133,6 +134,13 @@ std::vector<std::unique_ptr<cafmaker::IRecoBranchFiller>> getRecoFillers(const c
   {
     recoFillers.emplace_back(std::make_unique<cafmaker::SANDRecoBranchFiller>(sandFile));
     std::cout << "   SAND\n";
+  }
+  // Pandora LArRecoND
+  std::string pandoraFile;
+  if (par().cafmaker().pandoraLArRecoNDFile(pandoraFile))
+  {
+    recoFillers.emplace_back(std::make_unique<cafmaker::PandoraLArRecoNDBranchFiller>(pandoraFile));
+    std::cout << "  Pandora LArRecoND\n";
   }
 
   // next: did we do TMS reco?

--- a/src/reco/PandoraLArRecoNDBranchFiller.cxx
+++ b/src/reco/PandoraLArRecoNDBranchFiller.cxx
@@ -47,7 +47,6 @@ namespace cafmaker
 	  m_LArRecoNDTree->SetBranchAddress("dirZ", &m_dirZVect);
 	  m_LArRecoNDTree->SetBranchAddress("energy", &m_energyVect);
 	  m_LArRecoNDTree->SetBranchAddress("n3DHits", &m_n3DHitsVect);
-	  m_LArRecoNDTree->SetBranchAddress("length1", &m_length1Vect);
 	  m_LArRecoNDTree->SetBranchAddress("mcNuId", &m_mcNuIdVect);
 	  m_LArRecoNDTree->SetBranchAddress("isPrimary", &m_isPrimaryVect);
 	  m_LArRecoNDTree->SetBranchAddress("mcId", &m_mcIdVect);
@@ -118,7 +117,7 @@ namespace cafmaker
 	const float startZ = (m_startZVect != nullptr) ? (*m_startZVect)[i] : 0.0;
 	track.start = caf::SRVector3D(startX, startY, startZ);
 
-	// End position (length along principal direction or last hit location)
+	// End position
 	const float endX = (m_endXVect != nullptr) ? (*m_endXVect)[i] : 0.0;
 	const float endY = (m_endYVect != nullptr) ? (*m_endYVect)[i] : 0.0;
 	const float endZ = (m_endZVect != nullptr) ? (*m_endZVect)[i] : 0.0;
@@ -140,12 +139,14 @@ namespace cafmaker
 	const int n3DHits = (m_n3DHitsVect != nullptr) ? (*m_n3DHitsVect)[i] : 0;
 	track.qual = n3DHits*1.0;
 
-	// Cluster length along principal axis direction (cm)
-	const float length1 = (m_length1Vect != nullptr) ? (*m_length1Vect)[i] : 0.0;
-	track.len_cm = length1;
+	// Cluster length from start and end points
+	const float dX = endX - startX;
+	const float dY = endY - startY;
+	const float dZ = endZ - startZ;
+	track.len_cm = sqrt(dX*dX + dY*dY + dZ*dZ);
 
 	// Cluster length multiplied by LAr density (g/cm2)
-	track.len_gcm2 = length1*m_LArRho;
+	track.len_gcm2 = track.len_cm*m_LArRho;
 
 	// Use truth matching info from Pandora's LArContent hierarchy tools.
 	// For LArRecoND MC SpacePoints, we offset the MCId's to make them all unique:

--- a/src/reco/PandoraLArRecoNDBranchFiller.cxx
+++ b/src/reco/PandoraLArRecoNDBranchFiller.cxx
@@ -1,0 +1,306 @@
+#include "PandoraLArRecoNDBranchFiller.h"
+
+namespace cafmaker
+{
+
+  PandoraLArRecoNDBranchFiller::~PandoraLArRecoNDBranchFiller()
+  {
+      if (m_LArRecoNDFile && m_LArRecoNDFile->IsOpen())
+      {
+	  delete m_LArRecoNDTree; m_LArRecoNDTree = nullptr;
+      }
+      delete m_LArRecoNDFile; m_LArRecoNDFile = nullptr;      
+  }
+
+  PandoraLArRecoNDBranchFiller::PandoraLArRecoNDBranchFiller(const std::string &pandoraLArRecoNDFilename)
+  : IRecoBranchFiller("PandoraLArRecoND"),
+    m_Triggers(),
+    m_LastTriggerReqd(m_Triggers.end())
+  {
+      // Open Pandora LArRecoND hierarchy analysis ROOT file
+      m_LArRecoNDFile = TFile::Open(pandoraLArRecoNDFilename.c_str(), "read");
+      if (m_LArRecoNDFile && m_LArRecoNDFile->IsOpen()) {
+
+	  LOG.VERBOSE() << " Using PandoraLArRecoND file " << pandoraLArRecoNDFilename << "\n";
+	  
+	  // Input tree
+	  m_LArRecoNDTree = dynamic_cast<TTree*>(m_LArRecoNDFile->Get("LArRecoND"));
+	  if (!m_LArRecoNDTree) {
+	      LOG.FATAL() << "Did not find LArRecoND tree in input file " << pandoraLArRecoNDFilename << "\n";
+	      throw;
+	  }
+
+	  // Set branch addresses
+	  m_LArRecoNDTree->SetBranchAddress("event", &m_eventId);
+	  m_LArRecoNDTree->SetBranchAddress("run", &m_run);
+	  m_LArRecoNDTree->SetBranchAddress("subRun", &m_subRun);
+	  m_LArRecoNDTree->SetBranchAddress("startTime", &m_startTime);
+	  m_LArRecoNDTree->SetBranchAddress("sliceId", &m_sliceIdVect);
+	  m_LArRecoNDTree->SetBranchAddress("startX", &m_startXVect);
+	  m_LArRecoNDTree->SetBranchAddress("startY", &m_startYVect);
+	  m_LArRecoNDTree->SetBranchAddress("startZ", &m_startZVect);
+	  m_LArRecoNDTree->SetBranchAddress("endX", &m_endXVect);
+	  m_LArRecoNDTree->SetBranchAddress("endY", &m_endYVect);
+	  m_LArRecoNDTree->SetBranchAddress("endZ", &m_endZVect);
+	  m_LArRecoNDTree->SetBranchAddress("dirX", &m_dirXVect);
+	  m_LArRecoNDTree->SetBranchAddress("dirY", &m_dirYVect);
+	  m_LArRecoNDTree->SetBranchAddress("dirZ", &m_dirZVect);
+	  m_LArRecoNDTree->SetBranchAddress("energy", &m_energyVect);
+	  m_LArRecoNDTree->SetBranchAddress("n3DHits", &m_n3DHitsVect);
+	  m_LArRecoNDTree->SetBranchAddress("length1", &m_length1Vect);
+	  m_LArRecoNDTree->SetBranchAddress("mcNuId", &m_mcNuIdVect);
+	  m_LArRecoNDTree->SetBranchAddress("isPrimary", &m_isPrimaryVect);
+	  m_LArRecoNDTree->SetBranchAddress("mcId", &m_mcIdVect);
+	  m_LArRecoNDTree->SetBranchAddress("completeness", &m_completenessVect);
+	  
+	  // We have setup the input tree
+	  SetConfigured(true);
+      }
+  }
+
+  // Copy all of the Pandora LArRecoND info to the PandoraLArRecoND branch of the StandardRecord object
+  void PandoraLArRecoNDBranchFiller::_FillRecoBranches(const Trigger &trigger,
+						       caf::StandardRecord &sr,
+						       const cafmaker::Params &par,
+						       const TruthMatcher *truthMatch) const
+  {
+    // Figure out where in our list of triggers this event index is.
+    // We should always be looking forwards, since we expect to be traversing in that direction
+    auto it_start = (m_LastTriggerReqd == m_Triggers.end()) ? m_Triggers.cbegin() : m_LastTriggerReqd;
+    auto itTrig = std::find(it_start, m_Triggers.cend(), trigger);
+    if (itTrig == m_Triggers.end())
+    {
+      LOG.FATAL() << " Reco branch filler '" << GetName() << "' could not find trigger with evtID == "
+		  << trigger.evtID << "!  Abort.\n";
+      abort();
+    }
+    std::size_t idx = std::distance(m_Triggers.cbegin(), itTrig);
+
+    LOG.VERBOSE() << " Reco branch filler '" << GetName() << "', trigger.evtID == " << trigger.evtID
+		  << ", internal evt idx = " << idx << ".\n";
+
+    // Get the event entry
+    m_LArRecoNDTree->GetEntry(idx);
+
+    // Set the event and run numbers
+    sr.meta.nd_lar.enabled = true;
+    sr.meta.nd_lar.event = m_eventId;
+    sr.meta.nd_lar.run = m_run;
+    sr.meta.nd_lar.subrun = m_subRun;
+
+    // Set the size for the Pandora NDLAr standard record for this trigger/event
+    const int nClusters = (m_sliceIdVect != nullptr) ? m_sliceIdVect->size() : 0;
+    sr.nd.lar.pandora.resize(nClusters);
+    sr.nd.lar.npandora = sr.nd.lar.pandora.size();
+
+    // Fill track and shower info. Both use the same clusters (PFOs), and no
+    // distinction is made (yet) to identify which are tracks or showers
+    FillTracks(sr, nClusters);
+    FillShowers(sr, nClusters);
+  }
+
+  // ------------------------------------------------------------------------------
+    void PandoraLArRecoNDBranchFiller::FillTracks(caf::StandardRecord& sr, const int nClusters) const
+  {
+    // Create tracks for each PFO (cluster) in the event
+    LOG.VERBOSE() << " Pandora LArRecoND FillTracks using " << nClusters <<" PFO clusters\n";
+    
+    for (int i = 0; i < nClusters; i++)
+    {
+	// Slice id of the PFO cluster
+	const int sliceId = (*m_sliceIdVect)[i];
+
+	// Create standard record track
+	caf::SRTrack track;
+	// Starting position (vertex or first hit location)
+	const float startX = (m_startXVect != nullptr) ? (*m_startXVect)[i] : 0.0;
+	const float startY = (m_startYVect != nullptr) ? (*m_startYVect)[i] : 0.0;
+	const float startZ = (m_startZVect != nullptr) ? (*m_startZVect)[i] : 0.0;
+	track.start = caf::SRVector3D(startX, startY, startZ);
+
+	// End position (length along principal direction or last hit location)
+	const float endX = (m_endXVect != nullptr) ? (*m_endXVect)[i] : 0.0;
+	const float endY = (m_endYVect != nullptr) ? (*m_endYVect)[i] : 0.0;
+	const float endZ = (m_endZVect != nullptr) ? (*m_endZVect)[i] : 0.0;
+	track.end = caf::SRVector3D(endX, endY, endZ);
+
+	// Principal axis direction
+	const float dirX = (m_dirXVect != nullptr) ? (*m_dirXVect)[i] : 0.0;
+	const float dirY = (m_dirYVect != nullptr) ? (*m_dirYVect)[i] : 0.0;
+	const float dirZ = (m_dirZVect != nullptr) ? (*m_dirZVect)[i] : 0.0;
+	track.dir = caf::SRVector3D(dirX, dirY, dirZ);
+	track.enddir = caf::SRVector3D(dirX, dirY, dirZ);
+
+	// Energy (GeV)
+	const float energy = (m_energyVect != nullptr) ? (*m_energyVect)[i] : 0.0;
+	track.Evis = energy;
+	track.E = energy;
+
+	// Total number of 3D hits in the cluster
+	const int n3DHits = (m_n3DHitsVect != nullptr) ? (*m_n3DHitsVect)[i] : 0;
+	track.qual = n3DHits*1.0;
+
+	// Cluster length along principal axis direction (cm)
+	const float length1 = (m_length1Vect != nullptr) ? (*m_length1Vect)[i] : 0.0;
+	track.len_cm = length1;
+
+	// Cluster length multiplied by LAr density (g/cm2)
+	track.len_gcm2 = length1*m_LArRho;
+
+	// Use truth matching info from Pandora's LArContent hierarchy tools.
+	// For LArRecoND MC SpacePoints, we offset the MCId's to make them all unique:
+	// nuId = orig_nuId + 10^8, so orig_nuId = nuId - 10^8
+	// mcId = orig_mcId + nuIndex*10^6, where nuIndex = 0 to N-1 neutrinos
+	// nuIndex = int(mcId/10^6), so orig_mcId = mcId - nuIndex*10^6
+	// Use the original MCId values
+	const int mcNuId = (m_mcNuIdVect != nullptr) ? (*m_mcNuIdVect)[i] : 0;
+	const int origMCNuId = (mcNuId > m_nuIdOffset) ? mcNuId - m_nuIdOffset : mcNuId;
+	const int isPrimary = (m_isPrimaryVect != nullptr) ? (*m_isPrimaryVect)[i] : -1;
+	const int mcId = (m_mcIdVect != nullptr) ? (*m_mcIdVect)[i] : 0;
+	const int nuIndex = int(mcId/m_maxMCId);
+	const int origMCId = mcId - nuIndex*m_maxMCId;
+	
+	caf::TrueParticleID trueID;
+	trueID.ixn = origMCNuId;
+	if (isPrimary == 1) {
+	    trueID.type = caf::TrueParticleID::kPrimary;
+	} else if (isPrimary == -1) {
+	    trueID.type = caf::TrueParticleID::kUnknown;
+	} else {
+	    trueID.type = caf::TrueParticleID::kSecondary;
+	}
+	trueID.part = origMCId;
+
+	// Just store the best MC match
+	std::vector<caf::TrueParticleID> trueIDVect;
+	trueIDVect.emplace_back(trueID);
+	track.truth = trueIDVect;
+
+	// Fraction of true MC hits that are captured by the reconstructed cluster
+	const float completeness = (m_completenessVect != nullptr) ? (*m_completenessVect)[i] : 0.0;
+	std::vector<float> truthOverlap;
+	truthOverlap.emplace_back(completeness);
+	track.truthOverlap = truthOverlap;
+	
+	// Add track to the record
+	sr.nd.lar.pandora[sliceId].tracks.emplace_back(std::move(track));
+	sr.nd.lar.pandora[sliceId].ntracks++;
+    }
+  }
+    
+  // ------------------------------------------------------------------------------
+    void PandoraLArRecoNDBranchFiller::FillShowers(caf::StandardRecord& sr, const int nClusters) const
+  {
+    // Create showers for each PFO (cluster) in the event
+    LOG.VERBOSE() << " Pandora LArRecoND FillShowers using " << nClusters <<" PFO clusters\n";
+
+    for (int i = 0; i < nClusters; i++)
+    {
+	// Slice id of the PFO cluster
+	const int sliceId = (*m_sliceIdVect)[i];
+
+	// Create standard record shower
+	caf::SRShower shower;
+	// Starting position
+	const float startX = (m_startXVect != nullptr) ? (*m_startXVect)[i] : 0.0;
+	const float startY = (m_startYVect != nullptr) ? (*m_startYVect)[i] : 0.0;
+	const float startZ = (m_startZVect != nullptr) ? (*m_startZVect)[i] : 0.0;
+	shower.start = caf::SRVector3D(startX, startY, startZ);
+
+	// Principal axis direction
+	const float dirX = (m_dirXVect != nullptr) ? (*m_dirXVect)[i] : 0.0;
+	const float dirY = (m_dirYVect != nullptr) ? (*m_dirYVect)[i] : 0.0;
+	const float dirZ = (m_dirZVect != nullptr) ? (*m_dirZVect)[i] : 0.0;
+	shower.direction = caf::SRVector3D(dirX, dirY, dirZ);
+
+	// Energy (GeV)
+	const float energy = (m_energyVect != nullptr) ? (*m_energyVect)[i] : 0.0;
+	shower.Evis = energy;
+
+	// Use truth matching info from Pandora's LArContent hierarchy tools.
+	// For LArRecoND MC SpacePoints, we offset the MCId's to make them all unique:
+	// nuId = orig_nuId + 10^8, so orig_nuId = nuId - 10^8
+	// mcId = orig_mcId + nuIndex*10^6, where nuIndex = 0 to N-1 neutrinos
+	// nuIndex = int(mcId/10^6), so orig_mcId = mcId - nuIndex*10^6
+	// Use the original MCId values
+	const int mcNuId = (m_mcNuIdVect != nullptr) ? (*m_mcNuIdVect)[i] : 0;
+	const int origMCNuId = (mcNuId > m_nuIdOffset) ? mcNuId - m_nuIdOffset : mcNuId;
+	const int isPrimary = (m_isPrimaryVect != nullptr) ? (*m_isPrimaryVect)[i] : -1;
+	const int mcId = (m_mcIdVect != nullptr) ? (*m_mcIdVect)[i] : 0;
+	const int nuIndex = int(mcId/m_maxMCId);
+	const int origMCId = mcId - nuIndex*m_maxMCId;
+
+	caf::TrueParticleID trueID;
+	trueID.ixn = origMCNuId;
+	if (isPrimary == 1) {
+	    trueID.type = caf::TrueParticleID::kPrimary;
+	} else if (isPrimary == -1) {
+	    trueID.type = caf::TrueParticleID::kUnknown;
+	} else {
+	    trueID.type = caf::TrueParticleID::kSecondary;
+	}
+	trueID.part = origMCId;
+
+	// Just store the best MC match
+	std::vector<caf::TrueParticleID> trueIDVect;
+	trueIDVect.emplace_back(trueID);
+	shower.truth = trueIDVect;
+
+	// Fraction of true MC hits that are captured by the reconstructed cluster
+	const float completeness = (m_completenessVect != nullptr) ? (*m_completenessVect)[i] : 0.0;
+	std::vector<float> truthOverlap;
+	truthOverlap.emplace_back(completeness);
+	shower.truthOverlap = truthOverlap;
+
+	// Add shower to the record
+	sr.nd.lar.pandora[sliceId].showers.emplace_back(std::move(shower));
+	sr.nd.lar.pandora[sliceId].nshowers++;
+    }
+  }
+
+  // ------------------------------------------------------------------------------
+  std::deque<Trigger> PandoraLArRecoNDBranchFiller::GetTriggers(int triggerType) const
+  {
+    if (m_Triggers.empty())
+    {
+	const int nEvents = m_LArRecoNDTree->GetEntries();
+	LOG.DEBUG() << "Loading triggers with type " << triggerType << " within branch filler '" << GetName()
+		    << "' from " << nEvents << " Pandora LArRecoND tree entries:\n";
+	
+	m_Triggers.reserve(nEvents);
+	for (int entry = 0; entry < nEvents; entry++)
+	{
+	    m_LArRecoNDTree->GetEntry(entry);
+	    
+	    m_Triggers.emplace_back();
+	    Trigger &trig = m_Triggers.back();
+	    // Event number
+	    trig.evtID = m_eventId;
+	    // Pandora SpacePoint (SP) H5Flow-to-ROOT format doesn't store trigger type, so just select "all"
+	    trig.triggerType = -1;
+	    // Pandora SP format uses timestamp ticks from /charge/events/ts_start
+	    trig.triggerTime_s = m_startTime;
+	    // Use the same (integer) time for now
+	    trig.triggerTime_ns = m_startTime;
+
+	    LOG.VERBOSE() << "  added trigger: evtID = " << trig.evtID
+			  << ", triggerType = " << trig.triggerType
+			  << ", triggerTime_s = " << trig.triggerTime_s
+			  << ", triggerTime_ns = " << trig.triggerTime_ns
+			  << "\n";
+	}
+	// Since we just modified the list, any iterators have been invalidated
+	m_LastTriggerReqd = m_Triggers.end();
+    }
+
+    std::deque<Trigger> triggers;
+    for (const Trigger &trigger : m_Triggers)
+    {
+      if (triggerType < 0 || triggerType == m_Triggers.back().triggerType)
+	triggers.push_back(trigger);
+    }
+    
+    return triggers;
+  }
+
+} // end namespace

--- a/src/reco/PandoraLArRecoNDBranchFiller.h
+++ b/src/reco/PandoraLArRecoNDBranchFiller.h
@@ -1,0 +1,79 @@
+/// Fill Pandora LArRecoND branches
+///
+/// \author  John Back <J.J.Back@warwick.ac.uk>
+/// \date    Aug 2024
+
+#ifndef ND_CAFMAKER_PandoraLArRecoNDBranchFiller_H
+#define ND_CAFMAKER_PandoraLArRecoNDBranchFiller_H
+
+#include <iostream>
+#include <vector>
+#include <algorithm>
+
+// The virtual base class
+#include "reco/IRecoBranchFiller.h"
+#include "truth/FillTruth.h"
+
+// ROOT headers
+#include "TFile.h"
+#include "TTree.h"
+
+// duneanaobj
+#include "duneanaobj/StandardRecord/StandardRecord.h"
+
+namespace cafmaker
+{
+  class PandoraLArRecoNDBranchFiller : public cafmaker::IRecoBranchFiller
+  {
+    public:
+      PandoraLArRecoNDBranchFiller(const std::string & pandoraLArRecoNDFilename);
+
+      std::deque<Trigger> GetTriggers(int triggerType) const  override;
+
+      ~PandoraLArRecoNDBranchFiller();
+
+    private:
+      void _FillRecoBranches(const Trigger &trigger,
+			     caf::StandardRecord &sr,
+			     const cafmaker::Params &par,
+			     const TruthMatcher *truthMatch= nullptr) const override;
+
+      void FillTracks(caf::StandardRecord &sr, const int nClusters) const;
+      void FillShowers(caf::StandardRecord &sr, const int nClusters) const;
+      
+      TFile *m_LArRecoNDFile;
+      TTree *m_LArRecoNDTree;
+
+      int m_eventId;
+      int m_run;
+      int m_subRun;
+      int m_startTime;
+      std::vector<int> *m_sliceIdVect = nullptr;
+      std::vector<float> *m_startXVect = nullptr;
+      std::vector<float> *m_startYVect = nullptr;
+      std::vector<float> *m_startZVect = nullptr;
+      std::vector<float> *m_endXVect = nullptr;
+      std::vector<float> *m_endYVect = nullptr;
+      std::vector<float> *m_endZVect = nullptr;
+      std::vector<float> *m_dirXVect = nullptr;
+      std::vector<float> *m_dirYVect = nullptr;
+      std::vector<float> *m_dirZVect = nullptr;
+      std::vector<float> *m_energyVect = nullptr;
+      std::vector<int> *m_n3DHitsVect = nullptr;
+      std::vector<float> *m_length1Vect = nullptr;
+      std::vector<int> *m_mcNuIdVect = nullptr;
+      std::vector<int> *m_isPrimaryVect = nullptr;
+      std::vector<int> *m_mcIdVect = nullptr;
+      std::vector<float> *m_completenessVect = nullptr;
+
+      float m_LArRho{1.3973f}; // LAr density (g/cm3)
+
+      int m_nuIdOffset{100000000};
+      int m_maxMCId{1000000};
+
+      mutable std::vector<cafmaker::Trigger> m_Triggers;
+      mutable decltype(m_Triggers)::const_iterator  m_LastTriggerReqd; ///< the last trigger requested using _FillRecoBranches
+  };
+
+}
+#endif //ND_CAFMAKER_PandoraLArRecoNDBranchFiller_H

--- a/src/reco/PandoraLArRecoNDBranchFiller.h
+++ b/src/reco/PandoraLArRecoNDBranchFiller.h
@@ -60,7 +60,6 @@ namespace cafmaker
       std::vector<float> *m_dirZVect = nullptr;
       std::vector<float> *m_energyVect = nullptr;
       std::vector<int> *m_n3DHitsVect = nullptr;
-      std::vector<float> *m_length1Vect = nullptr;
       std::vector<int> *m_mcNuIdVect = nullptr;
       std::vector<int> *m_isPrimaryVect = nullptr;
       std::vector<int> *m_mcIdVect = nullptr;


### PR DESCRIPTION
Created the `PandoraLArRecoNDBranchFiller` class to store the reconstruction information from Pandora's [LArRecoND]( https://github.com/PandoraPFA/LArRecoND/tree/master) package (used for the DUNE ND). It requires a ROOT file created by the [HierarchyAnalysisAlgorithm](https://github.com/PandoraPFA/LArRecoND/blob/master/src/HierarchyAnalysisAlgorithm.cc#L141), which uses Pandora's [Hierarchy Tools](https://github.com/PandoraPFA/Documentation/blob/master/Hierarchy_Tools/Hierarchy_Tools_Overview.pdf).

The filled reco branches are `rec.nd.lar.pandora.tracks` and `.rec.nd.lar.pandora.showers`. No distinction is made (yet) between tracks and showers, and so the same 3D-cluster Particle Flow Objects (PFOs) are used for both. Here is the list of reco variables used:

1. Start position = cluster vertex point or the first hit position if no vertex is available
2. End position = cluster end position
3. Energy = [charge Q](https://github.com/DUNE/2x2_sim/wiki/File-data-definitions#chargecalib_prompt_hits)
4. Length = primary principal axis length
5. Quality = number of 3D hits.

Any changes needed here can be done mostly in the LArRecoND package, since the CAF just retrieves the output stored by Pandora's hierarchy algorithm.

The MC truth matching uses Pandora's Hierarchy Tools and not [TruthMatcher](https://github.com/DUNE/ND_CAFMaker/blob/main/src/truth/FillTruth.h#L126). Pandora requires **all MC particles to have a unique ID** (even if they originate from different neutrinos), and so the following offsets are applied to the original (ndlar-flow) MC Ids:

1. nuId = orig_nuId + 10^8
2. mcId = orig_mcId + nuIndex * 10^6

where nuIndex = 0 to N-1 for an event with N neutrinos, and the orig_mcId number range restarts from zero for each neutrino. This ensures all IDs are unique, for up to 100 neutrino interactions per event, each containing up to 10^6 hits.

These ID offsets are reversed when the Pandora CAF truth information is filled using the best reco-MC match achieved with Hierarchy Tools, and so the mcId's should then have values consistent with the equivalent input ndlar-flow files. The filled truth information corresponds to:

1. `truth.ixn` = orig_nuId
2. `truth.part` = orig_mcId (best match)
3. `truth.type` = primary, secondary or other
4. `truthOverlap` = completeness (best match)

H5 input files are first converted to ROOT using [h5_to_root_ndlarflow.py](https://github.com/PandoraPFA/LArRecoND/blob/master/ndlarflow/h5_to_root_ndlarflow.py)  before they are used by LArRecoND & Pandora, which in turn creates the hierarchy analysis output file that can be used to make the equivalent CAFs.

For the trigger, the event run numbers are propagated using those originally from the input ndar_flow ROOT files. Also, the start time is currently set using the [ts_start](https://github.com/DUNE/2x2_sim/wiki/File-data-definitions#chargeevents) variable, but this needs to be updated (in LArRecoND) to use the correct time and units.

Also updated `ndcaf_setup.sh` and `build.sh` to use a consistent environment.
