### PR TITLE
POT info to sandbox 2x2 data

### DIFF
--- a/src/Params.h
+++ b/src/Params.h
@@ -44,7 +44,7 @@ namespace cafmaker
     fhicl::OptionalAtom<std::string> sandRecoFile  { fhicl::Name{"SANDRecoFile"}, fhicl::Comment("Input SAND reco .root file") };
     fhicl::OptionalAtom<std::string> minervaRecoFile  { fhicl::Name{"MINERVARecoFile"}, fhicl::Comment("Input MINERVA reco .root file") };
 
-    // temporary hack for data
+    // fixme: temporary hack for data.  should be removed when interface to IFDB is complete
     fhicl::OptionalAtom<std::string> POTFile { fhicl::Name{"POTFile"}, fhicl::Comment("Input txt file with beam spill information") };
     
     // this is optional by way of the default value. Will result in an extra output file if enabled

--- a/src/Params.h
+++ b/src/Params.h
@@ -44,6 +44,9 @@ namespace cafmaker
     fhicl::OptionalAtom<std::string> sandRecoFile  { fhicl::Name{"SANDRecoFile"}, fhicl::Comment("Input SAND reco .root file") };
     fhicl::OptionalAtom<std::string> minervaRecoFile  { fhicl::Name{"MINERVARecoFile"}, fhicl::Comment("Input MINERVA reco .root file") };
 
+    // temporary hack for data
+    fhicl::OptionalAtom<std::string> POTFile { fhicl::Name{"POTFile"}, fhicl::Comment("Input txt file with beam spill information") };
+    
     // this is optional by way of the default value. Will result in an extra output file if enabled
     fhicl::Atom<bool> makeFlatCAF { fhicl::Name{"MakeFlatCAF"}, fhicl::Comment("Make 'flat' CAF in addition to structured CAF?"), true };
 
@@ -55,6 +58,9 @@ namespace cafmaker
     // 100 us is default
     fhicl::Atom<unsigned int>  trigMatchDT { fhicl::Name("TriggerMatchDeltaT"), fhicl::Comment("Maximum time difference, in ns, between triggers to be considered a match"), 100000 };
 
+    // 0.1 s is default
+    fhicl::Atom<float>  beamMatchDT { fhicl::Name("BeamMatchDeltaT"), fhicl::Comment("Maximum time difference, in s, between triggers and beam"), 0.1 };
+    
     // options are VERBOSE, DEBUG, INFO, WARNING, ERROR, FATAL
     fhicl::Atom<std::string> verbosity { fhicl::Name("Verbosity"), fhicl::Comment("Verbosity level of output"), "WARNING" };
   };

--- a/src/makeCAF.C
+++ b/src/makeCAF.C
@@ -452,7 +452,7 @@ void loop(CAF &caf,
       caf.pot = 0;
     caf.pot += pot;
     caf.sr.beam.pulsepot = pot;
-    caf.sr.beam.ismc = true; //should be handled in a smarter way for data and MC
+    caf.sr.beam.ismc = par().cafmaker().POTFile.hasValue();  // fixme: when we have proper IFDB interface, should use the same mechanism as however we decide when to use that
 
     caf.fill();
   }

--- a/src/makeCAF.C
+++ b/src/makeCAF.C
@@ -175,7 +175,7 @@ std::vector<std::unique_ptr<cafmaker::IRecoBranchFiller>> getRecoFillers(const c
 // -------------------------------------------------
 bool doTriggersMatch(const cafmaker::Trigger& t1, const cafmaker::Trigger& t2, unsigned int dT)
 {
-  return (abs(int(t1.triggerTime_s - t2.triggerTime_s)+int(t1.triggerTime_ns - t2.triggerTime_ns)/1.e9) < dT/1.e9);
+  return ( (std::max(t1.triggerTime_s, t2.triggerTime_s) - std::min(t1.triggerTime_s, t2.triggerTime_s)) * 10000000 + std::max(t1.triggerTime_ns, t2.triggerTime_ns) - std::min(t1.triggerTime_ns, t2.triggerTime_ns) ) < dT;
 }
 
 struct triggerTimeCmp

--- a/src/makeCAF.C
+++ b/src/makeCAF.C
@@ -370,15 +370,15 @@ double getPOT(const cafmaker::Params& par, const std::vector<double>& trigger_ti
         });
       });
 
-  if (it != beam_spills.end()) {
+    if (it != beam_spills.end()) {
       pot = it->second;
-  }
-  else {
+    }
+    else {
       auto LOG = [&]() -> const cafmaker::Logger & { return cafmaker::LOG_S("Beam spill matching"); };
       LOG().WARNING() << "No matching spill found for trigger " << ii << " with trigger times: ";
       std::for_each(trigger_times.begin(), trigger_times.end(), [](double tt) { std::cout << std::fixed <<  tt << " "; });
       std::cout << "\n";
-  }
+    }
  }
  else {
    pot = par().runInfo().POTPerSpill() * 1e13;


### PR DESCRIPTION
1. In the long term we want to get pot info from IFbeam database directly. Right now I added an option to read spills from a text file, compare it to the trigger times and fill pot for matched times. 
2. This works with a beam match dT of 0.9s which is too long. This is due to an issue with the trigger times in 2x2 files where every fifth spill has ~0.8s difference. Eventually we want to have this as ~0.1-0.2 s and test it again for time-fixed 2x2 files, but shouldn't change the main logic of the code. There should also be no abs() in the beam matching equation since trigger times are always later than beam times. I added that because on average 2x2 trigger times are 0.2 s earlier due to some bug unrelated to the first bug. 