### PR TITLE
Feature/meta triggertime

### DIFF
--- a/src/reco/MINERvARecoBranchFiller.cxx
+++ b/src/reco/MINERvARecoBranchFiller.cxx
@@ -225,7 +225,8 @@ namespace cafmaker
     sr.meta.minerva.run = ev_run;
     sr.meta.minerva.subrun = ev_sub_run;
     sr.meta.minerva.event = ev_gate;
-
+    sr.meta.minerva.readoutstart_s = trigger.triggerTime_s;
+    sr.meta.minerva.readoutstart_ns = trigger.triggerTime_ns;
 
     FillInteractions(truthMatch, sr);
 

--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -168,6 +168,9 @@ namespace cafmaker
       sr.meta.nd_lar.subrun = runinf.subrun;
       sr.meta.nd_lar.event = runinf.event;
     }
+    
+    sr.meta.nd_lar.readoutstart_s = trigger.triggerTime_s;
+    sr.meta.nd_lar.readoutstart_ns = trigger.triggerTime_ns;
 
     H5DataView<cafmaker::types::dlp::Interaction> interactions = fDSReader.GetProducts<cafmaker::types::dlp::Interaction>(idx);
     H5DataView<cafmaker::types::dlp::TrueInteraction> trueInteractions = fDSReader.GetProducts<cafmaker::types::dlp::TrueInteraction>(idx);

--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -161,16 +161,16 @@ namespace cafmaker
 
     //Fill ND-LAr specific info in the meta branch
     H5DataView<cafmaker::types::dlp::RunInfo> run_info = fDSReader.GetProducts<cafmaker::types::dlp::RunInfo>(idx);
-    sr.meta.lar_2x2.enabled = true;
+    sr.meta.lar2x2.enabled = true;
     for (const auto & runinf : run_info)
     {
-      sr.meta.lar_2x2.run = runinf.run;
-      sr.meta.lar_2x2.subrun = runinf.subrun;
-      sr.meta.lar_2x2.event = runinf.event;
+      sr.meta.lar2x2.run = runinf.run;
+      sr.meta.lar2x2.subrun = runinf.subrun;
+      sr.meta.lar2x2.event = runinf.event;
     }
     
-    sr.meta.lar_2x2.readoutstart_s = trigger.triggerTime_s;
-    sr.meta.lar_2x2.readoutstart_ns = trigger.triggerTime_ns;
+    sr.meta.lar2x2.readoutstart_s = trigger.triggerTime_s;
+    sr.meta.lar2x2.readoutstart_ns = trigger.triggerTime_ns;
 
     H5DataView<cafmaker::types::dlp::Interaction> interactions = fDSReader.GetProducts<cafmaker::types::dlp::Interaction>(idx);
     H5DataView<cafmaker::types::dlp::TrueInteraction> trueInteractions = fDSReader.GetProducts<cafmaker::types::dlp::TrueInteraction>(idx);

--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -161,16 +161,16 @@ namespace cafmaker
 
     //Fill ND-LAr specific info in the meta branch
     H5DataView<cafmaker::types::dlp::RunInfo> run_info = fDSReader.GetProducts<cafmaker::types::dlp::RunInfo>(idx);
-    sr.meta.nd_lar.enabled = true;
+    sr.meta.lar_2x2.enabled = true;
     for (const auto & runinf : run_info)
     {
-      sr.meta.nd_lar.run = runinf.run;
-      sr.meta.nd_lar.subrun = runinf.subrun;
-      sr.meta.nd_lar.event = runinf.event;
+      sr.meta.lar_2x2.run = runinf.run;
+      sr.meta.lar_2x2.subrun = runinf.subrun;
+      sr.meta.lar_2x2.event = runinf.event;
     }
     
-    sr.meta.nd_lar.readoutstart_s = trigger.triggerTime_s;
-    sr.meta.nd_lar.readoutstart_ns = trigger.triggerTime_ns;
+    sr.meta.lar_2x2.readoutstart_s = trigger.triggerTime_s;
+    sr.meta.lar_2x2.readoutstart_ns = trigger.triggerTime_ns;
 
     H5DataView<cafmaker::types::dlp::Interaction> interactions = fDSReader.GetProducts<cafmaker::types::dlp::Interaction>(idx);
     H5DataView<cafmaker::types::dlp::TrueInteraction> trueInteractions = fDSReader.GetProducts<cafmaker::types::dlp::TrueInteraction>(idx);


### PR DESCRIPTION
Fix for issue #75 will be useful for trigger match time studies at the CAFs level instead of dealing with both input files. 

Also changed the `MLNDLArRecoBranchFiller` to fill the `lar2x2` meta instead of `nd_lar`. It shouldn't be a problem as we don't expect both to interact but for consistency.

```
root [2] cafTree->Scan("rec.meta.minerva.readoutstart_s:rec.meta.minerva.readoutstart_ns:rec.meta.lar2x2.readoutstart_s:rec.meta.lar2x2.readoutstart_ns")
************************************************************
*    Row   * rec.meta. * rec.meta. * rec.meta. * rec.meta. *
************************************************************
*        0 * 1.720e+09 *  71391000 * 1.720e+09 * 886240482 *
*        1 * 1.720e+09 * 271809000 * 1.720e+09 *  86658954 *
*        2 * 1.720e+09 * 472282000 * 1.720e+09 * 287058830 *
*        3 * 1.720e+09 * 672659000 * 1.720e+09 * 487496376 *
*        4 * 1.720e+09 * 873068000 * 1.720e+09 * 687904119 *
*        5 * 1.720e+09 *  73524000 * 1.720e+09 * 888346672 *
*        6 * 1.720e+09 * 273912000 * 1.720e+09 *  88768243 *
*        7 * 1.720e+09 * 474377000 * 1.720e+09 * 289200305 *
*        8 * 1.720e+09 * 674816000 * 1.720e+09 * 489635467 *
*        9 * 1.720e+09 * 875263000 * 1.720e+09 * 690085887 *
*       10 * 1.720e+09 *  75766000 * 1.720e+09 * 890568494 *
*       11 * 1.720e+09 * 276252000 * 1.720e+09 *  91058015 *
*       12 * 1.720e+09 * 476757000 * 1.720e+09 * 291585206 *
*       13 * 1.720e+09 * 677388000 * 1.720e+09 * 492123365 *
*       14 * 1.720e+09 * 877917000 * 1.720e+09 * 692680835 *
*       15 * 1.720e+09 *  78367000 * 1.720e+09 * 893225193 *
*       16 * 1.720e+09 * 279038000 * 1.720e+09 *  93797206 *
*       17 * 1.720e+09 * 479601000 * 1.720e+09 * 294336318 *
*       18 * 1.720e+09 * 680114000 * 1.720e+09 * 494879961 *
*       19 * 1.720e+09 * 880667000 * 1.720e+09 * 695413112 *
*       20 * 1.720e+09 *  81130000 * 1.720e+09 * 895948171 *
*       21 * 1.720e+09 * 281640000 * 1.720e+09 *  96487283 *
*       22 * 1.720e+09 * 482227000 * 1.720e+09 * 297013759 *
*       23 * 1.720e+09 * 682781000 * 1.720e+09 * 497566461 *
*       24 * 1.720e+09 * 883303000 * 1.720e+09 * 698140859 *

```