### PR TITLE
Update SPINE format for MiniRun 6.2

### DIFF
--- a/src/reco/DLP_h5_classes.cxx
+++ b/src/reco/DLP_h5_classes.cxx
@@ -5,7 +5,7 @@
 //
 //    The invocation that generated this file was:
 //
-//       h5_to_cpp.py -f MiniRun5_1E19_RHC.flow.0000000.flash.larcv_spine.h5 -o DLP_h5_classes -ns cafmaker::types::dlp -d events -cn Event -d reco_interactions -cn Interaction -d reco_particles -cn Particle -d truth_interactions -cn TrueInteraction -d truth_particles -cn TrueParticle -d flashes -cn Flash -d run_info -cn RunInfo -d trigger -cn Trigger
+//       h5_to_cpp.py -f MiniRun6.1_1E19_RHC.flow.0000001.LARCV_spine.h5 -o DLP_h5_classes -ns cafmaker::types::dlp -d events -cn Event -d reco_interactions -cn Interaction -d reco_particles -cn Particle -d truth_interactions -cn TrueInteraction -d truth_particles -cn TrueParticle -d flashes -cn Flash -d run_info -cn RunInfo -d trigger -cn Trigger
 //
 
 #include "DLP_h5_classes.h"
@@ -28,6 +28,9 @@ namespace cafmaker::types::dlp
     match_ids.reset(&match_ids_handle);
     match_overlaps.reset(&match_overlaps_handle);
     particle_ids.reset(&particle_ids_handle);
+    flash_ids.reset(&flash_ids_handle);
+    flash_volume_ids.reset(&flash_volume_ids_handle);
+    flash_times.reset(&flash_times_handle);
   }
   
   
@@ -51,6 +54,9 @@ namespace cafmaker::types::dlp
     index_adapt.reset(&index_adapt_handle);
     index_g4.reset(&index_g4_handle);
     particle_ids.reset(&particle_ids_handle);
+    flash_ids.reset(&flash_ids_handle);
+    flash_volume_ids.reset(&flash_volume_ids_handle);
+    flash_times.reset(&flash_times_handle);
   }
   
   
@@ -91,19 +97,19 @@ namespace cafmaker::types::dlp
   {
     H5::CompType ctype(sizeof(Event));
   
-    ctype.insertMember("depositions_label", HOFFSET(Event, depositions_label), H5::PredType::STD_REF_DSETREG);
-    ctype.insertMember("reco_interactions", HOFFSET(Event, reco_interactions), H5::PredType::STD_REF_DSETREG);
-    ctype.insertMember("depositions", HOFFSET(Event, depositions), H5::PredType::STD_REF_DSETREG);
-    ctype.insertMember("trigger", HOFFSET(Event, trigger), H5::PredType::STD_REF_DSETREG);
     ctype.insertMember("points", HOFFSET(Event, points), H5::PredType::STD_REF_DSETREG);
-    ctype.insertMember("truth_interactions", HOFFSET(Event, truth_interactions), H5::PredType::STD_REF_DSETREG);
-    ctype.insertMember("run_info", HOFFSET(Event, run_info), H5::PredType::STD_REF_DSETREG);
-    ctype.insertMember("index", HOFFSET(Event, index), H5::PredType::STD_REF_DSETREG);
     ctype.insertMember("truth_particles", HOFFSET(Event, truth_particles), H5::PredType::STD_REF_DSETREG);
-    ctype.insertMember("meta", HOFFSET(Event, meta), H5::PredType::STD_REF_DSETREG);
+    ctype.insertMember("depositions", HOFFSET(Event, depositions), H5::PredType::STD_REF_DSETREG);
     ctype.insertMember("reco_particles", HOFFSET(Event, reco_particles), H5::PredType::STD_REF_DSETREG);
+    ctype.insertMember("meta", HOFFSET(Event, meta), H5::PredType::STD_REF_DSETREG);
+    ctype.insertMember("reco_interactions", HOFFSET(Event, reco_interactions), H5::PredType::STD_REF_DSETREG);
     ctype.insertMember("points_label", HOFFSET(Event, points_label), H5::PredType::STD_REF_DSETREG);
+    ctype.insertMember("truth_interactions", HOFFSET(Event, truth_interactions), H5::PredType::STD_REF_DSETREG);
+    ctype.insertMember("depositions_label", HOFFSET(Event, depositions_label), H5::PredType::STD_REF_DSETREG);
+    ctype.insertMember("trigger", HOFFSET(Event, trigger), H5::PredType::STD_REF_DSETREG);
+    ctype.insertMember("index", HOFFSET(Event, index), H5::PredType::STD_REF_DSETREG);
     ctype.insertMember("flashes", HOFFSET(Event, flashes), H5::PredType::STD_REF_DSETREG);
+    ctype.insertMember("run_info", HOFFSET(Event, run_info), H5::PredType::STD_REF_DSETREG);
   
     return ctype;
   }
@@ -138,8 +144,9 @@ namespace cafmaker::types::dlp
     ctype.insertMember("vertex", HOFFSET(Interaction, vertex), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("is_fiducial", HOFFSET(Interaction, is_fiducial), H5::PredType::STD_U8LE);
     ctype.insertMember("is_flash_matched", HOFFSET(Interaction, is_flash_matched), H5::PredType::STD_U8LE);
-    ctype.insertMember("flash_id", HOFFSET(Interaction, flash_id), H5::PredType::STD_I64LE);
-    ctype.insertMember("flash_time", HOFFSET(Interaction, flash_time), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("flash_ids", HOFFSET(Interaction, flash_ids_handle), H5::VarLenType(H5::PredType::STD_I32LE));
+    ctype.insertMember("flash_volume_ids", HOFFSET(Interaction, flash_volume_ids_handle), H5::VarLenType(H5::PredType::STD_I32LE));
+    ctype.insertMember("flash_times", HOFFSET(Interaction, flash_times_handle), H5::VarLenType(H5::PredType::STD_I32LE));
     ctype.insertMember("flash_total_pe", HOFFSET(Interaction, flash_total_pe), H5::PredType::IEEE_F64LE);
     ctype.insertMember("flash_hypo_pe", HOFFSET(Interaction, flash_hypo_pe), H5::PredType::IEEE_F64LE);
     
@@ -203,21 +210,26 @@ namespace cafmaker::types::dlp
     
     ctype.insertMember("pdg_code", HOFFSET(Particle, pdg_code), H5::PredType::STD_I64LE);
     ctype.insertMember("is_primary", HOFFSET(Particle, is_primary), H5::PredType::STD_U8LE);
-    ctype.insertMember("length", HOFFSET(Particle, length), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("length", HOFFSET(Particle, length), H5::PredType::IEEE_F32LE);
     ctype.insertMember("start_point", HOFFSET(Particle, start_point), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("end_point", HOFFSET(Particle, end_point), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("start_dir", HOFFSET(Particle, start_dir), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("end_dir", HOFFSET(Particle, end_dir), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
+    ctype.insertMember("mass", HOFFSET(Particle, mass), H5::PredType::IEEE_F64LE);
     ctype.insertMember("ke", HOFFSET(Particle, ke), H5::PredType::IEEE_F64LE);
     ctype.insertMember("calo_ke", HOFFSET(Particle, calo_ke), H5::PredType::IEEE_F64LE);
     ctype.insertMember("csda_ke", HOFFSET(Particle, csda_ke), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("csda_ke_per_pid", HOFFSET(Particle, csda_ke_per_pid), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{6}[0]));
     ctype.insertMember("mcs_ke", HOFFSET(Particle, mcs_ke), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("mcs_ke_per_pid", HOFFSET(Particle, mcs_ke_per_pid), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{6}[0]));
     ctype.insertMember("momentum", HOFFSET(Particle, momentum), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("p", HOFFSET(Particle, p), H5::PredType::IEEE_F32LE);
     ctype.insertMember("is_valid", HOFFSET(Particle, is_valid), H5::PredType::STD_U8LE);
     ctype.insertMember("pid_scores", HOFFSET(Particle, pid_scores), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{6}[0]));
     ctype.insertMember("primary_scores", HOFFSET(Particle, primary_scores), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{2}[0]));
     ctype.insertMember("ppn_ids", HOFFSET(Particle, ppn_ids_handle), H5::VarLenType(H5::PredType::STD_I32LE));
+    ctype.insertMember("vertex_distance", HOFFSET(Particle, vertex_distance), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("shower_split_angle", HOFFSET(Particle, shower_split_angle), H5::PredType::IEEE_F64LE);
   
     return ctype;
   }
@@ -249,6 +261,7 @@ namespace cafmaker::types::dlp
     ctype.insertMember("depositions_q_sum", HOFFSET(TrueInteraction, depositions_q_sum), H5::PredType::IEEE_F32LE);
     ctype.insertMember("index_adapt", HOFFSET(TrueInteraction, index_adapt_handle), H5::VarLenType(H5::PredType::STD_I64LE));
     ctype.insertMember("size_adapt", HOFFSET(TrueInteraction, size_adapt), H5::PredType::STD_I64LE);
+    ctype.insertMember("size_g4", HOFFSET(TrueInteraction, size_g4), H5::PredType::STD_I64LE);
     ctype.insertMember("depositions_adapt_sum", HOFFSET(TrueInteraction, depositions_adapt_sum), H5::PredType::IEEE_F32LE);
     ctype.insertMember("depositions_adapt_q_sum", HOFFSET(TrueInteraction, depositions_adapt_q_sum), H5::PredType::IEEE_F32LE);
     ctype.insertMember("index_g4", HOFFSET(TrueInteraction, index_g4_handle), H5::VarLenType(H5::PredType::STD_I64LE));
@@ -260,8 +273,9 @@ namespace cafmaker::types::dlp
     ctype.insertMember("vertex", HOFFSET(TrueInteraction, vertex), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("is_fiducial", HOFFSET(TrueInteraction, is_fiducial), H5::PredType::STD_U8LE);
     ctype.insertMember("is_flash_matched", HOFFSET(TrueInteraction, is_flash_matched), H5::PredType::STD_U8LE);
-    ctype.insertMember("flash_id", HOFFSET(TrueInteraction, flash_id), H5::PredType::STD_I64LE);
-    ctype.insertMember("flash_time", HOFFSET(TrueInteraction, flash_time), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("flash_ids", HOFFSET(TrueInteraction, flash_ids_handle), H5::VarLenType(H5::PredType::STD_I32LE));
+    ctype.insertMember("flash_volume_ids", HOFFSET(TrueInteraction, flash_volume_ids_handle), H5::VarLenType(H5::PredType::STD_I32LE));
+    ctype.insertMember("flash_times", HOFFSET(TrueInteraction, flash_times_handle), H5::VarLenType(H5::PredType::STD_I32LE));
     ctype.insertMember("flash_total_pe", HOFFSET(TrueInteraction, flash_total_pe), H5::PredType::IEEE_F64LE);
     ctype.insertMember("flash_hypo_pe", HOFFSET(TrueInteraction, flash_hypo_pe), H5::PredType::IEEE_F64LE);
     
@@ -469,6 +483,7 @@ namespace cafmaker::types::dlp
     ctype.insertMember("depositions_q_sum", HOFFSET(TrueParticle, depositions_q_sum), H5::PredType::IEEE_F32LE);
     ctype.insertMember("index_adapt", HOFFSET(TrueParticle, index_adapt_handle), H5::VarLenType(H5::PredType::STD_I64LE));
     ctype.insertMember("size_adapt", HOFFSET(TrueParticle, size_adapt), H5::PredType::STD_I64LE);
+    ctype.insertMember("size_g4", HOFFSET(TrueParticle, size_g4), H5::PredType::STD_I64LE);
     ctype.insertMember("depositions_adapt_sum", HOFFSET(TrueParticle, depositions_adapt_sum), H5::PredType::IEEE_F32LE);
     ctype.insertMember("depositions_adapt_q_sum", HOFFSET(TrueParticle, depositions_adapt_q_sum), H5::PredType::IEEE_F32LE);
     ctype.insertMember("index_g4", HOFFSET(TrueParticle, index_g4_handle), H5::VarLenType(H5::PredType::STD_I64LE));
@@ -507,10 +522,13 @@ namespace cafmaker::types::dlp
     ctype.insertMember("end_point", HOFFSET(TrueParticle, end_point), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("start_dir", HOFFSET(TrueParticle, start_dir), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("end_dir", HOFFSET(TrueParticle, end_dir), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
+    ctype.insertMember("mass", HOFFSET(TrueParticle, mass), H5::PredType::IEEE_F64LE);
     ctype.insertMember("ke", HOFFSET(TrueParticle, ke), H5::PredType::IEEE_F64LE);
     ctype.insertMember("calo_ke", HOFFSET(TrueParticle, calo_ke), H5::PredType::IEEE_F64LE);
     ctype.insertMember("csda_ke", HOFFSET(TrueParticle, csda_ke), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("csda_ke_per_pid", HOFFSET(TrueParticle, csda_ke_per_pid), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{6}[0]));
     ctype.insertMember("mcs_ke", HOFFSET(TrueParticle, mcs_ke), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("mcs_ke_per_pid", HOFFSET(TrueParticle, mcs_ke_per_pid), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{6}[0]));
     ctype.insertMember("momentum", HOFFSET(TrueParticle, momentum), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("p", HOFFSET(TrueParticle, p), H5::PredType::IEEE_F32LE);
     ctype.insertMember("is_valid", HOFFSET(TrueParticle, is_valid), H5::PredType::STD_U8LE);
@@ -548,6 +566,7 @@ namespace cafmaker::types::dlp
     ctype.insertMember("ancestor_creation_process", HOFFSET(TrueParticle, ancestor_creation_process), ancestor_creation_process_strType);
     
     ctype.insertMember("t", HOFFSET(TrueParticle, t), H5::PredType::IEEE_F64LE);
+    ctype.insertMember("end_t", HOFFSET(TrueParticle, end_t), H5::PredType::IEEE_F64LE);
     ctype.insertMember("parent_t", HOFFSET(TrueParticle, parent_t), H5::PredType::IEEE_F64LE);
     ctype.insertMember("ancestor_t", HOFFSET(TrueParticle, ancestor_t), H5::PredType::IEEE_F64LE);
     ctype.insertMember("position", HOFFSET(TrueParticle, position), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
@@ -560,6 +579,7 @@ namespace cafmaker::types::dlp
     ctype.insertMember("end_p", HOFFSET(TrueParticle, end_p), H5::PredType::IEEE_F32LE);
     ctype.insertMember("orig_interaction_id", HOFFSET(TrueParticle, orig_interaction_id), H5::PredType::STD_I64LE);
     ctype.insertMember("children_counts", HOFFSET(TrueParticle, children_counts_handle), H5::VarLenType(H5::PredType::STD_I64LE));
+    ctype.insertMember("reco_length", HOFFSET(TrueParticle, reco_length), H5::PredType::IEEE_F64LE);
     ctype.insertMember("reco_start_dir", HOFFSET(TrueParticle, reco_start_dir), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
     ctype.insertMember("reco_end_dir", HOFFSET(TrueParticle, reco_end_dir), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
   
@@ -573,17 +593,18 @@ namespace cafmaker::types::dlp
     H5::CompType ctype(sizeof(Flash));
   
     ctype.insertMember("id", HOFFSET(Flash, id), H5::PredType::STD_I64LE);
+    ctype.insertMember("volume_id", HOFFSET(Flash, volume_id), H5::PredType::STD_I64LE);
     ctype.insertMember("frame", HOFFSET(Flash, frame), H5::PredType::STD_I64LE);
     ctype.insertMember("in_beam_frame", HOFFSET(Flash, in_beam_frame), H5::PredType::STD_U8LE);
-    ctype.insertMember("on_beam_time", HOFFSET(Flash, on_beam_time), H5::PredType::STD_I64LE);
+    ctype.insertMember("on_beam_time", HOFFSET(Flash, on_beam_time), H5::PredType::STD_U8LE);
     ctype.insertMember("time", HOFFSET(Flash, time), H5::PredType::IEEE_F64LE);
     ctype.insertMember("time_width", HOFFSET(Flash, time_width), H5::PredType::IEEE_F64LE);
     ctype.insertMember("time_abs", HOFFSET(Flash, time_abs), H5::PredType::IEEE_F64LE);
     ctype.insertMember("total_pe", HOFFSET(Flash, total_pe), H5::PredType::IEEE_F64LE);
     ctype.insertMember("fast_to_total", HOFFSET(Flash, fast_to_total), H5::PredType::IEEE_F64LE);
     ctype.insertMember("pe_per_ch", HOFFSET(Flash, pe_per_ch_handle), H5::VarLenType(H5::PredType::IEEE_F32LE));
-    ctype.insertMember("center", HOFFSET(Flash, center), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
-    ctype.insertMember("width", HOFFSET(Flash, width), H5::ArrayType(H5::PredType::IEEE_F64LE, 1, &std::array<hsize_t, 1>{3}[0]));
+    ctype.insertMember("center", HOFFSET(Flash, center), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
+    ctype.insertMember("width", HOFFSET(Flash, width), H5::ArrayType(H5::PredType::IEEE_F32LE, 1, &std::array<hsize_t, 1>{3}[0]));
     
     H5::StrType units_strType(H5::PredType::C_S1, H5T_VARIABLE);
     units_strType.setCset(H5T_CSET_UTF8);

--- a/src/reco/DLP_h5_classes.h
+++ b/src/reco/DLP_h5_classes.h
@@ -5,7 +5,7 @@
 //
 //    The invocation that generated this file was:
 //
-//       h5_to_cpp.py -f MiniRun5_1E19_RHC.flow.0000000.flash.larcv_spine.h5 -o DLP_h5_classes -ns cafmaker::types::dlp -d events -cn Event -d reco_interactions -cn Interaction -d reco_particles -cn Particle -d truth_interactions -cn TrueInteraction -d truth_particles -cn TrueParticle -d flashes -cn Flash -d run_info -cn RunInfo -d trigger -cn Trigger
+//       h5_to_cpp.py -f MiniRun6.1_1E19_RHC.flow.0000001.LARCV_spine.h5 -o DLP_h5_classes -ns cafmaker::types::dlp -d events -cn Event -d reco_interactions -cn Interaction -d reco_particles -cn Particle -d truth_interactions -cn TrueInteraction -d truth_particles -cn TrueParticle -d flashes -cn Flash -d run_info -cn RunInfo -d trigger -cn Trigger
 //
 
 
@@ -202,32 +202,32 @@ namespace cafmaker::types::dlp
   
   struct Event
   {
-    hdset_reg_ref_t depositions_label;
-    hdset_reg_ref_t reco_interactions;
-    hdset_reg_ref_t depositions;
-    hdset_reg_ref_t trigger;
     hdset_reg_ref_t points;
-    hdset_reg_ref_t truth_interactions;
-    hdset_reg_ref_t run_info;
-    hdset_reg_ref_t index;
     hdset_reg_ref_t truth_particles;
-    hdset_reg_ref_t meta;
+    hdset_reg_ref_t depositions;
     hdset_reg_ref_t reco_particles;
+    hdset_reg_ref_t meta;
+    hdset_reg_ref_t reco_interactions;
     hdset_reg_ref_t points_label;
+    hdset_reg_ref_t truth_interactions;
+    hdset_reg_ref_t depositions_label;
+    hdset_reg_ref_t trigger;
+    hdset_reg_ref_t index;
     hdset_reg_ref_t flashes;
+    hdset_reg_ref_t run_info;
     
     void SyncVectors();
     
     template <typename T>
     const hdset_reg_ref_t& GetRef() const
     {
-      if constexpr(std::is_same_v<T, Interaction>) return reco_interactions;
-      else if(std::is_same_v<T, Trigger>) return trigger;
-      else if(std::is_same_v<T, TrueInteraction>) return truth_interactions;
-      else if(std::is_same_v<T, RunInfo>) return run_info;
-      else if(std::is_same_v<T, TrueParticle>) return truth_particles;
+      if constexpr(std::is_same_v<T, TrueParticle>) return truth_particles;
       else if(std::is_same_v<T, Particle>) return reco_particles;
+      else if(std::is_same_v<T, Interaction>) return reco_interactions;
+      else if(std::is_same_v<T, TrueInteraction>) return truth_interactions;
+      else if(std::is_same_v<T, Trigger>) return trigger;
       else if(std::is_same_v<T, Flash>) return flashes;
+      else if(std::is_same_v<T, RunInfo>) return run_info;
     }
     
   };
@@ -255,8 +255,9 @@ namespace cafmaker::types::dlp
     std::array<float, 3> vertex;
     bool is_fiducial;
     bool is_flash_matched;
-    int64_t flash_id;
-    double flash_time;
+    BufferView<int32_t> flash_ids;
+    BufferView<int32_t> flash_volume_ids;
+    BufferView<int32_t> flash_times;
     double flash_total_pe;
     double flash_hypo_pe;
     char * topology;
@@ -276,6 +277,9 @@ namespace cafmaker::types::dlp
     hvl_t match_ids_handle;
     hvl_t match_overlaps_handle;
     hvl_t particle_ids_handle;
+    hvl_t flash_ids_handle;
+    hvl_t flash_volume_ids_handle;
+    hvl_t flash_times_handle;
   };
   
   
@@ -301,21 +305,26 @@ namespace cafmaker::types::dlp
     Pid pid;
     int64_t pdg_code;
     bool is_primary;
-    double length;
+    float length;
     std::array<float, 3> start_point;
     std::array<float, 3> end_point;
     std::array<float, 3> start_dir;
     std::array<float, 3> end_dir;
+    double mass;
     double ke;
     double calo_ke;
     double csda_ke;
+    std::array<float, 6> csda_ke_per_pid;
     double mcs_ke;
+    std::array<float, 6> mcs_ke_per_pid;
     std::array<float, 3> momentum;
     float p;
     bool is_valid;
     std::array<float, 6> pid_scores;
     std::array<float, 2> primary_scores;
     BufferView<int32_t> ppn_ids;
+    double vertex_distance;
+    double shower_split_angle;
     
     void SyncVectors();
     
@@ -355,6 +364,7 @@ namespace cafmaker::types::dlp
     float depositions_q_sum;
     BufferView<int64_t> index_adapt;
     int64_t size_adapt;
+    int64_t size_g4;
     float depositions_adapt_sum;
     float depositions_adapt_q_sum;
     BufferView<int64_t> index_g4;
@@ -366,8 +376,9 @@ namespace cafmaker::types::dlp
     std::array<float, 3> vertex;
     bool is_fiducial;
     bool is_flash_matched;
-    int64_t flash_id;
-    double flash_time;
+    BufferView<int32_t> flash_ids;
+    BufferView<int32_t> flash_volume_ids;
+    BufferView<int32_t> flash_times;
     double flash_total_pe;
     double flash_hypo_pe;
     char * topology;
@@ -415,6 +426,9 @@ namespace cafmaker::types::dlp
     hvl_t index_adapt_handle;
     hvl_t index_g4_handle;
     hvl_t particle_ids_handle;
+    hvl_t flash_ids_handle;
+    hvl_t flash_volume_ids_handle;
+    hvl_t flash_times_handle;
   };
   
   
@@ -437,6 +451,7 @@ namespace cafmaker::types::dlp
     float depositions_q_sum;
     BufferView<int64_t> index_adapt;
     int64_t size_adapt;
+    int64_t size_g4;
     float depositions_adapt_sum;
     float depositions_adapt_q_sum;
     BufferView<int64_t> index_g4;
@@ -453,10 +468,13 @@ namespace cafmaker::types::dlp
     std::array<float, 3> end_point;
     std::array<float, 3> start_dir;
     std::array<float, 3> end_dir;
+    double mass;
     double ke;
     double calo_ke;
     double csda_ke;
+    std::array<float, 6> csda_ke_per_pid;
     double mcs_ke;
+    std::array<float, 6> mcs_ke_per_pid;
     std::array<float, 3> momentum;
     float p;
     bool is_valid;
@@ -482,6 +500,7 @@ namespace cafmaker::types::dlp
     char * parent_creation_process;
     char * ancestor_creation_process;
     double t;
+    double end_t;
     double parent_t;
     double ancestor_t;
     std::array<float, 3> position;
@@ -494,6 +513,7 @@ namespace cafmaker::types::dlp
     float end_p;
     int64_t orig_interaction_id;
     BufferView<int64_t> children_counts;
+    double reco_length;
     std::array<float, 3> reco_start_dir;
     std::array<float, 3> reco_end_dir;
     
@@ -522,17 +542,18 @@ namespace cafmaker::types::dlp
   struct Flash
   {
     int64_t id;
+    int64_t volume_id;
     int64_t frame;
     uint8_t in_beam_frame;
-    int64_t on_beam_time;
+    uint8_t on_beam_time;
     double time;
     double time_width;
     double time_abs;
     double total_pe;
     double fast_to_total;
     BufferView<float> pe_per_ch;
-    std::array<double, 3> center;
-    std::array<double, 3> width;
+    std::array<float, 3> center;
+    std::array<float, 3> width;
     char * units;
     
     void SyncVectors();

--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -714,7 +714,6 @@ namespace cafmaker
 
           LOG.VERBOSE() << "      id = " << truePartPassThrough.id << "; "
                     << "track id = " << truePartPassThrough.track_id << "; "
-                    << "gen ID = " << truePartPassThrough.track_id << "; "
                     << "interaction ID = " << truePartPassThrough.interaction_id << "; "
                     << "is primary = " << truePartPassThrough.is_primary << "; "
                     << "pdg = " << truePartPassThrough.pdg_code << "; "

--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -282,7 +282,7 @@ namespace cafmaker
   {
     const auto NaN = std::numeric_limits<float>::signaling_NaN();
     ValidateOrCopy(truePartPassthrough.pdg_code, srTruePart.pdg, 0, "pdg_code");
-    ValidateOrCopy(truePartPassthrough.gen_id, srTruePart.G4ID, -1,"SRTrueParticle::track_id");
+    ValidateOrCopy(truePartPassthrough.track_id, srTruePart.G4ID, -1,"SRTrueParticle::track_id");
 
     ValidateOrCopy(truePartPassthrough.orig_interaction_id, srTruePart.interaction_id, -1L, "SRTrueParticle::interaction_id");
 
@@ -439,8 +439,8 @@ namespace cafmaker
       sr.common.ixn.dlp.push_back(std::move(interaction));
       //Fill matched flash info
       caf::FlashMatch flashMatch;
-      flashMatch.id = ixn.flash_id;
-      flashMatch.time = ixn.flash_time;
+      //flashMatch.id = ixn.flash_id;
+      //flashMatch.time = ixn.flash_time;
       flashMatch.total_pe = ixn.flash_total_pe;
       flashMatch.hypothesis_pe = ixn.flash_hypo_pe;
       sr.nd.lar.dlp[ixnidx].flash.push_back(flashMatch);
@@ -503,7 +503,6 @@ namespace cafmaker
 
           LOG.VERBOSE() << "      id = " << truePartPassThrough.id << "; "
                     << "track id = " << truePartPassThrough.track_id << "; "
-                    << "gen ID = " << truePartPassThrough.gen_id << "; "
                     << "interaction ID = " << truePartPassThrough.interaction_id << "; "
                     << "is primary = " << truePartPassThrough.is_primary << "; "
                     << "pdg = " << truePartPassThrough.pdg_code << "; "
@@ -535,10 +534,10 @@ namespace cafmaker
                                                         [&srTrueInt](const caf::SRTrueInteraction& ixn) {return ixn.id == srTrueInt.id;}));
 
           bool is_primary = std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(), 
-                                   [&srTrueInt, &truePartPassThrough](const caf::SRTrueParticle& part) { return part.G4ID == truePartPassThrough.gen_id; }) != srTrueInt.prim.end();
-          srPartCmp.trkid = truePartPassThrough.gen_id;
-          caf::SRTrueParticle & srTruePart = is_primary ? truthMatch->GetTrueParticle(sr, srTrueInt, truePartPassThrough.gen_id, srPartCmp, true, (!truthMatch->HaveGENIE()))
-                                                        : truthMatch->GetTrueParticle(sr, srTrueInt, truePartPassThrough.gen_id, srPartCmp, false, true);
+                                   [&srTrueInt, &truePartPassThrough](const caf::SRTrueParticle& part) { return part.G4ID == truePartPassThrough.track_id; }) != srTrueInt.prim.end();
+          srPartCmp.trkid = truePartPassThrough.track_id;
+          caf::SRTrueParticle & srTruePart = is_primary ? truthMatch->GetTrueParticle(sr, srTrueInt, truePartPassThrough.track_id, srPartCmp, true, (!truthMatch->HaveGENIE()))
+                                                        : truthMatch->GetTrueParticle(sr, srTrueInt, truePartPassThrough.track_id, srPartCmp, false, true);
 
           //  this will fill in any other fields that weren't copied from a GENIE record
           // (which also handles the case where this particle is a secondary)
@@ -613,7 +612,6 @@ namespace cafmaker
 
           LOG.VERBOSE() << "      id = " << truePartPassThrough.id << "; "
                     << "track id = " << truePartPassThrough.track_id << "; "
-                    << "gen ID = " << truePartPassThrough.gen_id << "; "
                     << "interaction ID = " << truePartPassThrough.interaction_id << "; "
                     << "is primary = " << truePartPassThrough.is_primary << "; "
                     << "pdg = " << truePartPassThrough.pdg_code << "; "
@@ -645,15 +643,15 @@ namespace cafmaker
     	  
            
           bool is_primary = std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(), 
-                                   [&srTrueInt, &truePartPassThrough](const caf::SRTrueParticle& part) { return part.G4ID == truePartPassThrough.gen_id; }) != srTrueInt.prim.end();
-          srPartCmp.trkid = truePartPassThrough.gen_id;
+                                   [&srTrueInt, &truePartPassThrough](const caf::SRTrueParticle& part) { return part.G4ID == truePartPassThrough.track_id; }) != srTrueInt.prim.end();
+          srPartCmp.trkid = truePartPassThrough.track_id;
 
           // we want to make sure the particle is created, if it isn't there,
           // but we won't do anything further with it, so we throw the return value away
           if (is_primary)
-            truthMatch->GetTrueParticle(sr, srTrueInt, truePartPassThrough.gen_id, srPartCmp, true, (!truthMatch->HaveGENIE()));
+            truthMatch->GetTrueParticle(sr, srTrueInt, truePartPassThrough.track_id, srPartCmp, true, (!truthMatch->HaveGENIE()));
           else
-            truthMatch->GetTrueParticle(sr, srTrueInt, truePartPassThrough.gen_id, srPartCmp, false, true);
+            truthMatch->GetTrueParticle(sr, srTrueInt, truePartPassThrough.track_id, srPartCmp, false, true);
 
           // the particle idx is within the GENIE vector, which may not be the same as the index in the vector here
           // first find the interaction that it goes with
@@ -716,7 +714,7 @@ namespace cafmaker
 
           LOG.VERBOSE() << "      id = " << truePartPassThrough.id << "; "
                     << "track id = " << truePartPassThrough.track_id << "; "
-                    << "gen ID = " << truePartPassThrough.gen_id << "; "
+                    << "gen ID = " << truePartPassThrough.track_id << "; "
                     << "interaction ID = " << truePartPassThrough.interaction_id << "; "
                     << "is primary = " << truePartPassThrough.is_primary << "; "
                     << "pdg = " << truePartPassThrough.pdg_code << "; "
@@ -747,12 +745,12 @@ namespace cafmaker
                                                         [&srTrueInt](const caf::SRTrueInteraction& ixn) {return ixn.id == srTrueInt.id;}));
 
     	    bool is_primary = std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(), 
-                                   [&srTrueInt, &truePartPassThrough](const caf::SRTrueParticle& part) { return part.G4ID == truePartPassThrough.gen_id; }) != srTrueInt.prim.end();
-          srPartCmp.trkid = truePartPassThrough.gen_id;
+                                   [&srTrueInt, &truePartPassThrough](const caf::SRTrueParticle& part) { return part.G4ID == truePartPassThrough.track_id; }) != srTrueInt.prim.end();
+          srPartCmp.trkid = truePartPassThrough.track_id;
           // we don't actually need the return value here for anything,
           // but we do want the TruthMatcher to *create* a new particle when that's appropriate
-          is_primary ? truthMatch->GetTrueParticle(sr, srTrueInt, truePartPassThrough.gen_id, srPartCmp, true, (!truthMatch->HaveGENIE()))
-                     : truthMatch->GetTrueParticle(sr, srTrueInt, truePartPassThrough.gen_id, srPartCmp, false, true);
+          is_primary ? truthMatch->GetTrueParticle(sr, srTrueInt, truePartPassThrough.track_id, srPartCmp, true, (!truthMatch->HaveGENIE()))
+                     : truthMatch->GetTrueParticle(sr, srTrueInt, truePartPassThrough.track_id, srPartCmp, false, true);
 
 
           // the particle idx is within the GENIE vector, which may not be the same as the index in the vector here


### PR DESCRIPTION
Changes:

1. We no longer need `gen_id` since this info is now saved in `track_id` (hope I don't have nightmares about this anymore)
2. There are also other variable name/type changes in SPINE. The ones that affect CAFs are matched flash variables. A reco interaction can have more than one matched flash, so the variable types and names have to be changed also in the `StandardRecord`. For now, I am not filling the id and time variables of the matched flash(es) until we make that change. We don't have to worry about this for now since there is no flash matching. Hope to fill this after MiniRun 6.2 so we enough time to also request a new `duneanaobj` version
