### PR TITLE
Add Pandora interactions to the standard record

### DIFF
--- a/src/reco/PandoraLArRecoNDBranchFiller.h
+++ b/src/reco/PandoraLArRecoNDBranchFiller.h
@@ -37,8 +37,12 @@ namespace cafmaker
 			     const cafmaker::Params &par,
 			     const TruthMatcher *truthMatch = nullptr) const override;
 
-      void FillTracks(caf::StandardRecord &sr, const int nClusters, const TruthMatcher *truthMatch) const;
-      void FillShowers(caf::StandardRecord &sr, const int nClusters, const TruthMatcher *truthMatch) const;
+      void FillTracks(caf::StandardRecord &sr, const int nClusters, const std::vector<int> &uniqueSliceIDs,
+		      const TruthMatcher *truthMatch) const;
+      void FillShowers(caf::StandardRecord &sr, const int nClusters, const std::vector<int> &uniqueSliceIDs,
+		       const TruthMatcher *truthMatch) const;
+      void FillInteractions(caf::StandardRecord &sr, const std::vector<int> &uniqueSliceIDs,
+			    std::vector<caf::SRInteraction> &nuInteractions, const TruthMatcher *truthMatch) const;
       
       std::unique_ptr<TFile> m_LArRecoNDFile;
       std::unique_ptr<TTree> m_LArRecoNDTree;
@@ -65,6 +69,9 @@ namespace cafmaker
       std::vector<long> *m_mcLocalIdVect = nullptr;
       std::vector<int> *m_isPrimaryVect = nullptr;
       std::vector<float> *m_completenessVect = nullptr;
+      std::vector<float> *m_nuVtxXVect = nullptr;
+      std::vector<float> *m_nuVtxYVect = nullptr;
+      std::vector<float> *m_nuVtxZVect = nullptr;
 
       mutable std::vector<cafmaker::Trigger> m_Triggers;
       mutable decltype(m_Triggers)::const_iterator  m_LastTriggerReqd; ///< the last trigger requested using _FillRecoBranches


### PR DESCRIPTION
This adds the interaction information to the common part of the standard record for Pandora, which is currently missing in the CAFs. Each `SRInteraction` contains the reconstructed neutrino vertex along with the tracks and showers that are retrieved from the Pandora reco record, which are filled before the interactions.

We also fix an issue with the size of `sr.nd.lar.pandora`, which stores the reco tracks and showers, that was incorrectly set to the number of clusters and not the number of neutrinos.
