### PR TITLE
Use reco not MC PDG hypothesis & isPrimary boolean for Pandora CAFs

### DIFF
--- a/src/reco/PandoraLArRecoNDBranchFiller.h
+++ b/src/reco/PandoraLArRecoNDBranchFiller.h
@@ -38,11 +38,9 @@ namespace cafmaker
 			     const TruthMatcher *truthMatch = nullptr) const override;
 
       void FillTracks(caf::StandardRecord &sr, const int nClusters, const std::vector<int> &uniqueSliceIDs,
-		      const TruthMatcher *truthMatch) const;
+		      std::vector<caf::SRInteraction> &nuInteractions, const TruthMatcher *truthMatch) const;
       void FillShowers(caf::StandardRecord &sr, const int nClusters, const std::vector<int> &uniqueSliceIDs,
-		       const TruthMatcher *truthMatch) const;
-      void FillInteractions(caf::StandardRecord &sr, const std::vector<int> &uniqueSliceIDs,
-			    std::vector<caf::SRInteraction> &nuInteractions, const TruthMatcher *truthMatch) const;
+		       std::vector<caf::SRInteraction> &nuInteractions, const TruthMatcher *truthMatch) const;
       
       std::unique_ptr<TFile> m_LArRecoNDFile;
       std::unique_ptr<TTree> m_LArRecoNDTree;
@@ -72,6 +70,8 @@ namespace cafmaker
       std::vector<float> *m_nuVtxXVect = nullptr;
       std::vector<float> *m_nuVtxYVect = nullptr;
       std::vector<float> *m_nuVtxZVect = nullptr;
+      std::vector<int> *m_isRecoPrimaryVect = nullptr;
+      std::vector<int> *m_recoPDGVect = nullptr;
 
       mutable std::vector<cafmaker::Trigger> m_Triggers;
       mutable decltype(m_Triggers)::const_iterator  m_LastTriggerReqd; ///< the last trigger requested using _FillRecoBranches


### PR DESCRIPTION
Update the PDG hypothesis & isPrimary boolean to use the reconstruction not MC truth info for Pandora. 

Also moved the filling of the interaction information from `FillInteractions()` (which is now removed) to the `FillTracks()` and `FillShowers()` functions, depending if the Pandora clusters are tracks or showers, respectively. 

The input Pandora ROOT file stores the reco PDG hypothesis & isPrimary variables for each cluster, and it is easier to set these interaction variables when the track & shower Standard Record objects are being created, rather than retrieving them from the Standard Record, as was done by the previous `FillInteractions()` function, and then trying to work out which Pandora cluster ntuple entry they should correspond to (e.g. using a map).

This update requires LArRecoND [v01-01-05](https://github.com/PandoraPFA/LArRecoND/tree/v01-01-05) for adding the two new reco ROOT variables `isRecoPrimary` and `recoPDG`, as well as LArContent [v04_14_00](https://github.com/PandoraPFA/LArContent/tree/v04_14_00) for adding functionality to say whether a reconstructed cluster is a primary one or not.