### PR TITLE
Set Pandora trigger type.

### DIFF
--- a/src/reco/PandoraLArRecoNDBranchFiller.cxx
+++ b/src/reco/PandoraLArRecoNDBranchFiller.cxx
@@ -32,6 +32,7 @@ namespace cafmaker
 	  m_LArRecoNDTree->SetBranchAddress("subRun", &m_subRun);
 	  m_LArRecoNDTree->SetBranchAddress("unixTime", &m_unixTime);
 	  m_LArRecoNDTree->SetBranchAddress("startTime", &m_startTime);
+	  m_LArRecoNDTree->SetBranchAddress("triggers", &m_triggerType);
 	  m_LArRecoNDTree->SetBranchAddress("isShower", &m_isShowerVect);
 	  m_LArRecoNDTree->SetBranchAddress("sliceId", &m_sliceIdVect);
 	  m_LArRecoNDTree->SetBranchAddress("startX", &m_startXVect);
@@ -488,8 +489,8 @@ namespace cafmaker
 	    Trigger &trig = m_Triggers.back();
 	    // Event number
 	    trig.evtID = m_eventId;
-	    // Pandora SpacePoint (SP) H5Flow-to-ROOT format doesn't store trigger type, so just select "all"
-	    trig.triggerType = -1;
+	    // Type
+	    trig.triggerType = m_triggerType;
 	    // unix_ts trigger time (seconds)
 	    trig.triggerTime_s = m_unixTime;
 	    // ts_start ticks (0.1 microseconds) converted to nanoseconds

--- a/src/reco/PandoraLArRecoNDBranchFiller.h
+++ b/src/reco/PandoraLArRecoNDBranchFiller.h
@@ -50,6 +50,7 @@ namespace cafmaker
       int m_subRun;
       int m_unixTime;
       int m_startTime;
+      int m_triggerType;
       std::vector<int> *m_isShowerVect = nullptr;
       std::vector<int> *m_sliceIdVect = nullptr;
       std::vector<float> *m_startXVect = nullptr;


### PR DESCRIPTION
The trigger type integer "triggers" is now stored in the Pandora hierarchy ROOT output file in LArRecoND tag [v01-02-00](https://github.com/PandoraPFA/LArRecoND/tree/v01-02-00), which includes the code added in [PR29](https://github.com/PandoraPFA/LArRecoND/pull/29) and [PR30](https://github.com/PandoraPFA/LArRecoND/pull/30). This integer is now used to set the trigger type for the Pandora CAFs.