### PR TITLE
Feature/minerva data processing

### DIFF
--- a/src/beam/IFBeam.cxx
+++ b/src/beam/IFBeam.cxx
@@ -56,7 +56,7 @@ namespace cafmaker
       double max_time = std::numeric_limits<double>::lowest();
       for (const auto& group : groupedTriggers) {
           for (const auto& trig : group) {
-              if (trig.second.triggerType !=1) continue;
+              if (trig.second.triggerType !=Trigger::TriggerType::beamTrigger) continue;
               double trigger_time = util::getTriggerTime(trig.second);
 
               // HACK
@@ -104,9 +104,7 @@ namespace cafmaker
   
   double IFBeam::getPOT(const cafmaker::Params& par, const TriggerGroup& groupedTrigger, int ii) {
       double pot = 0.0;
-      if (groupedTrigger.front().second.triggerType != 1) return 0.0;
-   //   for (auto trig : groupedTrigger) {std::cout<<trig.second.triggerType<<" ";}
-  //  std::cout<<std::endl;
+      if (groupedTrigger.front().second.triggerType != Trigger::TriggerType::beamTrigger) return 0.0;
       auto it = std::find_if(beamSpills.begin(), beamSpills.end(),
           [par, &groupedTrigger](const auto& spill) {
               return std::all_of(groupedTrigger.cbegin(), groupedTrigger.cend(),
@@ -123,13 +121,12 @@ namespace cafmaker
           std::vector<std::pair<const cafmaker::IRecoBranchFiller*, cafmaker::Trigger>> matched_triggers;
           std::vector<std::pair<const cafmaker::IRecoBranchFiller*, cafmaker::Trigger>> unmatched_triggers;
           for (auto trig : groupedTrigger) {
-              //check if the trigger is a type 1 trigger (beam trigger)
-              if (trig.second.triggerType != 1) return 0;
+              //check if the trigger is a type Trigger::TriggerType::beamTrigger
+              if (trig.second.triggerType != Trigger::TriggerType::beamTrigger) return 0;
               bool matched = std::any_of(beamSpills.cbegin(), beamSpills.cend(),
                   [par, &trig](const auto& spill) {
                       return std::abs(util::getTriggerTime(trig.second) - spill.first) < par().cafmaker().beamMatchDT();
                   });
-              std::cout<<std::endl<<std::endl; 
               if (matched) {
                   any_matched = true;
                   matched_triggers.push_back(trig);
@@ -154,10 +151,10 @@ namespace cafmaker
 
           } 
           else {
-             /* log_message << "No matching spill found for trigger group " << ii << " with triggers: \n";
+              log_message << "No matching spill found for trigger group " << ii << " with triggers: \n";
               for (auto trig : groupedTrigger)
                   log_message << std::fixed << trig.first->GetName() << " " << util::getTriggerTime(trig.second) << "\n";
-              cafmaker::LOG_S("Fill beam POT information").WARNING() << log_message.str() << "\n";*/
+              cafmaker::LOG_S("Fill beam POT information").WARNING() << log_message.str() << "\n";
           }
       }
   

--- a/src/beam/IFBeam.cxx
+++ b/src/beam/IFBeam.cxx
@@ -59,9 +59,6 @@ namespace cafmaker
               if (trig.second.triggerType !=Trigger::TriggerType::beamTrigger) continue;
               double trigger_time = util::getTriggerTime(trig.second);
 
-              // HACK
-              if (trigger_time > 1e12)
-                continue;
               min_time = std::min(min_time, trigger_time - dt);
               max_time = std::max(max_time, trigger_time + dt);
           }

--- a/src/makeCAF.C
+++ b/src/makeCAF.C
@@ -274,12 +274,31 @@ buildTriggerList(std::map<const cafmaker::IRecoBranchFiller*, std::deque<cafmake
       //  map if it's empty, per below)
       if (fillerTrigPair.first != seedFillerIt->first)
       {
+        auto& refTrigger = trigGroup.front().second;
+        auto it_trig = std::find_if(fillerTrigPair.second.begin(), fillerTrigPair.second.end(), [ &refTrigger](const cafmaker::Trigger& t)
+        {
+              return t.triggerType == refTrigger.triggerType;
+          });
+
+        if(it_trig != fillerTrigPair.second.end()){
+            if (it_trig != fillerTrigPair.second.begin()) {
+                //Move the trigger to the front 
+                cafmaker::Trigger temp = std::move(*it_trig);
+                fillerTrigPair.second.erase(it_trig);
+                fillerTrigPair.second.push_front(std::move(temp));
+            }
+        }
+        else continue; //Not found any trigger that match with ref trigger type
+      
         const auto & trig = fillerTrigPair.second.front();
         ss << "       " << fillerTrigPair.first->GetName() << ", " << trig.evtID;
 
         // we will only take at most one trigger from each of the other streams.
         // since the seed was the earliest one out of all the triggers,
         // we only need to check the first one in each other stream
+
+
+        
         if (doTriggersMatch( trigGroup.front().second, fillerTrigPair.second.front(), trigMatchMaxDT))
         {
           ss << " -->  MATCHES\n";

--- a/src/reco/IRecoBranchFiller.h
+++ b/src/reco/IRecoBranchFiller.h
@@ -16,10 +16,18 @@ namespace cafmaker
 {
   class TruthMatcher;
 
-  struct Trigger
-  {
+  struct Trigger{
+
+    enum TriggerType
+    {
+      beamTrigger,
+      lightTrigger2x2,
+      selfTrigger2x2,
+      other
+    };
+
     long int          evtID;
-    int               triggerType;
+    TriggerType          triggerType;
     unsigned long int triggerTime_s;
     unsigned int      triggerTime_ns;
 

--- a/src/reco/MINERvARecoBranchFiller.cxx
+++ b/src/reco/MINERvARecoBranchFiller.cxx
@@ -559,8 +559,7 @@ namespace cafmaker
         trig.evtID = Long_t(ev_gl_gate);
 
 
-        // todo: these are placeholder values until we can propagate enough info through the reco files
-        trig.triggerType = ev_trigger_type;
+        trig.triggerType = Trigger::TriggerType::beamTrigger;
         trig.triggerTime_s = ev_gps_time_sec;
         trig.triggerTime_ns = ev_gps_time_usec * 1000.;
 

--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -830,7 +830,15 @@ namespace cafmaker
         Trigger & trig = fTriggers.back();
         trig.evtID = trigger.id;
 
-        trig.triggerType = trigger.type;
+        //Flow trigger types are the following:
+        //5 = Beam trigger 
+        //6 = light trigger 
+        //Anything else = Charge self triggering
+        if (trigger.type == 5) trig.triggerType = Trigger::TriggerType::beamTrigger;
+        else if (trigger.type == 6) trig.triggerType = Trigger::TriggerType::lightTrigger2x2;
+        else trig.triggerType = Trigger::TriggerType::selfTrigger2x2;
+        //trig.triggerType = trigger.type;
+
         trig.triggerTime_s = trigger.time_s;
         trig.triggerTime_ns = trigger.time_ns;
 

--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -830,14 +830,13 @@ namespace cafmaker
         Trigger & trig = fTriggers.back();
         trig.evtID = trigger.id;
 
-        //Flow trigger types are the following:
+        //2x2 Flow trigger types are the following:
         //5 = Beam trigger 
         //6 = light trigger 
         //Anything else = Charge self triggering
         if (trigger.type == 5) trig.triggerType = Trigger::TriggerType::beamTrigger;
         else if (trigger.type == 6) trig.triggerType = Trigger::TriggerType::lightTrigger2x2;
         else trig.triggerType = Trigger::TriggerType::selfTrigger2x2;
-        //trig.triggerType = trigger.type;
 
         trig.triggerTime_s = trigger.time_s;
         trig.triggerTime_ns = trigger.time_ns;

--- a/src/reco/PandoraLArRecoNDBranchFiller.cxx
+++ b/src/reco/PandoraLArRecoNDBranchFiller.cxx
@@ -490,7 +490,13 @@ namespace cafmaker
 	    // Event number
 	    trig.evtID = m_eventId;
 	    // Type
-	    trig.triggerType = m_triggerType;
+      //2x2 Flow trigger types are the following:
+      //5 = Beam trigger
+      //6 = light trigger
+      //Anything else = Charge self triggering
+      if (m_triggerType == 5) trig.triggerType = Trigger::TriggerType::beamTrigger;
+      else if (m_triggerType == 6) trig.triggerType = Trigger::TriggerType::lightTrigger2x2;
+      else trig.triggerType = Trigger::TriggerType::selfTrigger2x2;
 	    // unix_ts trigger time (seconds)
 	    trig.triggerTime_s = m_unixTime;
 	    // ts_start ticks (0.1 microseconds) converted to nanoseconds


### PR DESCRIPTION
Related to issue #97, Several additions:

- Trigger type now is listed to make it less arbitrary and easier to understand in the future. Could be an issue in the link flow io_group -> trigger type, it works or 2x2 but not sure if FSD/NDLar would keep the same link, so I tried to made it clear that it's 2x2 only.
- The trigger matching logics now find the next trigger of same type in the other trigger streams, and then tries to do the matching with those.
- The POT is only fetched for beam trigger.

effect of the fix have been reported page 2 of that presentation:
https://docs.dunescience.org/cgi-bin/sso/RetrieveFile?docid=33729&filename=trigger_issue_v9.pdf&version=1