### PR TITLE
Use reference object for filling in the Pandora shower interactions

### DIFF
--- a/src/reco/PandoraLArRecoNDBranchFiller.cxx
+++ b/src/reco/PandoraLArRecoNDBranchFiller.cxx
@@ -428,7 +428,7 @@ namespace cafmaker
 	sr.nd.lar.pandora[nuIndex].nshowers++;
 
 	// Store this shower in the corresponding neutrino interaction
-	caf::SRInteraction interaction = nuInteractions[nuIndex];
+	caf::SRInteraction &interaction = nuInteractions[nuIndex];
 
 	// Shower reco particle
 	caf::SRRecoParticle showerPart;


### PR DESCRIPTION
In PandoraLArRecoNDBranchFiller::FillShowers(), a local object was used to fill in the shower interactions instead of the required object reference. This meant that no shower interactions were actually stored in the CAF output, only tracks.

This pdf file shows the effect before/after this fix:

[PandoraShowerPDG.pdf](https://github.com/user-attachments/files/20597390/PandoraShowerPDG.pdf)


