### PR TITLE
Trigger type/time filling updates

### DIFF
--- a/src/reco/PandoraLArRecoNDBranchFiller.cxx
+++ b/src/reco/PandoraLArRecoNDBranchFiller.cxx
@@ -33,6 +33,7 @@ namespace cafmaker
       m_LArRecoNDTree->SetBranchAddress("run", &m_run);
       m_LArRecoNDTree->SetBranchAddress("subRun", &m_subRun);
       m_LArRecoNDTree->SetBranchAddress("unixTime", &m_unixTime);
+      m_LArRecoNDTree->SetBranchAddress("unixTimeUsec", &m_unixTimeUsec);
       m_LArRecoNDTree->SetBranchAddress("startTime", &m_startTime);
       m_LArRecoNDTree->SetBranchAddress("triggers", &m_triggerType);
       m_LArRecoNDTree->SetBranchAddress("isShower", &m_isShowerVect);
@@ -531,8 +532,8 @@ namespace cafmaker
         trig.triggerType = m_triggerType;
         // unix_ts trigger time (seconds)
         trig.triggerTime_s = m_unixTime;
-        // ts_start ticks (0.1 microseconds) converted to nanoseconds
-        trig.triggerTime_ns = m_startTime * 100;
+        // unix_time_usec ticks (microseconds) converted to nanoseconds
+        trig.triggerTime_ns = m_unixTimeUsec * 1000;
 
         LOG.VERBOSE() << "  added trigger: evtID = " << trig.evtID
                       << ", triggerType = " << trig.triggerType

--- a/src/reco/PandoraLArRecoNDBranchFiller.h
+++ b/src/reco/PandoraLArRecoNDBranchFiller.h
@@ -52,6 +52,7 @@ namespace cafmaker
       int m_run;
       int m_subRun;
       int m_unixTime;
+      int m_unixTimeUsec;
       int m_startTime;
       int m_triggerType;
       std::vector<int> *m_isShowerVect = nullptr;


### PR DESCRIPTION
Complements https://github.com/DUNE/ND_CAFMaker/pull/99 (which should be merged first). Linked to https://github.com/DUNE/ndlar_flow/pull/195 and https://github.com/PandoraPFA/LArRecoND/pull/40.

- ~Fix compiler error in TMS filler now that trigger type is an enum~ (no longer necessary)
- ~Set Pandora trigger type properly~ (done in #99)
- Use the new `unix_time_usec` for Pandora trigger times. This makes it possible to match with Mx2 triggers using a < 5ms window. 