### PR TITLE
Unique match reco filler check cheated vectors nonempty

### DIFF
--- a/src/reco/NDLArTMSUniqueMatchRecoFiller.cxx
+++ b/src/reco/NDLArTMSUniqueMatchRecoFiller.cxx
@@ -226,8 +226,19 @@ namespace cafmaker
       if (use_time) {
         // this handles time-based matching - using truth-level particle times for now instead of light in LAr
         
+	bool timeFail = false;
 	std::vector<float> tOv = trk.truthOverlap;
 	std::vector<caf::TrueParticleID> truIDs = trk.truth;
+	if (tOv.size() == 0) {
+	  timeFail = true;
+	}
+	if (truIDs.size() == 0) {
+	  timeFail = true;
+	}
+	if (truIDs.size() != tOv.size()) {
+	  timeFail = true;
+	}
+	if (!timeFail) {
 	int idx_max = std::distance(tOv.begin(),std::max_element(tOv.begin(),tOv.end()));
 	caf::TrueParticleID partID = truIDs[idx_max]; // ID of true particle that makes up the majority of the track
 	const auto& matchedPart = FindParticle(sr.mc,partID); // gets the particle object corresponding to the ID
@@ -239,19 +250,21 @@ namespace cafmaker
           delta_t = tms_time - lar_time;
           matchScore += pow((delta_t-mean_t)/sigma_t,2); // adds the time difference term to the matchScore
 	  // Following code is for checking if the particle IDs for matching tracks themselves match. This allows you to identify true matches
-	  // std::vector<float> tOvTMS = tms_trk.truthOverlap;
-	  // std::vector<caf::TrueParticleID> truIDsTMS = tms_trk.truth;
-	  // int idx_max_TMS = std::distance(tOvTMS.begin(),std::max_element(tOvTMS.begin(),tOvTMS.end()));
-	  // caf::TrueParticleID partIDTMS = truIDsTMS[idx_max_TMS];
-	  // const auto& TMSPart = FindParticle(sr.mc,partIDTMS);
+	  std::vector<float> tOvTMS = tms_trk.truthOverlap;
+	  std::vector<caf::TrueParticleID> truIDsTMS = tms_trk.truth;
+	  int idx_max_TMS = std::distance(tOvTMS.begin(),std::max_element(tOvTMS.begin(),tOvTMS.end()));
+	  caf::TrueParticleID partIDTMS = truIDsTMS[idx_max_TMS];
+	  const auto& TMSPart = FindParticle(sr.mc,partIDTMS);
 	  // TODO: Right now the partIDTMS values are nonsensical and the TMSPart->G4ID is always a null pointer. There are problems bringing TMS truth info into ND-CAFMaker
 	  // Uncomment the following once this has been fixed
-	  //if (TMSPart != nullptr) {
-	    //if (matchedPart->G4ID==TMSPart->G4ID) {
-		// TODO: Add "TrueMatch" boolean attribute to SRNDTrackAssn object and set to true if these G4IDs match 
-	      // }
-	  //  }
+	  if (TMSPart != nullptr) {
+	    if (matchedPart->G4ID==TMSPart->G4ID) {
+		// TODO: Add "TrueMatch" boolean attribute to the TrackAssn and set to true
+		std::cout << "True Match!" << std::endl; 
+	       }
+	    }
      	 }
+	}
       }
 
       caf::SRTMSID tmsid;

--- a/src/reco/NDLArTMSUniqueMatchRecoFiller.cxx
+++ b/src/reco/NDLArTMSUniqueMatchRecoFiller.cxx
@@ -229,7 +229,7 @@ namespace cafmaker
 	bool timeFail = false;
 	std::vector<float> tOv = trk.truthOverlap;
 	std::vector<caf::TrueParticleID> truIDs = trk.truth;
-	if (tOv.size() == 0) {
+	if (tOv.empty()) {
 	  timeFail = true;
 	}
 	if (truIDs.size() == 0) {

--- a/src/reco/NDLArTMSUniqueMatchRecoFiller.cxx
+++ b/src/reco/NDLArTMSUniqueMatchRecoFiller.cxx
@@ -260,7 +260,7 @@ namespace cafmaker
 	  if (TMSPart != nullptr) {
 	    if (matchedPart->G4ID==TMSPart->G4ID) {
 		// TODO: Add "TrueMatch" boolean attribute to the TrackAssn and set to true
-		std::cout << "True Match!" << std::endl; 
+		// std::cout << "True Match!" << std::endl; 
 	       }
 	    }
      	 }

--- a/src/reco/NDLArTMSUniqueMatchRecoFiller.cxx
+++ b/src/reco/NDLArTMSUniqueMatchRecoFiller.cxx
@@ -232,7 +232,7 @@ namespace cafmaker
 	if (tOv.empty()) {
 	  timeFail = true;
 	}
-	if (truIDs.size() == 0) {
+	if (truIDs.empty()) {
 	  timeFail = true;
 	}
 	if (truIDs.size() != tOv.size()) {


### PR DESCRIPTION
Added check that the truth overlap and truth id arrays for a LAr track are nonempty (and equal in length) before attempting to carry out the cheated matching