### PR TITLE
129 fill new reco object parent and corresponding reco particle fields

### DIFF
--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -117,6 +117,23 @@ namespace cafmaker
 
   }
 
+  // ------------------------------------------------------------------------------
+  // helper class to map from SPINE track ID to (sr.common.ixn.dlp, sr.common.ixn.dlp.part.dlp) indices for the corresponding SRRecoParticle
+  caf::SRRecoParticleID MLNDLArRecoBranchFiller::MLNDLArRecoParticleMapper::GetRecoParticleID(int64_t partID) const
+  {
+    if(fParticleMap.find(partID) == fParticleMap.end())
+    {
+      LOG.FATAL() << "MLNDLArRecoParticleMapper: could not find particle ID " << partID << " in the particle map! Abort.\n";
+      abort();
+    }
+    auto [ixn_idx, prt_idx] = fParticleMap.at(partID);
+    return caf::SRRecoParticleID{ixn_idx, caf::SRRecoParticleID::SRRecoParticleCollectionType::kSPINE, prt_idx};
+  }
+
+  caf::SRRecoParticle& MLNDLArRecoBranchFiller::MLNDLArRecoParticleMapper::GetRecoParticle(caf::StandardRecord & sr, size_t ixn_idx, size_t prt_idx) const
+  {
+    return sr.common.ixn.dlp[ixn_idx].part.dlp[prt_idx];
+  }
 
   // ------------------------------------------------------------------------------
   // todo: possibly build some mechanism for customizing the dataset names in the file here
@@ -173,7 +190,7 @@ namespace cafmaker
     sr.meta.lar2x2.readoutstart_ns = trigger.triggerTime_ns;
     
     // reset the map of SPINE particle ID to (sr.common.ixn.dlp, sr.common.ixn.dlp.part.dlp) indices for this entry
-    fParticleMap.clear();
+    fParticleMapper.Reset();
 
     H5DataView<cafmaker::types::dlp::Interaction> interactions = fDSReader.GetProducts<cafmaker::types::dlp::Interaction>(idx);
     H5DataView<cafmaker::types::dlp::TrueInteraction> trueInteractions = fDSReader.GetProducts<cafmaker::types::dlp::TrueInteraction>(idx);
@@ -579,7 +596,7 @@ namespace cafmaker
       // index of the particle within the sr.common.ixn.dlp.part.dlp vector
       auto prt_idx = sr.common.ixn.dlp[ixn_idx].part.dlp.size();
       // save the indices for this particle so we can get it back later
-      fParticleMap[part.id] = std::make_pair(ixn_idx, prt_idx);
+      fParticleMapper[part.id] = {ixn_idx, prt_idx};
       // fill the reco particle
       sr.common.ixn.dlp[ixn_idx].part.dlp.push_back(std::move(reco_particle));
       sr.common.ixn.dlp[ixn_idx].part.ndlp++;
@@ -702,11 +719,9 @@ namespace cafmaker
       // index of the track within the sr.nd.lar.dlp[ixn_idx].tracks vector (i.e., the number of tracks already there, since we're about to add this one)
       auto trk_idx = sr.nd.lar.dlp[ixn_idx].tracks.size();
       // fill the SRRecoParticleID info
-      track.part.ixn = fParticleMap.at(part.id).first; // this is the index of the interaction within the sr.common.ixn.dlp vector
-      track.part.ipart = fParticleMap.at(part.id).second; // this is the index within the vector of particles for this interaction
-      track.part.type = caf::SRRecoParticleID::SRRecoParticleCollectionType::kSPINE;
+      track.part = fParticleMapper.GetRecoParticleID(part.id);
       // get a reference to the right SRRecoParticle and update its recoobj info
-      auto &srPart = sr.common.ixn.dlp.at(fParticleMap.at(part.id).first).part.dlp.at(fParticleMap.at(part.id).second);
+      auto &srPart = fParticleMapper.GetRecoParticle(sr, ixn_idx, trk_idx);
       srPart.recoobj.ixn = ixn_idx;
       srPart.recoobj.irecoobj = trk_idx;
       srPart.recoobj.type = caf::SRRecoBaseID::SRRecoBaseCollectionType::kNDLArDLPTrack;
@@ -816,11 +831,9 @@ namespace cafmaker
       // index of the shower within the sr.nd.lar.dlp[ixn_idx].showers vector (i.e., the number of showers already there, since we're about to add this one)
       auto shw_idx = sr.nd.lar.dlp[ixn_idx].showers.size();
       // fill the SRRecoParticleID info
-      shower.part.ixn = fParticleMap.at(part.id).first; // this is the index of the interaction within the sr.common.ixn.dlp vector
-      shower.part.ipart = fParticleMap.at(part.id).second; // this is the index within the vector of particles for this interaction
-      shower.part.type = caf::SRRecoParticleID::SRRecoParticleCollectionType::kSPINE;
+      shower.part.ixn = fParticleMapper.GetRecoParticleID(part.id);
       // get a reference to the right SRRecoParticle and update its recoobj info
-      auto &srPart = sr.common.ixn.dlp.at(fParticleMap.at(part.id).first).part.dlp.at(fParticleMap.at(part.id).second);
+      auto &srPart = fParticleMapper.GetRecoParticle(sr, ixn_idx, shw_idx);
       srPart.recoobj.ixn = ixn_idx;
       srPart.recoobj.irecoobj = shw_idx;
       srPart.recoobj.type = caf::SRRecoBaseID::SRRecoBaseCollectionType::kNDLArDLPShower;

--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -127,7 +127,7 @@ namespace cafmaker
       abort();
     }
     auto [ixn_idx, prt_idx] = fParticleMap.at(partID);
-    return caf::SRRecoParticleID{ixn_idx, caf::SRRecoParticleID::SRRecoParticleCollectionType::kSPINE, prt_idx};
+    return caf::SRRecoParticleID{static_cast<int>(ixn_idx), caf::SRRecoParticleID::SRRecoParticleCollectionType::kSPINE, static_cast<int>(prt_idx)};
   }
 
   caf::SRRecoParticle& MLNDLArRecoBranchFiller::MLNDLArRecoParticleMapper::GetRecoParticle(caf::StandardRecord & sr, size_t ixn_idx, size_t prt_idx) const
@@ -831,7 +831,7 @@ namespace cafmaker
       // index of the shower within the sr.nd.lar.dlp[ixn_idx].showers vector (i.e., the number of showers already there, since we're about to add this one)
       auto shw_idx = sr.nd.lar.dlp[ixn_idx].showers.size();
       // fill the SRRecoParticleID info
-      shower.part.ixn = fParticleMapper.GetRecoParticleID(part.id);
+      shower.part = fParticleMapper.GetRecoParticleID(part.id);
       // get a reference to the right SRRecoParticle and update its recoobj info
       auto &srPart = fParticleMapper.GetRecoParticle(sr, ixn_idx, shw_idx);
       srPart.recoobj.ixn = ixn_idx;
@@ -840,7 +840,6 @@ namespace cafmaker
       // fill the shower branch
       sr.nd.lar.dlp[ixn_idx].showers.push_back(std::move(shower));
       sr.nd.lar.dlp[ixn_idx].nshowers++;
-
     }
   }
 

--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -118,7 +118,9 @@ namespace cafmaker
   }
 
   // ------------------------------------------------------------------------------
-  // helper class to map from SPINE track ID to (sr.common.ixn.dlp, sr.common.ixn.dlp.part.dlp) indices for the corresponding SRRecoParticle
+  // Helper class to map from SPINE track ID to (sr.common.ixn.dlp, sr.common.ixn.dlp.part.dlp) indices for the corresponding SRRecoParticle
+  // This method is `const` because it applies to the _mapper_--- we're not changing the mapping---  
+  // but the returned instance is part of the SR itself and can be modified  
   caf::SRRecoParticleID MLNDLArRecoBranchFiller::MLNDLArRecoParticleMapper::GetRecoParticleID(int64_t partID) const
   {
     if(fParticleMap.find(partID) == fParticleMap.end())

--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -696,6 +696,7 @@ namespace cafmaker
         LOG.FATAL() << "Particle's interaction ID (" << part.interaction_id << ") does not match any in the DLP set!\n";
         abort();
       }
+      
       // index of the interaction within the sr.common.ixn.dlp vector
       auto ixn_idx = std::distance(sr.common.ixn.dlp.begin(), itIxn);
       // index of the track within the sr.nd.lar.dlp[ixn_idx].tracks vector (i.e., the number of tracks already there, since we're about to add this one)
@@ -809,8 +810,23 @@ namespace cafmaker
         LOG.FATAL() << "Particle's interaction ID (" << part.interaction_id << ") does not match any in the DLP set!\n";
         abort();
       }
-      sr.nd.lar.dlp[std::distance(sr.common.ixn.dlp.begin(), itIxn)].showers.push_back(std::move(shower));
-      sr.nd.lar.dlp[std::distance(sr.common.ixn.dlp.begin(), itIxn)].nshowers++;
+      
+      // index of the interaction within the sr.common.ixn.dlp vector
+      auto ixn_idx = std::distance(sr.common.ixn.dlp.begin(), itIxn);
+      // index of the shower within the sr.nd.lar.dlp[ixn_idx].showers vector (i.e., the number of showers already there, since we're about to add this one)
+      auto shw_idx = sr.nd.lar.dlp[ixn_idx].showers.size();
+      // fill the SRRecoParticleID info
+      shower.part.ixn = fParticleMap.at(part.id).first; // this is the index of the interaction within the sr.common.ixn.dlp vector
+      shower.part.ipart = fParticleMap.at(part.id).second; // this is the index within the vector of particles for this interaction
+      shower.part.type = caf::SRRecoParticleID::SRRecoParticleCollectionType::kSPINE;
+      // get a reference to the right SRRecoParticle and update its recoobj info
+      auto &srPart = sr.common.ixn.dlp.at(fParticleMap.at(part.id).first).part.dlp.at(fParticleMap.at(part.id).second);
+      srPart.recoobj.ixn = ixn_idx;
+      srPart.recoobj.irecoobj = shw_idx;
+      srPart.recoobj.type = caf::SRRecoBaseID::SRRecoBaseCollectionType::kNDLArDLPShower;
+      // fill the shower branch
+      sr.nd.lar.dlp[ixn_idx].showers.push_back(std::move(shower));
+      sr.nd.lar.dlp[ixn_idx].nshowers++;
 
     }
   }

--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -132,7 +132,17 @@ namespace cafmaker
 
   caf::SRRecoParticle& MLNDLArRecoBranchFiller::MLNDLArRecoParticleMapper::GetRecoParticle(caf::StandardRecord & sr, size_t ixn_idx, size_t prt_idx) const
   {
-    return sr.common.ixn.dlp[ixn_idx].part.dlp[prt_idx];
+    if(ixn_idx >= sr.common.ixn.dlp.size())
+    {
+      LOG.FATAL() << "MLNDLArRecoParticleMapper: interaction index " << ixn_idx << " is out of range for sr.common.ixn.dlp with size " << sr.common.ixn.dlp.size() << "! Abort.\n";
+      abort();
+    }
+    if(prt_idx >= sr.common.ixn.dlp.at(ixn_idx).part.dlp.size())
+    {
+      LOG.FATAL() << "MLNDLArRecoParticleMapper: particle index " << prt_idx << " is out of range for sr.common.ixn.dlp[" << ixn_idx << "].part.dlp with size " << sr.common.ixn.dlp.at(ixn_idx).part.dlp.size() << "! Abort.\n";
+      abort();
+    }
+    return sr.common.ixn.dlp.at(ixn_idx).part.dlp.at(prt_idx);
   }
 
   // ------------------------------------------------------------------------------

--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -130,8 +130,15 @@ namespace cafmaker
     return caf::SRRecoParticleID{static_cast<int>(ixn_idx), caf::SRRecoParticleID::SRRecoParticleCollectionType::kSPINE, static_cast<int>(prt_idx)};
   }
 
-  caf::SRRecoParticle& MLNDLArRecoBranchFiller::MLNDLArRecoParticleMapper::GetRecoParticle(caf::StandardRecord & sr, size_t ixn_idx, size_t prt_idx) const
+  caf::SRRecoParticle& MLNDLArRecoBranchFiller::MLNDLArRecoParticleMapper::GetRecoParticle(caf::StandardRecord & sr, int64_t partID) const
   {
+    if(fParticleMap.find(partID) == fParticleMap.end())
+    {
+      LOG.FATAL() << "MLNDLArRecoParticleMapper: could not find particle ID " << partID << " in the particle map! Abort.\n";
+      abort();
+    }
+    auto [ixn_idx, prt_idx] = fParticleMap.at(partID);
+
     if(ixn_idx >= sr.common.ixn.dlp.size())
     {
       LOG.FATAL() << "MLNDLArRecoParticleMapper: interaction index " << ixn_idx << " is out of range for sr.common.ixn.dlp with size " << sr.common.ixn.dlp.size() << "! Abort.\n";
@@ -731,7 +738,7 @@ namespace cafmaker
       // fill the SRRecoParticleID info
       track.part = fParticleMapper.GetRecoParticleID(part.id);
       // get a reference to the right SRRecoParticle and update its recoobj info
-      auto &srPart = fParticleMapper.GetRecoParticle(sr, ixn_idx, trk_idx);
+      auto &srPart = fParticleMapper.GetRecoParticle(sr, part.id);
       srPart.recoobj.ixn = ixn_idx;
       srPart.recoobj.irecoobj = trk_idx;
       srPart.recoobj.type = caf::SRRecoBaseID::SRRecoBaseCollectionType::kNDLArDLPTrack;
@@ -843,7 +850,7 @@ namespace cafmaker
       // fill the SRRecoParticleID info
       shower.part = fParticleMapper.GetRecoParticleID(part.id);
       // get a reference to the right SRRecoParticle and update its recoobj info
-      auto &srPart = fParticleMapper.GetRecoParticle(sr, ixn_idx, shw_idx);
+      auto &srPart = fParticleMapper.GetRecoParticle(sr, part.id);
       srPart.recoobj.ixn = ixn_idx;
       srPart.recoobj.irecoobj = shw_idx;
       srPart.recoobj.type = caf::SRRecoBaseID::SRRecoBaseCollectionType::kNDLArDLPShower;

--- a/src/reco/MLNDLArRecoBranchFiller.cxx
+++ b/src/reco/MLNDLArRecoBranchFiller.cxx
@@ -171,6 +171,9 @@ namespace cafmaker
     
     sr.meta.lar2x2.readoutstart_s = trigger.triggerTime_s;
     sr.meta.lar2x2.readoutstart_ns = trigger.triggerTime_ns;
+    
+    // reset the map of SPINE particle ID to (sr.common.ixn.dlp, sr.common.ixn.dlp.part.dlp) indices for this entry
+    fParticleMap.clear();
 
     H5DataView<cafmaker::types::dlp::Interaction> interactions = fDSReader.GetProducts<cafmaker::types::dlp::Interaction>(idx);
     H5DataView<cafmaker::types::dlp::TrueInteraction> trueInteractions = fDSReader.GetProducts<cafmaker::types::dlp::TrueInteraction>(idx);
@@ -571,8 +574,15 @@ namespace cafmaker
         LOG.FATAL() << "Particle's interaction ID (" << part.interaction_id << ") does not match any in the DLP set!\n";
         abort();
       }
-      sr.common.ixn.dlp[std::distance(sr.common.ixn.dlp.begin(), itIxn)].part.dlp.push_back(std::move(reco_particle));
-      sr.common.ixn.dlp[std::distance(sr.common.ixn.dlp.begin(), itIxn)].part.ndlp++;
+      // index of the interaction within the sr.common.ixn.dlp vector
+      auto ixn_idx = std::distance(sr.common.ixn.dlp.begin(), itIxn);
+      // index of the particle within the sr.common.ixn.dlp.part.dlp vector
+      auto prt_idx = sr.common.ixn.dlp[ixn_idx].part.dlp.size();
+      // save the indices for this particle so we can get it back later
+      fParticleMap[part.id] = std::make_pair(ixn_idx, prt_idx);
+      // fill the reco particle
+      sr.common.ixn.dlp[ixn_idx].part.dlp.push_back(std::move(reco_particle));
+      sr.common.ixn.dlp[ixn_idx].part.ndlp++;
 
     }
   }
@@ -686,8 +696,22 @@ namespace cafmaker
         LOG.FATAL() << "Particle's interaction ID (" << part.interaction_id << ") does not match any in the DLP set!\n";
         abort();
       }
-      sr.nd.lar.dlp[std::distance(sr.common.ixn.dlp.begin(), itIxn)].tracks.push_back(std::move(track));
-      sr.nd.lar.dlp[std::distance(sr.common.ixn.dlp.begin(), itIxn)].ntracks++;
+      // index of the interaction within the sr.common.ixn.dlp vector
+      auto ixn_idx = std::distance(sr.common.ixn.dlp.begin(), itIxn);
+      // index of the track within the sr.nd.lar.dlp[ixn_idx].tracks vector (i.e., the number of tracks already there, since we're about to add this one)
+      auto trk_idx = sr.nd.lar.dlp[ixn_idx].tracks.size();
+      // fill the SRRecoParticleID info
+      track.part.ixn = fParticleMap.at(part.id).first; // this is the index of the interaction within the sr.common.ixn.dlp vector
+      track.part.ipart = fParticleMap.at(part.id).second; // this is the index within the vector of particles for this interaction
+      track.part.type = caf::SRRecoParticleID::SRRecoParticleCollectionType::kSPINE;
+      // get a reference to the right SRRecoParticle and update its recoobj info
+      auto &srPart = sr.common.ixn.dlp.at(fParticleMap.at(part.id).first).part.dlp.at(fParticleMap.at(part.id).second);
+      srPart.recoobj.ixn = ixn_idx;
+      srPart.recoobj.irecoobj = trk_idx;
+      srPart.recoobj.type = caf::SRRecoBaseID::SRRecoBaseCollectionType::kNDLArDLPTrack;
+      // fill the track branch
+      sr.nd.lar.dlp[ixn_idx].tracks.push_back(std::move(track));
+      sr.nd.lar.dlp[ixn_idx].ntracks++;
     }
   }
 

--- a/src/reco/MLNDLArRecoBranchFiller.h
+++ b/src/reco/MLNDLArRecoBranchFiller.h
@@ -87,7 +87,8 @@ namespace cafmaker
       mutable decltype(fTriggers)::const_iterator  fLastTriggerReqd;    ///< the last trigger requested using _FillRecoBranches()
       mutable std::map<int, int> fEntryMap; //Map of the filtered trigger entries stored in the caf file
 
-      class MLNDLArRecoParticleMapper: public Loggable {
+      class MLNDLArRecoParticleMapper: public Loggable 
+      {
         ///< helper class to map from SPINE track ID to (sr.common.ixn.dlp, sr.common.ixn.dlp.part.dlp) indices for the corresponding SRRecoParticle
         public:
           MLNDLArRecoParticleMapper(cafmaker::Logger::THRESHOLD logThresh=cafmaker::Logger::THRESHOLD::WARNING) : Loggable("MLNDLArRecoParticleMapper", logThresh) {}
@@ -95,8 +96,6 @@ namespace cafmaker
           caf::SRRecoParticleID GetRecoParticleID(int64_t partID) const;
 
           caf::SRRecoParticle& GetRecoParticle(caf::StandardRecord & sr, int64_t partID) const;
-
-          std::pair<size_t, size_t>& operator[](int64_t partID) { return fParticleMap[partID]; }
 
           void Reset() { fParticleMap.clear(); }
 

--- a/src/reco/MLNDLArRecoBranchFiller.h
+++ b/src/reco/MLNDLArRecoBranchFiller.h
@@ -94,7 +94,7 @@ namespace cafmaker
 
           caf::SRRecoParticleID GetRecoParticleID(int64_t partID) const;
 
-          caf::SRRecoParticle& GetRecoParticle(caf::StandardRecord & sr, size_t ixn_idx, size_t prt_idx) const;
+          caf::SRRecoParticle& GetRecoParticle(caf::StandardRecord & sr, int64_t partID) const;
 
           std::pair<size_t, size_t>& operator[](int64_t partID) { return fParticleMap[partID]; }
 

--- a/src/reco/MLNDLArRecoBranchFiller.h
+++ b/src/reco/MLNDLArRecoBranchFiller.h
@@ -87,19 +87,47 @@ namespace cafmaker
       mutable decltype(fTriggers)::const_iterator  fLastTriggerReqd;    ///< the last trigger requested using _FillRecoBranches()
       mutable std::map<int, int> fEntryMap; //Map of the filtered trigger entries stored in the caf file
 
+      /// @brief Helper class to map from SPINE track ID to SRRecoParticle indices
+      ///
+      /// This mapper maintains a mapping between SPINE track IDs (from the ML reconstruction)
+      /// and the corresponding indices in the CAF StandardRecord:
+      /// - The interaction index in sr.common.ixn.dlp
+      /// - The particle index in sr.common.ixn.dlp.part.dlp
+      ///
+      /// It is used to establish the linkage between low-level SPINE reconstruction
+      /// and high-level SRRecoParticle objects in the CAF format.
       class MLNDLArRecoParticleMapper: public Loggable 
       {
-        ///< helper class to map from SPINE track ID to (sr.common.ixn.dlp, sr.common.ixn.dlp.part.dlp) indices for the corresponding SRRecoParticle
+        /// @brief Construct a new mapper with optional logging threshold
+        /// @param logThresh Logging threshold (default: WARNING)
         public:
           MLNDLArRecoParticleMapper(cafmaker::Logger::THRESHOLD logThresh=cafmaker::Logger::THRESHOLD::WARNING) : Loggable("MLNDLArRecoParticleMapper", logThresh) {}
 
+          /// @brief Get the SRRecoParticleID for a given SPINE track ID
+          /// @param partID The SPINE track ID from ML reconstruction
+          /// @return SRRecoParticleID containing the interaction index, collection type (kSPINE), and particle index
+          ///
+          /// @note This function will FATAL log and abort if the track ID is not found in the map.
           caf::SRRecoParticleID GetRecoParticleID(int64_t partID) const;
 
+          /// @brief Get a reference to the SRRecoParticle for a given SPINE track ID
+          /// @param sr The StandardRecord containing the reconstructed data
+          /// @param partID The SPINE track ID from ML reconstruction
+          /// @return Reference to the corresponding SRRecoParticle
+          ///
+          /// @note This function will FATAL log and abort if the track ID is not found in the map.
           caf::SRRecoParticle& GetRecoParticle(caf::StandardRecord & sr, int64_t partID) const;
 
+          /// @brief Access or create a mapping for a SPINE track ID
+          /// @param partID The SPINE track ID from ML reconstruction
+          /// @return Reference to the (ixn_idx, prt_idx) pair
+          std::pair<size_t, size_t>& operator[](int64_t partID) { return fParticleMap[partID]; }
+
+          /// @brief Clear all particle mappings
           void Reset() { fParticleMap.clear(); }
 
         private:
+          /// @brief Internal map from SPINE track ID to (interaction index, particle index) pairs
           std::map<int64_t, std::pair<size_t, size_t>> fParticleMap;
       };
 

--- a/src/reco/MLNDLArRecoBranchFiller.h
+++ b/src/reco/MLNDLArRecoBranchFiller.h
@@ -20,6 +20,8 @@ namespace caf
 {
   class SRTrueInteraction;
   class SRTrueParticle;
+  class SRRecoParticleID;
+  class SRRecoParticle;
 }
 
 namespace cafmaker
@@ -84,7 +86,25 @@ namespace cafmaker
       mutable std::vector<cafmaker::Trigger> fTriggers;
       mutable decltype(fTriggers)::const_iterator  fLastTriggerReqd;    ///< the last trigger requested using _FillRecoBranches()
       mutable std::map<int, int> fEntryMap; //Map of the filtered trigger entries stored in the caf file
-      mutable std::map<int64_t, std::pair<size_t, size_t>> fParticleMap; ///< key: input SPINE particle ID (used as unique key), value: pair of indices in (sr.common.ixn.dlp, sr.common.ixn.dlp.part.dlp) vectors; main purpose is to enable linkage between low-level <-> high-level recoobjects
+
+      class MLNDLArRecoParticleMapper: public Loggable {
+        ///< helper class to map from SPINE track ID to (sr.common.ixn.dlp, sr.common.ixn.dlp.part.dlp) indices for the corresponding SRRecoParticle
+        public:
+          MLNDLArRecoParticleMapper(cafmaker::Logger::THRESHOLD logThresh=cafmaker::Logger::THRESHOLD::WARNING) : Loggable("MLNDLArRecoParticleMapper", logThresh) {}
+
+          caf::SRRecoParticleID GetRecoParticleID(int64_t partID) const;
+
+          caf::SRRecoParticle& GetRecoParticle(caf::StandardRecord & sr, size_t ixn_idx, size_t prt_idx) const;
+
+          std::pair<size_t, size_t>& operator[](int64_t partID) { return fParticleMap[partID]; }
+
+          void Reset() { fParticleMap.clear(); }
+
+        private:
+          std::map<int64_t, std::pair<size_t, size_t>> fParticleMap;
+      };
+
+      mutable MLNDLArRecoParticleMapper fParticleMapper; ///< helper object to map from SPINE track ID to (sr.common.ixn.dlp, sr.common.ixn.dlp.part.dlp) indices for the corresponding SRRecoParticle
 
       
   };  // class MLNDLArRecoBranchFiller

--- a/src/reco/MLNDLArRecoBranchFiller.h
+++ b/src/reco/MLNDLArRecoBranchFiller.h
@@ -84,7 +84,7 @@ namespace cafmaker
       mutable std::vector<cafmaker::Trigger> fTriggers;
       mutable decltype(fTriggers)::const_iterator  fLastTriggerReqd;    ///< the last trigger requested using _FillRecoBranches()
       mutable std::map<int, int> fEntryMap; //Map of the filtered trigger entries stored in the caf file
-      
+      mutable std::map<int64_t, std::pair<size_t, size_t>> fParticleMap; ///< key: input SPINE particle ID (used as unique key), value: pair of indices in (sr.common.ixn.dlp, sr.common.ixn.dlp.part.dlp) vectors; main purpose is to enable linkage between low-level <-> high-level recoobjects
 
       
   };  // class MLNDLArRecoBranchFiller

--- a/src/reco/PandoraLArRecoNDBranchFiller.cxx
+++ b/src/reco/PandoraLArRecoNDBranchFiller.cxx
@@ -491,7 +491,6 @@ namespace cafmaker
     
     // now fill the SR reco particle
     caf::SRRecoParticle recoParticle;
-
     recoParticle.recoobj = recoBaseID;
 
     recoParticle.E = energy;
@@ -632,7 +631,13 @@ namespace cafmaker
 
       // Track reco particle
       caf::SRRecoParticle recoParticle;
-            
+
+      // Instantiate SRRecoParticleID and SRRecoBaseID
+      int ixn_idx = nuIndex;
+      int prt_idx = interaction.part.pandora.size(); // this will be the index of the particle in the interaction's particle vector after we add it
+      caf::SRRecoParticleID recoPartID{ixn_idx, caf::SRRecoParticleID::SRRecoParticleCollectionType::kPandora, prt_idx};
+      caf::SRRecoBaseID recoBaseID;
+
       // Truth info
       recoParticle.truth = truePartIDVect;
       recoParticle.truthOverlap = truthOverlap;
@@ -658,6 +663,10 @@ namespace cafmaker
           caf::SRTrack track;
           track.E = recoParticle.E;
           track.Evis = (m_trkfitVisE != nullptr) ? (*m_trkfitVisE)[i] : -999.;
+          
+          int robj_idx = sr.nd.lar.pandora[nuIndex].tracks.size(); // this will be the index of the track in the interaction's track vector after we add it
+          recoBaseID = {ixn_idx, caf::SRRecoBaseID::SRRecoBaseCollectionType::kNDLArPandoraTrack, robj_idx};
+          track.part = recoPartID;
 
           // Total number of 3D hits in the cluster
           const int n3DHits = (m_n3DHitsVect != nullptr) ? (*m_n3DHitsVect)[i] : 0;
@@ -694,6 +703,10 @@ namespace cafmaker
           FillShower(i, shower);
           shower.truth = truePartIDVect;
           shower.truthOverlap = truthOverlap;
+          
+          int robj_idx = sr.nd.lar.pandora[nuIndex].showers.size(); // this will be the index of the shower in the interaction's shower vector after we add it
+          recoBaseID = {ixn_idx, caf::SRRecoBaseID::SRRecoBaseCollectionType::kNDLARPandoraShower, robj_idx};
+          shower.part = recoPartID;
 
           recoParticle.E_method = caf::PartEMethod::kCalorimetry;
           recoParticle.start = shower.start;    
@@ -771,6 +784,9 @@ namespace cafmaker
         LOG.DEBUG() << "trackfit failed for particle number : " << i << ", assigning pdg 0\n";
         FillClusterDefault(sr, i, uniqueSliceIDs, nuInteractions, truthMatch, longestTrack, longestTrackDir, maxShowerE, maxShowerEDir);
       }
+      
+      // Set the recoobj ID for the particle
+      recoParticle.recoobj = recoBaseID;
 
       // Add particle to the interaction
       interaction.part.pandora.emplace_back(std::move(recoParticle));

--- a/src/reco/PandoraLArRecoNDBranchFiller.cxx
+++ b/src/reco/PandoraLArRecoNDBranchFiller.cxx
@@ -426,9 +426,19 @@ namespace cafmaker
     FillTruthInfo(iCluster, truthMatch, sr, truePartID);
     truePartIDVect.emplace_back(truePartID);
 
+    // Instantiate SRRecoParticleID and SRRecoBaseID
+    int ixn_idx = nuIndex;
+    int prt_idx = nuInteractions[nuIndex].part.pandora.size(); // this will be the index of the particle in the interaction's particle vector after we add it
+    caf::SRRecoParticleID recoPartID{ixn_idx, caf::SRRecoParticleID::SRRecoParticleCollectionType::kPandora, prt_idx};
+    caf::SRRecoBaseID recoBaseID;
+
     if (isShower) // fill sr shower
     {
       caf::SRShower shower;
+
+      int robj_idx = sr.nd.lar.pandora[nuIndex].showers.size(); // this will be the index of the shower in the interaction's shower vector after we add it
+      recoBaseID = {ixn_idx, caf::SRRecoBaseID::SRRecoBaseCollectionType::kNDLARPandoraShower, robj_idx};
+      shower.part = recoPartID;
 
       shower.start = start;
       shower.direction = dir;
@@ -451,6 +461,10 @@ namespace cafmaker
     else // fill sr track
     {
       caf::SRTrack track;
+
+      int robj_idx = sr.nd.lar.pandora[nuIndex].tracks.size(); // this will be the index of the track in the interaction's track vector after we add it
+      recoBaseID = {ixn_idx, caf::SRRecoBaseID::SRRecoBaseCollectionType::kNDLArPandoraTrack, robj_idx};
+      track.part = recoPartID;
 
       track.start = start;
       track.end = end;
@@ -477,6 +491,8 @@ namespace cafmaker
     
     // now fill the SR reco particle
     caf::SRRecoParticle recoParticle;
+
+    recoParticle.recoobj = recoBaseID;
 
     recoParticle.E = energy;
     recoParticle.E_method = caf::PartEMethod::kCalorimetry;


### PR DESCRIPTION
## Linkage between reco objects and SRRecoParticle (SPINE + Pandora)

### Summary
Implements bidirectional linkage between low-level reco objects (tracks/showers) and the corresponding `SRRecoParticle` in the `StandardRecord`, for both SPINE/DLP and Pandora. 

---

### Changes

**`MLNDLArRecoBranchFiller.h/.cxx`**
- Implemented new inner class `MLNDLArRecoParticleMapper`, which encapsulates the SPINE particle ID → `(ixn_idx, prt_idx)` mapping with a safe interface:
  - `GetRecoParticleID(partID)` — returns the corresponding `SRRecoParticleID`
  - `GetRecoParticle(sr, partID)` — returns a reference to the `SRRecoParticle`
  - `Reset()` — clears the map at the start of each event, before reading HDF5 products
- `track.part` and `shower.part` are now filled via `GetRecoParticleID(part.id)`
- `srPart.recoobj` is now filled for both tracks and showers with the correct `ixn_idx`, `robj_idx`, and collection type

**`PandoraLArRecoNDBranchFiller.cxx`**
- `SRRecoParticleID` and `SRRecoBaseID` are now constructed and filled in both `FillClusterDefault` and the main particle loop
- `track.part`, `shower.part`, and `recoParticle.recoobj` are set before the objects are pushed into their respective vectors

---

### Notes
- The SPINE/DLP implementation has been tested on real input files. The Pandora implementation compiles but could not be fully tested due to missing input files