### PR TITLE
bugfix

### DIFF
--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -672,7 +672,7 @@ namespace cafmaker
     if (it_tree->second->GetEntry(evtNum) == 0)
     {
       std::stringstream ss;
-      ss << "Event number " << evtNum << " was not found in run: " << runNum \n";
+      ss << "Event number " << evtNum << " was not found in run: " << runNum << "\n";
       LOG.FATAL() << ss.str();
       throw std::range_error(ss.str());
     }


### PR DESCRIPTION
I had incorrectly formatted the error‑reporting string in `void TruthMatcher::GTreeContainer::SelectEvent(unsigned long runNum, unsigned int evtNum)`. This should now be fixed. I managed to introduce a bug by changing just 7 lines of code, probably not a record, but notable anyway 😄