### PR TITLE
Fixes the connection between primary and secondary particles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/scripts/validate_caf_truth.py
+++ b/scripts/validate_caf_truth.py
@@ -3,11 +3,19 @@
 Validate CAF truth-particle parent/ancestor bookkeeping in one file.
 
 This is intentionally a PyROOT-side diagnostic script: it opens a CAF file,
-walks rec.mc.nu[*].sec[*], and checks that every secondary can be resolved
-through the stored G4 parent chain to the primary referenced by ancestor_id.
-It can also warn when secondary start positions are not near the immediate
-parent's endpoint, which is a useful sanity check for inelastic/cascade-like
-secondary production.
+walks rec.mc.nu[*].sec[*], validates that ancestor_id resolves to a sensible
+particle reference, and checks the CAF-visible part of the stored G4 parent
+chain when enough parent particles are present in the CAF.
+
+Important limitation: FillTruth.cxx computed ancestor_id with the full
+TG4Event trajectory list. The CAF only stores selected prim/sec/prefsi
+particles, so many intermediate parents can be missing from the CAF. Those
+cases are reported as unverified/inconclusive by default, not as failures.
+
+Endpoint checks are also diagnostic-only and opt-in. A secondary created by an
+inelastic interaction can start somewhere along the parent trajectory; with
+only CAF start/end positions, parent end_pos is not generally the production
+vertex.
 
 Examples
 --------
@@ -17,8 +25,8 @@ Examples
 # Look at one entry with verbose per-particle diagnostics
 ./validate_caf_truth.py file.root --event 12 --verbose
 
-# Treat endpoint mismatches as failures instead of warnings
-./validate_caf_truth.py file.root --strict-endpoint --endpoint-tol 0.05
+# Run the speculative endpoint diagnostic too
+./validate_caf_truth.py file.root --check-endpoints --endpoint-tol 0.05
 """
 
 import argparse
@@ -51,8 +59,10 @@ parser.add_argument("-l", "--sr-lib-name", default="libduneanaobj_StandardRecord
 parser.add_argument("-L", "--sr-lib-dir", help="Colon-separated directories to prepend to LD_LIBRARY_PATH")
 parser.add_argument("-e", "--event", type=int, action="append", help="Specific tree entry to validate (repeatable)")
 parser.add_argument("-n", "--nevents", type=int, default=-1, help="Maximum number of entries to scan")
+parser.add_argument("--check-endpoints", action="store_true", help="Run diagnostic parent end_pos vs child start_pos checks")
 parser.add_argument("--endpoint-tol", type=float, default=0.1, help="Parent endpoint vs child start tolerance in cm (default: 0.1)")
-parser.add_argument("--strict-endpoint", action="store_true", help="Count endpoint mismatches as errors instead of warnings")
+parser.add_argument("--strict-endpoint", action="store_true", help="Run endpoint checks and count mismatches as errors instead of warnings")
+parser.add_argument("--strict-caf-chain", action="store_true", help="Require every CAF secondary parent chain to be fully present in the CAF")
 parser.add_argument("--allow-cross-ixn", action="store_true", help="Allow ancestor_id.ixn to point to a different interaction")
 parser.add_argument("--max-report", type=int, default=50, help="Maximum issues to print before suppressing details")
 parser.add_argument("--verbose", action="store_true", help="Print per-secondary trace details")
@@ -277,10 +287,18 @@ def validate_entry(root, entry, reports, counters):
                     anc_txt = f"{anc_coll}[{anc_idx}] G4ID={int(anc_part.G4ID)} pdg={int(anc_part.pdg)}"
                 print(f"TRACE: entry {entry} ixn {ixn_idx} sec[{sec_idx}] G4ID={int(sec.G4ID)}: {trace_txt}; ancestor={anc_txt}; status={status}")
 
+            if anc_ref is not None:
+                counters["ancestor_ref_resolved"] += 1
+
             if status != "ok":
                 counters[f"trace_{status}"] += 1
-                issue(reports, "ERROR", entry, ixn_idx, "sec", sec_idx,
-                      f"could not trace parent chain to a primary: status={status}, trace={trace}")
+                if status == "missing-parent" and anc_ref is not None and not args.strict_caf_chain:
+                    counters["ancestor_unverified_missing_parent"] += 1
+                    issue(reports, "INFO", entry, ixn_idx, "sec", sec_idx,
+                          f"CAF parent chain is incomplete, so ancestor_id cannot be independently checked from CAF alone: trace={trace}")
+                else:
+                    issue(reports, "ERROR", entry, ixn_idx, "sec", sec_idx,
+                          f"could not trace parent chain to a primary: status={status}, trace={trace}")
                 continue
 
             primary_coll, primary_idx, primary_part = primary
@@ -298,42 +316,45 @@ def validate_entry(root, entry, reports, counters):
             else:
                 counters["ancestor_ok"] += 1
 
-            parent_tuple = g4_index.get(int(sec.parent))
-            if parent_tuple is not None:
-                parent_coll, parent_idx, parent_part = parent_tuple
-                parent_end = vec3_tuple(parent_part.end_pos)
-                child_start = vec3_tuple(sec.start_pos)
-                d = dist(parent_end, child_start)
-                if is_finite_vec(parent_end) and is_finite_vec(child_start) and d > args.endpoint_tol:
-                    counters["endpoint_mismatch"] += 1
-                    level = "ERROR" if args.strict_endpoint else "WARN"
-                    issue(reports, level, entry, ixn_idx, "sec", sec_idx,
-                          f"child start is {d:.6g} cm from immediate parent endpoint "
-                          f"({parent_coll}[{parent_idx}] G4ID={int(parent_part.G4ID)}); "
-                          f"parent_end={parent_end}, child_start={child_start}")
-                else:
-                    counters["endpoint_ok"] += 1
+            if args.check_endpoints or args.strict_endpoint:
+                parent_tuple = g4_index.get(int(sec.parent))
+                if parent_tuple is not None:
+                    parent_coll, parent_idx, parent_part = parent_tuple
+                    parent_end = vec3_tuple(parent_part.end_pos)
+                    child_start = vec3_tuple(sec.start_pos)
+                    d = dist(parent_end, child_start)
+                    if is_finite_vec(parent_end) and is_finite_vec(child_start) and d > args.endpoint_tol:
+                        counters["endpoint_mismatch"] += 1
+                        level = "ERROR" if args.strict_endpoint else "WARN"
+                        issue(reports, level, entry, ixn_idx, "sec", sec_idx,
+                              f"child start is {d:.6g} cm from immediate parent endpoint "
+                              f"({parent_coll}[{parent_idx}] G4ID={int(parent_part.G4ID)}); "
+                              f"parent_end={parent_end}, child_start={child_start}")
+                    else:
+                        counters["endpoint_ok"] += 1
 
-        # A compact parent-level endpoint check for inelastic/cascade-like vertices:
-        # if a particle has multiple secondary children, their starts should be
-        # mutually clustered near the parent's endpoint. This is warning-only
-        # unless --strict-endpoint is set, same as the per-child check above.
-        for parent_g4id, children in children_by_parent.items():
-            if parent_g4id < 0 or len(children) < 2 or parent_g4id not in g4_index:
-                continue
-            parent_coll, parent_idx, parent_part = g4_index[parent_g4id]
-            parent_end = vec3_tuple(parent_part.end_pos)
-            far = []
-            for child_idx, child in children:
-                d = dist(parent_end, vec3_tuple(child.start_pos))
-                if math.isfinite(d) and d > args.endpoint_tol:
-                    far.append((child_idx, int(child.G4ID), d))
-            if far:
-                counters["multi_child_endpoint_mismatch"] += 1
-                level = "ERROR" if args.strict_endpoint else "WARN"
-                issue(reports, level, entry, ixn_idx, parent_coll, parent_idx,
-                      f"parent G4ID={parent_g4id} has {len(children)} secondary children; "
-                      f"{len(far)} are farther than {args.endpoint_tol} cm from endpoint: {far[:8]}")
+        if args.check_endpoints or args.strict_endpoint:
+            # A compact parent-level endpoint check for inelastic/cascade-like vertices:
+            # if a particle has multiple secondary children, their starts should be
+            # mutually clustered near the parent's endpoint. This is only a loose
+            # diagnostic because CAF start/end positions do not encode the full
+            # parent trajectory or exact secondary-production vertex.
+            for parent_g4id, children in children_by_parent.items():
+                if parent_g4id < 0 or len(children) < 2 or parent_g4id not in g4_index:
+                    continue
+                parent_coll, parent_idx, parent_part = g4_index[parent_g4id]
+                parent_end = vec3_tuple(parent_part.end_pos)
+                far = []
+                for child_idx, child in children:
+                    d = dist(parent_end, vec3_tuple(child.start_pos))
+                    if math.isfinite(d) and d > args.endpoint_tol:
+                        far.append((child_idx, int(child.G4ID), d))
+                if far:
+                    counters["multi_child_endpoint_mismatch"] += 1
+                    level = "ERROR" if args.strict_endpoint else "WARN"
+                    issue(reports, level, entry, ixn_idx, parent_coll, parent_idx,
+                          f"parent G4ID={parent_g4id} has {len(children)} secondary children; "
+                          f"{len(far)} are farther than {args.endpoint_tol} cm from endpoint: {far[:8]}")
 
 
 def main():
@@ -364,21 +385,28 @@ def main():
 
     n_error = sum(1 for r in reports if r[0] == "ERROR")
     n_warn = sum(1 for r in reports if r[0] == "WARN")
+    n_info = sum(1 for r in reports if r[0] == "INFO")
 
     print("\n=== validation summary ===")
     print(f"file: {args.caf_file}")
     print(f"entries checked: {len(entries)}")
     print(f"secondaries checked: {counters['secondaries']}")
-    print(f"ancestor chain matches: {counters['ancestor_ok']}")
-    print(f"endpoint checks passed: {counters['endpoint_ok']}")
-    if counters.get("endpoint_mismatch"):
-        print(f"endpoint mismatches: {counters['endpoint_mismatch']} ({'errors' if args.strict_endpoint else 'warnings'})")
-    if counters.get("multi_child_endpoint_mismatch"):
-        print(f"multi-child endpoint mismatches: {counters['multi_child_endpoint_mismatch']} ({'errors' if args.strict_endpoint else 'warnings'})")
+    print(f"ancestor refs resolved: {counters['ancestor_ref_resolved']}")
+    print(f"ancestor chain matches where CAF chain is complete: {counters['ancestor_ok']}")
+    if counters.get("ancestor_unverified_missing_parent"):
+        print(f"ancestor refs not independently checkable because CAF parent is missing: {counters['ancestor_unverified_missing_parent']}")
+    if args.check_endpoints or args.strict_endpoint:
+        print(f"endpoint checks passed: {counters['endpoint_ok']}")
+        if counters.get("endpoint_mismatch"):
+            print(f"endpoint mismatches: {counters['endpoint_mismatch']} ({'errors' if args.strict_endpoint else 'warnings'})")
+        if counters.get("multi_child_endpoint_mismatch"):
+            print(f"multi-child endpoint mismatches: {counters['multi_child_endpoint_mismatch']} ({'errors' if args.strict_endpoint else 'warnings'})")
     for key in sorted(k for k in counters if k.startswith("trace_") or k == "duplicate_g4id"):
         print(f"{key}: {counters[key]}")
     print(f"errors: {n_error}")
     print(f"warnings: {n_warn}")
+    if n_info:
+        print(f"info: {n_info}")
 
     if n_error:
         print("FAIL")

--- a/scripts/validate_caf_truth.py
+++ b/scripts/validate_caf_truth.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""
+Validate CAF truth-particle parent/ancestor bookkeeping in one file.
+
+This is intentionally a PyROOT-side diagnostic script: it opens a CAF file,
+walks rec.mc.nu[*].sec[*], and checks that every secondary can be resolved
+through the stored G4 parent chain to the primary referenced by ancestor_id.
+It can also warn when secondary start positions are not near the immediate
+parent's endpoint, which is a useful sanity check for inelastic/cascade-like
+secondary production.
+
+Examples
+--------
+# Validate every event in a CAF file
+./validate_caf_truth.py file.root
+
+# Look at one entry with verbose per-particle diagnostics
+./validate_caf_truth.py file.root --event 12 --verbose
+
+# Treat endpoint mismatches as failures instead of warnings
+./validate_caf_truth.py file.root --strict-endpoint --endpoint-tol 0.05
+"""
+
+import argparse
+import math
+import os
+import sys
+from collections import defaultdict
+
+
+TYPE_UNKNOWN = 0
+TYPE_PRIMARY = 1
+TYPE_PREFSI = 2
+TYPE_SECONDARY = 3
+
+TYPE_NAMES = {
+    TYPE_UNKNOWN: "unknown",
+    TYPE_PRIMARY: "primary",
+    TYPE_PREFSI: "prefsi",
+    TYPE_SECONDARY: "secondary",
+}
+
+
+parser = argparse.ArgumentParser(
+    description="Validate CAF truth secondary parent chains and ancestor_id references"
+)
+parser.add_argument("caf_file", help="Input CAF ROOT file")
+parser.add_argument("-t", "--tree-name", default="cafTree", help="Tree name (default: cafTree)")
+parser.add_argument("-r", "--rec-tree", default="rec", help="Record branch name; use empty string for flat CAFs")
+parser.add_argument("-l", "--sr-lib-name", default="libduneanaobj_StandardRecord_dict.so", help="StandardRecord dictionary library name")
+parser.add_argument("-L", "--sr-lib-dir", help="Colon-separated directories to prepend to LD_LIBRARY_PATH")
+parser.add_argument("-e", "--event", type=int, action="append", help="Specific tree entry to validate (repeatable)")
+parser.add_argument("-n", "--nevents", type=int, default=-1, help="Maximum number of entries to scan")
+parser.add_argument("--endpoint-tol", type=float, default=0.1, help="Parent endpoint vs child start tolerance in cm (default: 0.1)")
+parser.add_argument("--strict-endpoint", action="store_true", help="Count endpoint mismatches as errors instead of warnings")
+parser.add_argument("--allow-cross-ixn", action="store_true", help="Allow ancestor_id.ixn to point to a different interaction")
+parser.add_argument("--max-report", type=int, default=50, help="Maximum issues to print before suppressing details")
+parser.add_argument("--verbose", action="store_true", help="Print per-secondary trace details")
+args = parser.parse_args()
+
+
+try:
+    import ROOT
+    from ROOT import TFile, gSystem
+except ImportError:
+    print("ERROR: PyROOT is not available in this Python environment.", file=sys.stderr)
+    print("Set up your ROOT/duneanaobj environment first, then rerun.", file=sys.stderr)
+    sys.exit(2)
+
+
+if args.sr_lib_dir:
+    old = os.environ.get("LD_LIBRARY_PATH", "")
+    os.environ["LD_LIBRARY_PATH"] = f"{args.sr_lib_dir}:{old}" if old else args.sr_lib_dir
+
+if gSystem.Load(args.sr_lib_name) < 0:
+    print("ERROR: Could not load StandardRecord library", file=sys.stderr)
+    print(f"  library: {args.sr_lib_name}", file=sys.stderr)
+    print(f"  LD_LIBRARY_PATH: {os.environ.get('LD_LIBRARY_PATH', '')}", file=sys.stderr)
+    sys.exit(2)
+
+
+def open_tree(path):
+    tf = TFile.Open(path, "READ")
+    if not tf or tf.IsZombie():
+        raise RuntimeError(f"Could not open file: {path}")
+    tree = tf.Get(args.tree_name)
+    if not tree:
+        raise RuntimeError(f"Could not load tree '{args.tree_name}' from file: {path}")
+    return tf, tree
+
+
+def get_record_root(tree):
+    return getattr(tree, args.rec_tree) if args.rec_tree else tree
+
+
+def safe_size(container):
+    try:
+        return int(container.size())
+    except Exception:
+        return len(container)
+
+
+def safe_at(container, idx):
+    try:
+        if idx < 0:
+            return None
+        if hasattr(container, "size"):
+            if idx >= container.size():
+                return None
+            return container.at(idx)
+        if idx >= len(container):
+            return None
+        return container[idx]
+    except Exception:
+        return None
+
+
+def vec3_tuple(v):
+    return (float(v.x), float(v.y), float(v.z))
+
+
+def dist(a, b):
+    if a is None or b is None:
+        return float("nan")
+    return math.sqrt(sum((x - y) ** 2 for x, y in zip(a, b)))
+
+
+def is_finite_vec(v):
+    return v is not None and all(math.isfinite(x) for x in v)
+
+
+def type_name(v):
+    return TYPE_NAMES.get(int(v), str(int(v)))
+
+
+def collection_for_type(ixn, ptype):
+    ptype = int(ptype)
+    if ptype == TYPE_PRIMARY:
+        return ixn.prim, "prim"
+    if ptype == TYPE_PREFSI:
+        return ixn.prefsi, "prefsi"
+    if ptype == TYPE_SECONDARY:
+        return ixn.sec, "sec"
+    return None, "unknown"
+
+
+def iter_collection(coll):
+    for i in range(safe_size(coll)):
+        yield i, coll.at(i) if hasattr(coll, "at") else coll[i]
+
+
+def build_g4_index(ixn):
+    """Return G4ID -> (collection name, index, particle) for one interaction."""
+    out = {}
+    duplicates = defaultdict(list)
+    for coll_name in ("prim", "prefsi", "sec"):
+        coll = getattr(ixn, coll_name)
+        for i, part in iter_collection(coll):
+            g4id = int(part.G4ID)
+            if g4id in out:
+                duplicates[g4id].append((coll_name, i))
+            else:
+                duplicates[g4id].append((coll_name, i))
+                out[g4id] = (coll_name, i, part)
+    return out, duplicates
+
+
+def issue(reports, level, entry, ixn_idx, coll, part_idx, message):
+    reports.append((level, entry, ixn_idx, coll, part_idx, message))
+    if len(reports) <= args.max_report:
+        loc = f"entry {entry} ixn {ixn_idx} {coll}[{part_idx}]"
+        print(f"{level}: {loc}: {message}")
+    elif len(reports) == args.max_report + 1:
+        print(f"... suppressing further issue details after --max-report={args.max_report}")
+
+
+def resolve_ancestor_ref(root, this_ixn_idx, sec, reports, entry, sec_idx):
+    anc = sec.ancestor_id
+    anc_ixn = int(anc.ixn)
+    anc_type = int(anc.type)
+    anc_part = int(anc.part)
+
+    if anc_ixn < 0 or anc_ixn >= safe_size(root.mc.nu):
+        issue(reports, "ERROR", entry, this_ixn_idx, "sec", sec_idx,
+              f"ancestor_id.ixn={anc_ixn} is outside rec.mc.nu range")
+        return None
+
+    if anc_ixn != this_ixn_idx and not args.allow_cross_ixn:
+        issue(reports, "ERROR", entry, this_ixn_idx, "sec", sec_idx,
+              f"ancestor_id.ixn={anc_ixn} does not match containing interaction")
+
+    anc_ixn_obj = root.mc.nu.at(anc_ixn)
+    anc_coll, anc_coll_name = collection_for_type(anc_ixn_obj, anc_type)
+    if anc_coll is None:
+        issue(reports, "ERROR", entry, this_ixn_idx, "sec", sec_idx,
+              f"ancestor_id.type={anc_type} ({type_name(anc_type)}) is not a particle collection")
+        return None
+
+    anc_part_obj = safe_at(anc_coll, anc_part)
+    if anc_part_obj is None:
+        issue(reports, "ERROR", entry, this_ixn_idx, "sec", sec_idx,
+              f"ancestor_id points to {anc_coll_name}[{anc_part}], but collection size is {safe_size(anc_coll)}")
+        return None
+
+    return anc_ixn, anc_coll_name, anc_part, anc_part_obj
+
+
+def trace_to_primary(sec, g4_index):
+    """Trace a secondary's CAF parent chain until a primary is reached.
+
+    Returns (status, trace, primary_tuple). trace contains tuples
+    (G4ID, collection, index, parent_G4ID). primary_tuple is
+    (collection, index, particle), normally for collection 'prim'.
+    """
+    current_parent = int(sec.parent)
+    trace = [(int(sec.G4ID), "sec", None, current_parent)]
+    visited = {int(sec.G4ID)}
+
+    while current_parent >= 0:
+        if current_parent in visited:
+            return "cycle", trace, None
+        visited.add(current_parent)
+
+        found = g4_index.get(current_parent)
+        if found is None:
+            return "missing-parent", trace, None
+
+        coll_name, idx, part = found
+        parent = int(part.parent)
+        trace.append((int(part.G4ID), coll_name, idx, parent))
+        if coll_name == "prim":
+            return "ok", trace, found
+        current_parent = parent
+
+    return "no-primary", trace, None
+
+
+def validate_entry(root, entry, reports, counters):
+    n_ixn = safe_size(root.mc.nu)
+    for ixn_idx in range(n_ixn):
+        ixn = root.mc.nu.at(ixn_idx)
+        g4_index, duplicates = build_g4_index(ixn)
+
+        for g4id, places in duplicates.items():
+            if len(places) > 1:
+                counters["duplicate_g4id"] += 1
+                issue(reports, "ERROR", entry, ixn_idx, "ixn", -1,
+                      f"G4ID {g4id} appears multiple times: {places}")
+
+        children_by_parent = defaultdict(list)
+        for sec_idx, sec in iter_collection(ixn.sec):
+            children_by_parent[int(sec.parent)].append((sec_idx, sec))
+
+        for sec_idx, sec in iter_collection(ixn.sec):
+            counters["secondaries"] += 1
+            anc_ref = resolve_ancestor_ref(root, ixn_idx, sec, reports, entry, sec_idx)
+            status, trace, primary = trace_to_primary(sec, g4_index)
+
+            if args.verbose:
+                trace_txt = " -> ".join(
+                    f"{coll}[{idx}] G4ID={g4id} parent={parent}"
+                    for g4id, coll, idx, parent in trace
+                )
+                if anc_ref is None:
+                    anc_txt = "unresolved"
+                else:
+                    _, anc_coll, anc_idx, anc_part = anc_ref
+                    anc_txt = f"{anc_coll}[{anc_idx}] G4ID={int(anc_part.G4ID)} pdg={int(anc_part.pdg)}"
+                print(f"TRACE: entry {entry} ixn {ixn_idx} sec[{sec_idx}] G4ID={int(sec.G4ID)}: {trace_txt}; ancestor={anc_txt}; status={status}")
+
+            if status != "ok":
+                counters[f"trace_{status}"] += 1
+                issue(reports, "ERROR", entry, ixn_idx, "sec", sec_idx,
+                      f"could not trace parent chain to a primary: status={status}, trace={trace}")
+                continue
+
+            primary_coll, primary_idx, primary_part = primary
+            if anc_ref is None:
+                continue
+
+            _, anc_coll, anc_idx, anc_part = anc_ref
+            if anc_coll != "prim":
+                issue(reports, "ERROR", entry, ixn_idx, "sec", sec_idx,
+                      f"ancestor_id resolves to {anc_coll}[{anc_idx}], expected prim[{primary_idx}] from parent chain")
+            elif anc_idx != primary_idx or int(anc_part.G4ID) != int(primary_part.G4ID):
+                issue(reports, "ERROR", entry, ixn_idx, "sec", sec_idx,
+                      f"ancestor_id resolves to prim[{anc_idx}] G4ID={int(anc_part.G4ID)}, "
+                      f"but parent chain reaches prim[{primary_idx}] G4ID={int(primary_part.G4ID)}")
+            else:
+                counters["ancestor_ok"] += 1
+
+            parent_tuple = g4_index.get(int(sec.parent))
+            if parent_tuple is not None:
+                parent_coll, parent_idx, parent_part = parent_tuple
+                parent_end = vec3_tuple(parent_part.end_pos)
+                child_start = vec3_tuple(sec.start_pos)
+                d = dist(parent_end, child_start)
+                if is_finite_vec(parent_end) and is_finite_vec(child_start) and d > args.endpoint_tol:
+                    counters["endpoint_mismatch"] += 1
+                    level = "ERROR" if args.strict_endpoint else "WARN"
+                    issue(reports, level, entry, ixn_idx, "sec", sec_idx,
+                          f"child start is {d:.6g} cm from immediate parent endpoint "
+                          f"({parent_coll}[{parent_idx}] G4ID={int(parent_part.G4ID)}); "
+                          f"parent_end={parent_end}, child_start={child_start}")
+                else:
+                    counters["endpoint_ok"] += 1
+
+        # A compact parent-level endpoint check for inelastic/cascade-like vertices:
+        # if a particle has multiple secondary children, their starts should be
+        # mutually clustered near the parent's endpoint. This is warning-only
+        # unless --strict-endpoint is set, same as the per-child check above.
+        for parent_g4id, children in children_by_parent.items():
+            if parent_g4id < 0 or len(children) < 2 or parent_g4id not in g4_index:
+                continue
+            parent_coll, parent_idx, parent_part = g4_index[parent_g4id]
+            parent_end = vec3_tuple(parent_part.end_pos)
+            far = []
+            for child_idx, child in children:
+                d = dist(parent_end, vec3_tuple(child.start_pos))
+                if math.isfinite(d) and d > args.endpoint_tol:
+                    far.append((child_idx, int(child.G4ID), d))
+            if far:
+                counters["multi_child_endpoint_mismatch"] += 1
+                level = "ERROR" if args.strict_endpoint else "WARN"
+                issue(reports, level, entry, ixn_idx, parent_coll, parent_idx,
+                      f"parent G4ID={parent_g4id} has {len(children)} secondary children; "
+                      f"{len(far)} are farther than {args.endpoint_tol} cm from endpoint: {far[:8]}")
+
+
+def main():
+    try:
+        tf, tree = open_tree(args.caf_file)
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    nentries = int(tree.GetEntries())
+    if args.nevents >= 0:
+        nentries = min(nentries, args.nevents)
+
+    if args.event:
+        entries = args.event
+    else:
+        entries = list(range(nentries))
+
+    reports = []
+    counters = defaultdict(int)
+
+    for entry in entries:
+        if entry < 0 or entry >= int(tree.GetEntries()):
+            print(f"WARN: skipping out-of-range entry {entry}", file=sys.stderr)
+            continue
+        tree.GetEntry(entry)
+        validate_entry(get_record_root(tree), entry, reports, counters)
+
+    n_error = sum(1 for r in reports if r[0] == "ERROR")
+    n_warn = sum(1 for r in reports if r[0] == "WARN")
+
+    print("\n=== validation summary ===")
+    print(f"file: {args.caf_file}")
+    print(f"entries checked: {len(entries)}")
+    print(f"secondaries checked: {counters['secondaries']}")
+    print(f"ancestor chain matches: {counters['ancestor_ok']}")
+    print(f"endpoint checks passed: {counters['endpoint_ok']}")
+    if counters.get("endpoint_mismatch"):
+        print(f"endpoint mismatches: {counters['endpoint_mismatch']} ({'errors' if args.strict_endpoint else 'warnings'})")
+    if counters.get("multi_child_endpoint_mismatch"):
+        print(f"multi-child endpoint mismatches: {counters['multi_child_endpoint_mismatch']} ({'errors' if args.strict_endpoint else 'warnings'})")
+    for key in sorted(k for k in counters if k.startswith("trace_") or k == "duplicate_g4id"):
+        print(f"{key}: {counters[key]}")
+    print(f"errors: {n_error}")
+    print(f"warnings: {n_warn}")
+
+    if n_error:
+        print("FAIL")
+        return 1
+    print("PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_caf_truth.py
+++ b/scripts/validate_caf_truth.py
@@ -294,8 +294,9 @@ def validate_entry(root, entry, reports, counters):
                 counters[f"trace_{status}"] += 1
                 if status == "missing-parent" and anc_ref is not None and not args.strict_caf_chain:
                     counters["ancestor_unverified_missing_parent"] += 1
-                    issue(reports, "INFO", entry, ixn_idx, "sec", sec_idx,
-                          f"CAF parent chain is incomplete, so ancestor_id cannot be independently checked from CAF alone: trace={trace}")
+                    if args.verbose:
+                        issue(reports, "INFO", entry, ixn_idx, "sec", sec_idx,
+                              f"CAF parent chain is incomplete, so ancestor_id cannot be independently checked from CAF alone: trace={trace}")
                 else:
                     issue(reports, "ERROR", entry, ixn_idx, "sec", sec_idx,
                           f"could not trace parent chain to a primary: status={status}, trace={trace}")

--- a/scripts/validate_caf_truth.py
+++ b/scripts/validate_caf_truth.py
@@ -150,13 +150,22 @@ def iter_collection(coll):
 
 
 def build_g4_index(ixn):
-    """Return G4ID -> (collection name, index, particle) for one interaction."""
+    """Return G4ID -> (collection name, index, particle) for one interaction.
+
+    Only prim/sec are used for the CAF-side parent-chain trace. The prefsi
+    collection is GENIE/pre-FSI bookkeeping and, in observed CAFs, can contain
+    placeholder/non-GEANT G4ID values such as repeated -1 entries. Those are
+    still resolvable through ancestor_id.type=prefsi via collection_for_type(),
+    but they should not participate in G4 parent-chain indexing.
+    """
     out = {}
     duplicates = defaultdict(list)
-    for coll_name in ("prim", "prefsi", "sec"):
+    for coll_name in ("prim", "sec"):
         coll = getattr(ixn, coll_name)
         for i, part in iter_collection(coll):
             g4id = int(part.G4ID)
+            if g4id < 0:
+                continue
             if g4id in out:
                 duplicates[g4id].append((coll_name, i))
             else:

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -531,6 +531,76 @@ namespace cafmaker
 
       return ancestor;
     }
+
+    bool HasParticleWithG4ID(const std::vector<caf::SRTrueParticle> &collection,
+                             int G4ID)
+    {
+      return std::find_if(collection.begin(), collection.end(),
+                          [G4ID](const caf::SRTrueParticle &part)
+                          {
+                            return part.G4ID == G4ID;
+                          }) != collection.end();
+    }
+
+    void FillParticleFields(caf::SRTrueParticle &part,
+                            const caf::SRTrueInteraction &ixn,
+                            std::size_t nixn,
+                            int G4ID,
+                            const TG4Event *g4event)
+    {
+      auto traj = g4event->Trajectories[G4ID];
+
+      part.G4ID = traj.TrackId;
+      part.interaction_id = ixn.id;
+      part.pdg = traj.PDGCode;
+      part.p = traj.InitialMomentum*0.001;
+
+      part.parent = traj.ParentId;
+      part.ancestor_id = FindPrimaryAncestor(ixn, nixn, G4ID, g4event);
+
+      auto p0 = traj.Points[0];
+      part.start_pos = (p0.Position * .1).Vect();
+
+      auto pf = traj.Points[traj.Points.size()-1];
+      part.end_pos = (pf.Position * .1).Vect();
+    }
+
+    void EnsureSecondaryParentClosure(caf::SRTrueInteraction &ixn,
+                                      std::size_t nixn,
+                                      int G4ID,
+                                      std::vector<caf::SRTrueParticle> &secondaries,
+                                      int &counter,
+                                      const TG4Event *g4event)
+    {
+      if (!g4event) return;
+      if (G4ID < 0 || G4ID >= static_cast<int>(g4event->Trajectories.size())) return;
+
+      int current = g4event->Trajectories[G4ID].ParentId;
+      std::vector<int> visited{G4ID};
+
+      while (current >= 0)
+      {
+        if (std::find(visited.begin(), visited.end(), current) != visited.end())
+          return;
+        visited.push_back(current);
+
+        if (current >= static_cast<int>(g4event->Trajectories.size()))
+          return;
+
+        if (HasParticleWithG4ID(ixn.prim, current))
+          return;
+
+        if (HasParticleWithG4ID(secondaries, current))
+          return;
+
+        const int particle_index = counter;
+        secondaries.emplace_back();
+        counter++;
+
+        FillParticleFields(secondaries.at(particle_index), ixn, nixn, current, g4event);
+        current = g4event->Trajectories[current].ParentId;
+      }
+    }
   }
 
   int TruthMatcher::FillParticle(caf::SRTrueInteraction &ixn, std::size_t nixn, int G4ID, std::vector<caf::SRTrueParticle> & collection, int & counter, const TG4Event * g4event)
@@ -540,23 +610,12 @@ namespace cafmaker
     int part_index = counter;
     counter++;
 
-    auto traj = g4event->Trajectories[G4ID];
-    caf::SRTrueParticle & part = collection.at(part_index);
+    FillParticleFields(collection.at(part_index), ixn, nixn, G4ID, g4event);
 
-    part.G4ID = traj.TrackId;
-    part.interaction_id = ixn.id;
-    part.pdg = traj.PDGCode;
-    part.p = traj.InitialMomentum*0.001;
+    if (&collection == &ixn.sec)
+      EnsureSecondaryParentClosure(ixn, nixn, G4ID, collection, counter, g4event);
 
-    part.parent = traj.ParentId;
-    part.ancestor_id = FindPrimaryAncestor(ixn, nixn, G4ID, g4event);
-
-    auto p0 = traj.Points[0];
-    part.start_pos = (p0.Position * .1).Vect();
-
-    auto pf = traj.Points[traj.Points.size()-1];
-    part.end_pos = (pf.Position * .1).Vect();
-    return part.ancestor_id.part;
+    return collection.at(part_index).ancestor_id.part;
   }
 
   // ------------------------------------------------------------

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -548,7 +548,7 @@ namespace cafmaker
                             int G4ID,
                             const TG4Event *g4event)
     {
-      auto traj = g4event->Trajectories[G4ID];
+      const auto & traj = g4event->Trajectories[G4ID];
 
       part.G4ID = traj.TrackId;
       part.interaction_id = ixn.id;
@@ -558,10 +558,10 @@ namespace cafmaker
       part.parent = traj.ParentId;
       part.ancestor_id = FindPrimaryAncestor(ixn, nixn, G4ID, g4event);
 
-      auto p0 = traj.Points[0];
+      const auto & p0 = traj.Points[0];
       part.start_pos = (p0.Position * .1).Vect();
 
-      auto pf = traj.Points[traj.Points.size()-1];
+      const auto & pf = traj.Points.back();
       part.end_pos = (pf.Position * .1).Vect();
     }
 

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -107,6 +107,11 @@ caf::ScatteringMode GENIE2CAF(genie::EScatteringType sc)
 
 namespace cafmaker
 {
+  namespace
+  {
+    bool PrintMaterializationStatsEnabled();
+  }
+
   template <>
   void ValidateOrCopy<double, float>(const double & input, float & target, const float & unsetVal, const std::string & fieldName)
   {

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -7,6 +7,7 @@
 
 #include "FillTruth.h"
 
+#include <cstdlib>
 #include <map>
 #include <regex>
 
@@ -149,21 +150,23 @@ namespace cafmaker
     const unsigned long totalSecondaryAdds = fMaterializationStats.missingSecondaryAdds
                                            + fMaterializationStats.missingSecondaryClosureAdds;
     const unsigned long totalClosureCalls = fMaterializationStats.secondaryClosureCalls;
+    if (!PrintMaterializationStatsEnabled())
+      return;
     if (fMaterializationStats.missingPrimaryAdds == 0 && totalSecondaryAdds == 0 && totalClosureCalls == 0)
       return;
 
-    LOG.WARNING() << "Materialized missing true particles: prim="
-                  << fMaterializationStats.missingPrimaryAdds
-                  << ", sec(requested)=" << fMaterializationStats.missingSecondaryAdds
-                  << ", sec(parent-closure)=" << fMaterializationStats.missingSecondaryClosureAdds
-                  << ", sec(total)=" << totalSecondaryAdds
-                  << "; closure calls=" << totalClosureCalls
-                  << ", resolved(existing prim)=" << fMaterializationStats.secondaryClosureResolvedByExistingPrimary
-                  << ", resolved(existing sec)=" << fMaterializationStats.secondaryClosureResolvedByExistingSecondary
-                  << ", resolved(materialized prim)=" << fMaterializationStats.secondaryClosureResolvedByMaterializedPrimary
-                  << ", aborted(cycle)=" << fMaterializationStats.secondaryClosureAbortedCycle
-                  << ", aborted(out-of-range)=" << fMaterializationStats.secondaryClosureAbortedOutOfRange
-                  << "\n";
+    LOG.INFO() << "TruthMatcher materialization stats: prim(added)="
+               << fMaterializationStats.missingPrimaryAdds
+               << ", sec(requested)=" << fMaterializationStats.missingSecondaryAdds
+               << ", sec(parent-closure)=" << fMaterializationStats.missingSecondaryClosureAdds
+               << ", sec(total)=" << totalSecondaryAdds
+               << "; closure calls=" << totalClosureCalls
+               << ", resolved(existing prim)=" << fMaterializationStats.secondaryClosureResolvedByExistingPrimary
+               << ", resolved(existing sec)=" << fMaterializationStats.secondaryClosureResolvedByExistingSecondary
+               << ", resolved(materialized prim)=" << fMaterializationStats.secondaryClosureResolvedByMaterializedPrimary
+               << ", aborted(cycle)=" << fMaterializationStats.secondaryClosureAbortedCycle
+               << ", aborted(out-of-range)=" << fMaterializationStats.secondaryClosureAbortedOutOfRange
+               << " [set ND_CAFMAKER_STATS=1 to enable]\n";
   }
 
   // --------------------------------------------------------------
@@ -562,6 +565,12 @@ namespace cafmaker
                           {
                             return part.G4ID == G4ID;
                           }) != collection.end();
+    }
+
+    bool PrintMaterializationStatsEnabled()
+    {
+      const char *env = std::getenv("ND_CAFMAKER_STATS");
+      return env && std::string(env) == "1";
     }
 
     void FillParticleFields(caf::SRTrueParticle &part,

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -587,6 +587,12 @@ namespace cafmaker
         if (current >= static_cast<int>(g4event->Trajectories.size()))
           return;
 
+        // If we have reached a G4 root trajectory but it is not represented in
+        // ixn.prim, stop here and leave the ancestor unknown rather than
+        // inserting that root into the secondary list.
+        if (g4event->Trajectories[current].ParentId < 0)
+          return;
+
         if (HasParticleWithG4ID(ixn.prim, current))
           return;
 

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -148,14 +148,22 @@ namespace cafmaker
   {
     const unsigned long totalSecondaryAdds = fMaterializationStats.missingSecondaryAdds
                                            + fMaterializationStats.missingSecondaryClosureAdds;
-    if (fMaterializationStats.missingPrimaryAdds == 0 && totalSecondaryAdds == 0)
+    const unsigned long totalClosureCalls = fMaterializationStats.secondaryClosureCalls;
+    if (fMaterializationStats.missingPrimaryAdds == 0 && totalSecondaryAdds == 0 && totalClosureCalls == 0)
       return;
 
     LOG.WARNING() << "Materialized missing true particles: prim="
                   << fMaterializationStats.missingPrimaryAdds
                   << ", sec(requested)=" << fMaterializationStats.missingSecondaryAdds
                   << ", sec(parent-closure)=" << fMaterializationStats.missingSecondaryClosureAdds
-                  << ", sec(total)=" << totalSecondaryAdds << "\n";
+                  << ", sec(total)=" << totalSecondaryAdds
+                  << "; closure calls=" << totalClosureCalls
+                  << ", resolved(existing prim)=" << fMaterializationStats.secondaryClosureResolvedByExistingPrimary
+                  << ", resolved(existing sec)=" << fMaterializationStats.secondaryClosureResolvedByExistingSecondary
+                  << ", resolved(materialized prim)=" << fMaterializationStats.secondaryClosureResolvedByMaterializedPrimary
+                  << ", aborted(cycle)=" << fMaterializationStats.secondaryClosureAbortedCycle
+                  << ", aborted(out-of-range)=" << fMaterializationStats.secondaryClosureAbortedOutOfRange
+                  << "\n";
   }
 
   // --------------------------------------------------------------
@@ -591,6 +599,8 @@ namespace cafmaker
     if (!g4event) return;
     if (G4ID < 0 || G4ID >= static_cast<int>(g4event->Trajectories.size())) return;
 
+    fMaterializationStats.secondaryClosureCalls++;
+
     int current = g4event->Trajectories[G4ID].ParentId;
     std::vector<int> visited{G4ID};
     std::vector<int> missingAncestors;
@@ -598,17 +608,29 @@ namespace cafmaker
     while (current >= 0)
     {
       if (std::find(visited.begin(), visited.end(), current) != visited.end())
+      {
+        fMaterializationStats.secondaryClosureAbortedCycle++;
         return;
+      }
       visited.push_back(current);
 
       if (current >= static_cast<int>(g4event->Trajectories.size()))
+      {
+        fMaterializationStats.secondaryClosureAbortedOutOfRange++;
         return;
+      }
 
       if (HasParticleWithG4ID(ixn.prim, current))
+      {
+        fMaterializationStats.secondaryClosureResolvedByExistingPrimary++;
         break;
+      }
 
       if (HasParticleWithG4ID(secondaries, current))
+      {
+        fMaterializationStats.secondaryClosureResolvedByExistingSecondary++;
         break;
+      }
 
       const auto &traj = g4event->Trajectories[current];
       if (traj.ParentId < 0)
@@ -622,6 +644,7 @@ namespace cafmaker
         ixn.nprim++;
         FillParticleFields(ixn.prim.at(particle_index), ixn, nixn, current, g4event);
         fMaterializationStats.missingPrimaryAdds++;
+        fMaterializationStats.secondaryClosureResolvedByMaterializedPrimary++;
         break;
       }
 
@@ -631,10 +654,6 @@ namespace cafmaker
 
     for (auto it = missingAncestors.rbegin(); it != missingAncestors.rend(); ++it)
     {
-      LOG.WARNING() << "Materializing missing secondary trajectory " << *it
-                    << " into sec for interaction " << ixn.id
-                    << " while closing parent chain for secondary trajectory " << G4ID << "\n";
-
       const int particle_index = counter;
       secondaries.emplace_back();
       counter++;
@@ -646,12 +665,12 @@ namespace cafmaker
   int TruthMatcher::FillParticle(caf::SRTrueInteraction &ixn, std::size_t nixn, int G4ID, std::vector<caf::SRTrueParticle> & collection, int & counter, const TG4Event * g4event) const
   {
     const bool isPrimaryCollection = (&collection == &ixn.prim);
-    LOG.WARNING() << "Materializing missing " << (isPrimaryCollection ? "primary" : "secondary")
-                  << " trajectory " << G4ID << " into " << (isPrimaryCollection ? "prim" : "sec")
-                  << " for interaction " << ixn.id << "\n";
-
     if (isPrimaryCollection)
+    {
+      LOG.WARNING() << "Materializing missing primary trajectory " << G4ID
+                    << " into prim for interaction " << ixn.id << "\n";
       fMaterializationStats.missingPrimaryAdds++;
+    }
     else
       fMaterializationStats.missingSecondaryAdds++;
 

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -144,6 +144,20 @@ namespace cafmaker
     LOG_S("TruthMatcher::FillInteraction").WARNING() << "CAFMaker has GENIE but no Edepsim, truth will be limited, should not be used for official production \n";
   }
 
+  TruthMatcher::~TruthMatcher()
+  {
+    const unsigned long totalSecondaryAdds = fMaterializationStats.missingSecondaryAdds
+                                           + fMaterializationStats.missingSecondaryClosureAdds;
+    if (fMaterializationStats.missingPrimaryAdds == 0 && totalSecondaryAdds == 0)
+      return;
+
+    LOG.WARNING() << "Materialized missing true particles: prim="
+                  << fMaterializationStats.missingPrimaryAdds
+                  << ", sec(requested)=" << fMaterializationStats.missingSecondaryAdds
+                  << ", sec(parent-closure)=" << fMaterializationStats.missingSecondaryClosureAdds
+                  << ", sec(total)=" << totalSecondaryAdds << "\n";
+  }
+
   // --------------------------------------------------------------
   void TruthMatcher::FillInteraction(caf::SRTrueInteraction& nu, const genie::NtpMCEventRecord * gEvt, const TG4Event * g4event, int nixn)
   {
@@ -565,52 +579,81 @@ namespace cafmaker
       part.end_pos = (pf.Position * .1).Vect();
     }
 
-    void EnsureSecondaryParentClosure(caf::SRTrueInteraction &ixn,
-                                      std::size_t nixn,
-                                      int G4ID,
-                                      std::vector<caf::SRTrueParticle> &secondaries,
-                                      int &counter,
-                                      const TG4Event *g4event)
+  }
+
+  void TruthMatcher::EnsureSecondaryParentClosure(caf::SRTrueInteraction &ixn,
+                                                  std::size_t nixn,
+                                                  int G4ID,
+                                                  std::vector<caf::SRTrueParticle> &secondaries,
+                                                  int &counter,
+                                                  const TG4Event *g4event) const
+  {
+    if (!g4event) return;
+    if (G4ID < 0 || G4ID >= static_cast<int>(g4event->Trajectories.size())) return;
+
+    int current = g4event->Trajectories[G4ID].ParentId;
+    std::vector<int> visited{G4ID};
+    std::vector<int> missingAncestors;
+
+    while (current >= 0)
     {
-      if (!g4event) return;
-      if (G4ID < 0 || G4ID >= static_cast<int>(g4event->Trajectories.size())) return;
+      if (std::find(visited.begin(), visited.end(), current) != visited.end())
+        return;
+      visited.push_back(current);
 
-      int current = g4event->Trajectories[G4ID].ParentId;
-      std::vector<int> visited{G4ID};
+      if (current >= static_cast<int>(g4event->Trajectories.size()))
+        return;
 
-      while (current >= 0)
+      if (HasParticleWithG4ID(ixn.prim, current))
+        break;
+
+      if (HasParticleWithG4ID(secondaries, current))
+        break;
+
+      const auto &traj = g4event->Trajectories[current];
+      if (traj.ParentId < 0)
       {
-        if (std::find(visited.begin(), visited.end(), current) != visited.end())
-          return;
-        visited.push_back(current);
+        LOG.WARNING() << "Materializing missing primary trajectory " << current
+                      << " into prim for interaction " << ixn.id
+                      << " while closing parent chain for secondary trajectory " << G4ID << "\n";
 
-        if (current >= static_cast<int>(g4event->Trajectories.size()))
-          return;
-
-        // If we have reached a G4 root trajectory but it is not represented in
-        // ixn.prim, stop here and leave the ancestor unknown rather than
-        // inserting that root into the secondary list.
-        if (g4event->Trajectories[current].ParentId < 0)
-          return;
-
-        if (HasParticleWithG4ID(ixn.prim, current))
-          return;
-
-        if (HasParticleWithG4ID(secondaries, current))
-          return;
-
-        const int particle_index = counter;
-        secondaries.emplace_back();
-        counter++;
-
-        FillParticleFields(secondaries.at(particle_index), ixn, nixn, current, g4event);
-        current = g4event->Trajectories[current].ParentId;
+        const int particle_index = ixn.nprim;
+        ixn.prim.emplace_back();
+        ixn.nprim++;
+        FillParticleFields(ixn.prim.at(particle_index), ixn, nixn, current, g4event);
+        fMaterializationStats.missingPrimaryAdds++;
+        break;
       }
+
+      missingAncestors.push_back(current);
+      current = traj.ParentId;
+    }
+
+    for (auto it = missingAncestors.rbegin(); it != missingAncestors.rend(); ++it)
+    {
+      LOG.WARNING() << "Materializing missing secondary trajectory " << *it
+                    << " into sec for interaction " << ixn.id
+                    << " while closing parent chain for secondary trajectory " << G4ID << "\n";
+
+      const int particle_index = counter;
+      secondaries.emplace_back();
+      counter++;
+      FillParticleFields(secondaries.at(particle_index), ixn, nixn, *it, g4event);
+      fMaterializationStats.missingSecondaryClosureAdds++;
     }
   }
 
-  int TruthMatcher::FillParticle(caf::SRTrueInteraction &ixn, std::size_t nixn, int G4ID, std::vector<caf::SRTrueParticle> & collection, int & counter, const TG4Event * g4event)
+  int TruthMatcher::FillParticle(caf::SRTrueInteraction &ixn, std::size_t nixn, int G4ID, std::vector<caf::SRTrueParticle> & collection, int & counter, const TG4Event * g4event) const
   {
+    const bool isPrimaryCollection = (&collection == &ixn.prim);
+    LOG.WARNING() << "Materializing missing " << (isPrimaryCollection ? "primary" : "secondary")
+                  << " trajectory " << G4ID << " into " << (isPrimaryCollection ? "prim" : "sec")
+                  << " for interaction " << ixn.id << "\n";
+
+    if (isPrimaryCollection)
+      fMaterializationStats.missingPrimaryAdds++;
+    else
+      fMaterializationStats.missingSecondaryAdds++;
 
     collection.emplace_back();
     int part_index = counter;
@@ -618,8 +661,11 @@ namespace cafmaker
 
     FillParticleFields(collection.at(part_index), ixn, nixn, G4ID, g4event);
 
-    if (&collection == &ixn.sec)
+    if (!isPrimaryCollection)
+    {
       EnsureSecondaryParentClosure(ixn, nixn, G4ID, collection, counter, g4event);
+      FillParticleFields(collection.at(part_index), ixn, nixn, G4ID, g4event);
+    }
 
     return collection.at(part_index).ancestor_id.part;
   }

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -486,6 +486,53 @@ namespace cafmaker
     fGTrees.SetLogThrehsold(thresh);
   }
 
+  namespace
+  {
+    caf::TrueParticleID FindPrimaryAncestor(const caf::SRTrueInteraction &ixn,
+                                            std::size_t nixn,
+                                            int G4ID,
+                                            const TG4Event *g4event)
+    {
+      caf::TrueParticleID ancestor;
+      ancestor.ixn = nixn;
+
+      if (!g4event) return ancestor;
+
+      int current = G4ID;
+      std::vector<int> visited;
+
+      while (current >= 0)
+      {
+        if (std::find(visited.begin(), visited.end(), current) != visited.end())
+          return ancestor;
+        visited.push_back(current);
+
+        if (current >= static_cast<int>(g4event->Trajectories.size()))
+          return ancestor;
+
+        const int parent = g4event->Trajectories[current].ParentId;
+        if (parent < 0)
+          return ancestor;
+
+        const auto itPrimary = std::find_if(ixn.prim.begin(), ixn.prim.end(),
+                                            [parent](const caf::SRTrueParticle &primary)
+                                            {
+                                              return primary.G4ID == parent;
+                                            });
+        if (itPrimary != ixn.prim.end())
+        {
+          ancestor.type = caf::TrueParticleID::kPrimary;
+          ancestor.part = std::distance(ixn.prim.begin(), itPrimary);
+          return ancestor;
+        }
+
+        current = parent;
+      }
+
+      return ancestor;
+    }
+  }
+
   int TruthMatcher::FillParticle(caf::SRTrueInteraction &ixn, std::size_t nixn, int G4ID, std::vector<caf::SRTrueParticle> & collection, int & counter, const TG4Event * g4event)
   {
 
@@ -494,28 +541,6 @@ namespace cafmaker
     counter++;
 
     auto traj = g4event->Trajectories[G4ID];
-    //Get Ancestor
-    int ancestor_id = traj.ParentId;
-    int ancestor_parent_id = g4event->Trajectories[ancestor_id].ParentId;
-    if (ancestor_parent_id !=-1)
-    {
-      
-      if(auto itPart = std::find_if(collection.begin(),
-                                    collection.end(),
-                                    [ancestor_id](const caf::SRTrueParticle& mypart)
-                                    {
-                                      return mypart.G4ID == ancestor_id;
-                                    }); itPart == collection.end())
-      {
-        
-        ancestor_id = FillParticle(ixn, nixn, ancestor_id, collection, counter, g4event);
-      } 
-      else
-      {
-        ancestor_id = ((*itPart)).ancestor_id.part;
-        // ancestor_id;
-      }
-    }
     caf::SRTrueParticle & part = collection.at(part_index);
 
     part.G4ID = traj.TrackId;
@@ -524,16 +549,14 @@ namespace cafmaker
     part.p = traj.InitialMomentum*0.001;
 
     part.parent = traj.ParentId;
-
-    part.ancestor_id.ixn = nixn;
-    part.ancestor_id.part = ancestor_id ;
+    part.ancestor_id = FindPrimaryAncestor(ixn, nixn, G4ID, g4event);
 
     auto p0 = traj.Points[0];
     part.start_pos = (p0.Position * .1).Vect();
 
     auto pf = traj.Points[traj.Points.size()-1];
     part.end_pos = (pf.Position * .1).Vect();
-    return ancestor_id;
+    return part.ancestor_id.part;
   }
 
   // ------------------------------------------------------------

--- a/src/truth/FillTruth.h
+++ b/src/truth/FillTruth.h
@@ -251,6 +251,12 @@
         unsigned long missingPrimaryAdds = 0;
         unsigned long missingSecondaryAdds = 0;
         unsigned long missingSecondaryClosureAdds = 0;
+        unsigned long secondaryClosureCalls = 0;
+        unsigned long secondaryClosureResolvedByExistingPrimary = 0;
+        unsigned long secondaryClosureResolvedByExistingSecondary = 0;
+        unsigned long secondaryClosureResolvedByMaterializedPrimary = 0;
+        unsigned long secondaryClosureAbortedCycle = 0;
+        unsigned long secondaryClosureAbortedOutOfRange = 0;
       };
       mutable MaterializationStats fMaterializationStats;
 

--- a/src/truth/FillTruth.h
+++ b/src/truth/FillTruth.h
@@ -132,6 +132,7 @@
                   std::string edepsimFilename,
                    const genie::NtpMCEventRecord *gEvt,
                    std::function<int(const genie::NtpMCEventRecord *)> genieFillerCallback);
+      ~TruthMatcher();
 
       /// Find a TrueParticle within a given StandardRecord, or, if it doesn't exist, optionally make a new one
       ///
@@ -186,7 +187,13 @@
     private:
     static void FillInteraction(caf::SRTrueInteraction& nu, const genie::NtpMCEventRecord * gEvt, const TG4Event * g4event, int nixn);
     // static void FillParticle(caf::SRTrueParticle * part, std::size_t nixn, const TG4Event * g4event);
-    static  int FillParticle(caf::SRTrueInteraction &ixn, std::size_t nixn, int G4ID, std::vector<caf::SRTrueParticle> & collection, int & counter, const TG4Event * g4event);
+    int FillParticle(caf::SRTrueInteraction &ixn, std::size_t nixn, int G4ID, std::vector<caf::SRTrueParticle> & collection, int & counter, const TG4Event * g4event) const;
+    void EnsureSecondaryParentClosure(caf::SRTrueInteraction &ixn,
+                                      std::size_t nixn,
+                                      int G4ID,
+                                      std::vector<caf::SRTrueParticle> &secondaries,
+                                      int &counter,
+                                      const TG4Event *g4event) const;
 
 
 
@@ -238,6 +245,14 @@
           bool f_isTreeLoaded;
       };
       mutable EdepSimTreeContainer fEdepSimTree;
+
+      struct MaterializationStats
+      {
+        unsigned long missingPrimaryAdds = 0;
+        unsigned long missingSecondaryAdds = 0;
+        unsigned long missingSecondaryClosureAdds = 0;
+      };
+      mutable MaterializationStats fMaterializationStats;
 
   };
 }


### PR DESCRIPTION
Properly connects secondary particles to the parent particles in the caf, see issue #116. Also adds validation script.

```bash
# Before fix
=== validation summary ===
file: default/example-CAF.root
entries checked: 13
secondaries checked: 10426
ancestor refs resolved: 0
ancestor chain matches where CAF chain is complete: 0
errors: 10426
warnings: 0
FAIL

# After fix:
python scripts/validate_caf_truth.py fixed_secondaries/example-CAF.root 
=== validation summary ===
file: fixed_secondaries/example-CAF.root
entries checked: 13
secondaries checked: 10426
ancestor refs resolved: 10426
ancestor chain matches where CAF chain is complete: 10426
errors: 0
warnings: 0
PASS
```

The file sizes are not that different
```bash
3.5M    default/example-CAF.root
3.5M    fixed_secondaries/example-CAF.root
```
Run times are not either (note these were measured on two different days):
```bash
Original: 3m31s
Fixed: 3m29s
```

# Note about intermediate secondaries
Secondaries are only saved if a reconstructed track warrants it. This makes sense so we're not save too much info. But this meant that some intermediate particles weren't saved. Like if a secondary neutron creates a proton track, which we reconstruct, then there was no parent to the proton in the caf. Below is the result of the validation if we don't save the interemediate particles. The fix was to save the intermediate particles. It's a more general and stable solution than trying to link the secondary to the primary. Currently the unreco'd particles are not individually flagged but we could add that if need be.

```bash
python scripts/validate_caf_truth.py particle_fix/example-CAF.root 
=== validation summary ===
file: particle_fix/example-CAF.root
entries checked: 13
secondaries checked: 7680
ancestor refs resolved: 7680
ancestor chain matches where CAF chain is complete: 5279
ancestor refs not independently checkable because CAF parent is missing: 2401
trace_missing-parent: 2401
errors: 0
warnings: 0
PASS
```

# Files touched
`src/truth/FillTruth.cxx`
`.gitignore`

# Files added
`scripts/validate_caf_truth.py`