### PR TITLE
132 Fix SelectEvent by Correctly Mapping Event Num to Entry Num

### DIFF
--- a/src/Params.h
+++ b/src/Params.h
@@ -89,6 +89,9 @@ namespace cafmaker
     fhicl::Atom<double> sigmaT { fhicl::Name("SigmaT"), fhicl::Comment("Standard deviation of time difference between recorded Pandora reco track and matching TMS reco track [ns]"), 8.84};
     fhicl::Atom<double> fcut { fhicl::Name("fCut"), fhicl::Comment("Maximum permissible match score for the matching, (best choice depends on whether time is included)"), 59.67}; //without time: 5.25
 
+    fhicl::Atom<double> vertexMatchToleranceMm { fhicl::Name("VertexMatchToleranceMm"), fhicl::Comment("Maximum distance between Truth_Spill primary-particle birth position and matched Truth_Spill vertex [mm]"), 100.0};
+    fhicl::Atom<double> positionToleranceMm { fhicl::Name("PositionToleranceMm"), fhicl::Comment("Maximum distance between TMS truth position and matched EDepSim vertex position [mm]"), 1.0};
+
     // options are VERBOSE, DEBUG, INFO, WARNING, ERROR, FATAL
     fhicl::Atom<std::string> verbosity { fhicl::Name("Verbosity"), fhicl::Comment("Verbosity level of output"), "WARNING" };
   };

--- a/src/makeCAF.C
+++ b/src/makeCAF.C
@@ -155,7 +155,8 @@ std::vector<std::unique_ptr<cafmaker::IRecoBranchFiller>> getRecoFillers(const c
   std::string tmsFile;
   if (par().cafmaker().tmsRecoFile(tmsFile))
   {
-    recoFillers.emplace_back(std::make_unique<cafmaker::TMSRecoBranchFiller>(tmsFile));
+    recoFillers.emplace_back(std::make_unique<cafmaker::TMSRecoBranchFiller>(tmsFile,
+                                                                              par().cafmaker().vertexMatchToleranceMm()));
     std::cout << "   TMS\n";
   }
 
@@ -389,7 +390,8 @@ void loop(CAF &caf,
   // but the TruthMatching knows not to try to do anything with a null gtree
   cafmaker::Logger::THRESHOLD thresh = cafmaker::Logger::parseStringThresh(par().cafmaker().verbosity());
   cafmaker::TruthMatcher truthMatcher(ghepFilenames, edepsimFilename , caf.mcrec,
-                                      [&caf](const genie::NtpMCEventRecord* mcrec){ return caf.StoreGENIEEvent(mcrec); });
+                                      [&caf](const genie::NtpMCEventRecord* mcrec){ return caf.StoreGENIEEvent(mcrec); },
+                                      par().cafmaker().positionToleranceMm());
   truthMatcher.SetLogThrehsold(thresh);
   // figure out which triggers we need to loop over between the various reco fillers
   std::map<const cafmaker::IRecoBranchFiller*, std::deque<cafmaker::Trigger>> triggersByRBF;

--- a/src/reco/TMSRecoBranchFiller.cxx
+++ b/src/reco/TMSRecoBranchFiller.cxx
@@ -73,17 +73,21 @@ namespace cafmaker
       //TMSRecoTree->SetBranchAddress("TimeSliceStartTime",    &_TimeSliceStartTime);
       TMSLCTree->SetBranchAddress("TMSStartTime",            _TMSStartTime); // Temporary for prod n4p1, time avialable in Reco_Tree for future prods
 
-      // Add Truth tree for the index of the true primary particles
-      TMSTrueTree->SetBranchAddress("TrueVtxX",                       _TrueVtxX);
-      TMSTrueTree->SetBranchAddress("TrueVtxY",                       _TrueVtxY);
-      TMSTrueTree->SetBranchAddress("TrueVtxZ",                       _TrueVtxZ);
-      TMSTrueTree->SetBranchAddress("RecoTrackPrimaryParticleVtxId",  _RecoTrueVtxId);
-      TMSTrueTree->SetBranchAddress("RecoTrackPrimaryParticleIndex",  _RecoTruePartId);
+      // Truth_Info is only used to map reco tracks to truth-particle indices.
+      TMSTrueTree->SetBranchAddress("RecoTrackPrimaryParticleIndex",   _RecoTruePartId);
       TMSTrueTree->SetBranchAddress("RecoTrackSecondaryParticleIndex", _RecoTruePartIdSec);
 
-      TMSTrueSpill->SetBranchAddress("VertexID",                       _TrueVtxId);
-      TMSTrueSpill->SetBranchAddress("TrueVtxN",                       &_TrueVtxN);
-      TMSTrueSpill->SetBranchAddress("RunNo",                          &_TrueRunNo);
+      TMSTrueSpill->SetBranchAddress("SpillNo",                        &_TruthSpillSpillNo);
+      TMSTrueSpill->SetBranchAddress("RunNo",                          &_TruthSpillRunNo);
+      TMSTrueSpill->SetBranchAddress("nTrueParticles",                 &_TruthSpillNTrueParticles);
+      TMSTrueSpill->SetBranchAddress("VertexID",                       _TruthSpillParticleVertexID);
+      TMSTrueSpill->SetBranchAddress("Parent",                         _TruthSpillParent);
+      TMSTrueSpill->SetBranchAddress("BirthPosition",                  _TruthSpillBirthPosition);
+      TMSTrueSpill->SetBranchAddress("TrueVtxN",                       &_TruthSpillTrueVtxN);
+      TMSTrueSpill->SetBranchAddress("TrueVtxID",                      _TruthSpillTrueVtxID);
+      TMSTrueSpill->SetBranchAddress("TrueVtxX",                       _TruthSpillTrueVtxX);
+      TMSTrueSpill->SetBranchAddress("TrueVtxY",                       _TruthSpillTrueVtxY);
+      TMSTrueSpill->SetBranchAddress("TrueVtxZ",                       _TruthSpillTrueVtxZ);
 
     } else {
       fTMSRecoFile = NULL;
@@ -106,16 +110,109 @@ namespace cafmaker
     fTMSRecoFile = NULL;
   }
 
-  unsigned long TMSRecoBranchFiller::ResolveTrueInteractionID(const TruthMatcher * truthMatch,
-                                                              int trueVtxId,
-                                                              double trueVtxX,
-                                                              double trueVtxY,
-                                                              double trueVtxZ) const
+  void TMSRecoBranchFiller::LoadTruthSpillEntry(int spillNo) const
+  {
+    if (fTruthSpillEntryBySpillNo.empty())
+    {
+      for (Long64_t entry = 0; entry < TMSTrueSpill->GetEntries(); ++entry)
+      {
+        TMSTrueSpill->GetEntry(entry);
+        auto [it, inserted] = fTruthSpillEntryBySpillNo.emplace(_TruthSpillSpillNo, entry);
+        if (!inserted && it->second != entry)
+        {
+          std::stringstream ss;
+          ss << "Truth_Spill has multiple entries for SpillNo " << _TruthSpillSpillNo << "\n";
+          throw std::runtime_error(ss.str());
+        }
+      }
+    }
+
+    auto it = fTruthSpillEntryBySpillNo.find(spillNo);
+    if (it == fTruthSpillEntryBySpillNo.end())
+    {
+      std::stringstream ss;
+      ss << "Could not find Truth_Spill entry for SpillNo " << spillNo << "\n";
+      throw std::runtime_error(ss.str());
+    }
+
+    TMSTrueSpill->GetEntry(it->second);
+  }
+
+  unsigned long TMSRecoBranchFiller::ResolveTrueInteractionIDFromVertexIndex(const TruthMatcher * truthMatch, int trueVtxIdx) const
   {
     if (!truthMatch)
       throw std::runtime_error("TMSRecoBranchFiller requires TruthMatcher to resolve true interaction IDs");
+    if (trueVtxIdx < 0 || trueVtxIdx >= _TruthSpillTrueVtxN)
+      throw std::runtime_error("Requested Truth_Spill vertex index is out of range");
 
-    return truthMatch->ResolveVertexID(static_cast<unsigned int>(trueVtxId), trueVtxX, trueVtxY, trueVtxZ);
+    return truthMatch->ResolveVertexID(static_cast<unsigned int>(_TruthSpillTrueVtxID[trueVtxIdx]),
+                                       _TruthSpillTrueVtxX[trueVtxIdx],
+                                       _TruthSpillTrueVtxY[trueVtxIdx],
+                                       _TruthSpillTrueVtxZ[trueVtxIdx]);
+  }
+
+  unsigned long TMSRecoBranchFiller::ResolveRecoTrackInteractionID(const TruthMatcher * truthMatch, int recoTrackIdx) const
+  {
+    if (recoTrackIdx < 0)
+      throw std::runtime_error("Requested reco track index is negative");
+
+    int particleIdx = _RecoTruePartId[recoTrackIdx];
+    if (particleIdx < 0 || particleIdx >= _TruthSpillNTrueParticles)
+    {
+      std::stringstream ss;
+      ss << "Reco track " << recoTrackIdx << " maps to invalid Truth_Spill particle index " << particleIdx << "\n";
+      throw std::runtime_error(ss.str());
+    }
+
+    while (_TruthSpillParent[particleIdx] != -1)
+    {
+      int parentIdx = _TruthSpillParent[particleIdx];
+      if (parentIdx < 0 || parentIdx >= _TruthSpillNTrueParticles)
+      {
+        std::stringstream ss;
+        ss << "Truth_Spill particle " << particleIdx << " has out-of-range parent index " << parentIdx << "\n";
+        throw std::runtime_error(ss.str());
+      }
+      particleIdx = parentIdx;
+    }
+
+    const int trueVtxId = _TruthSpillParticleVertexID[particleIdx];
+    const double birthX = _TruthSpillBirthPosition[particleIdx][0];
+    const double birthY = _TruthSpillBirthPosition[particleIdx][1];
+    const double birthZ = _TruthSpillBirthPosition[particleIdx][2];
+
+    constexpr double kVertexMatchToleranceMm = 100.0;
+    int matchedVtxIdx = -1;
+    for (int i = 0; i < _TruthSpillTrueVtxN; ++i)
+    {
+      if (_TruthSpillTrueVtxID[i] != trueVtxId)
+        continue;
+
+      const double dx = _TruthSpillTrueVtxX[i] - birthX;
+      const double dy = _TruthSpillTrueVtxY[i] - birthY;
+      const double dz = _TruthSpillTrueVtxZ[i] - birthZ;
+      const double dist2 = dx*dx + dy*dy + dz*dz;
+      if (dist2 > kVertexMatchToleranceMm * kVertexMatchToleranceMm)
+        continue;
+
+      if (matchedVtxIdx >= 0)
+      {
+        std::stringstream ss;
+        ss << "Reco track " << recoTrackIdx << " matches multiple Truth_Spill vertices for vertex ID " << trueVtxId << "\n";
+        throw std::runtime_error(ss.str());
+      }
+      matchedVtxIdx = i;
+    }
+
+    if (matchedVtxIdx < 0)
+    {
+      std::stringstream ss;
+      ss << "Reco track " << recoTrackIdx << " could not match primary particle birth position to a Truth_Spill vertex for vertex ID "
+         << trueVtxId << " within " << kVertexMatchToleranceMm << " mm\n";
+      throw std::runtime_error(ss.str());
+    }
+
+    return ResolveTrueInteractionIDFromVertexIndex(truthMatch, matchedVtxIdx);
   }
 
   // here we copy all the TMS reco into the SRTMS branch of the StandardRecord object.
@@ -148,16 +245,11 @@ namespace cafmaker
 
     caf::SRTMSInt *interaction;
 
-    // Fill Truth parts first?
-    for (int i_tru=0; i_tru< TMSTrueSpill->GetEntries(); i_tru++)
+    LoadTruthSpillEntry(LastSpillNo);
+    for (int i_tvtx = 0; i_tvtx < _TruthSpillTrueVtxN; ++i_tvtx)
     {
-      TMSTrueSpill->GetEntry(i_tru);
-
-      for (int i_tvtx=0; i_tvtx<_TrueVtxN; i_tvtx++)
-      {
-        auto neutrino_event_id = ResolveTrueInteractionID(truthMatcher, _TrueVtxId[i_tvtx], _TrueVtxX[i_tvtx], _TrueVtxY[i_tvtx], _TrueVtxZ[i_tvtx]);
-        (void)truthMatcher->GetTrueInteraction(sr, neutrino_event_id, true); // called for side effect of registering the interaction; cast suppresses unused-return-value warning
-      }
+      auto neutrino_event_id = ResolveTrueInteractionIDFromVertexIndex(truthMatcher, i_tvtx);
+      (void)truthMatcher->GetTrueInteraction(sr, neutrino_event_id, true); // called for side effect of registering the interaction; cast suppresses unused-return-value warning
     }
 
     // the i index is incremented at the end of the following while()
@@ -196,7 +288,7 @@ namespace cafmaker
           /*  Fill Truth
            *  The run numbers in the GHEP(?) or edep files are of the run number, followed by the event number, so we recreate that.
            * Long cos it's very long innit. Sorry. */
-          const auto genieIxnID = ResolveTrueInteractionID(truthMatcher, _RecoTrueVtxId[j], _TrueVtxX[j], _TrueVtxY[j], _TrueVtxZ[j]);
+          const auto genieIxnID = ResolveRecoTrackInteractionID(truthMatcher, j);
           caf::SRTrueInteraction& srTrueInt = truthMatcher->GetTrueInteraction(sr, genieIxnID);
 
           const int srTrueIntIdx = static_cast<int>(std::distance(sr.mc.nu.begin(),
@@ -228,10 +320,9 @@ namespace cafmaker
   void TMSRecoBranchFiller::FillInteractions(const TruthMatcher * truthMatch, caf::StandardRecord &sr) const
   {
 
-    for (int i_int = 0; i_int<_TrueVtxN; i_int++)
+    for (int i_int = 0; i_int < _TruthSpillTrueVtxN; ++i_int)
     {
-      //Long_t neutrino_event_id = _TrueVtxId[i_int];//mc_int_edepsimId[i_int];
-      auto neutrino_event_id = ResolveTrueInteractionID(truthMatch, _TrueVtxId[i_int], _TrueVtxX[i_int], _TrueVtxY[i_int], _TrueVtxZ[i_int]);
+      auto neutrino_event_id = ResolveTrueInteractionIDFromVertexIndex(truthMatch, i_int);
       caf::SRTrueInteraction & srTrueInt = truthMatch->GetTrueInteraction(sr, neutrino_event_id);
       LOG.VERBOSE() << "    --> resulting SRTrueInteraction has the following particles in it:\n";
       for (const caf::SRTrueParticle & part : srTrueInt.prim)

--- a/src/reco/TMSRecoBranchFiller.cxx
+++ b/src/reco/TMSRecoBranchFiller.cxx
@@ -455,7 +455,7 @@ namespace cafmaker
 
     for (const Trigger & trigger : fTriggers)
     {
-      if (triggerType < 0 || triggerType == fTriggers.back().triggerType)
+      if (triggerType < 0 || triggerType == trigger.triggerType)
       {
         triggers.push_back(trigger);
       }

--- a/src/reco/TMSRecoBranchFiller.cxx
+++ b/src/reco/TMSRecoBranchFiller.cxx
@@ -82,6 +82,7 @@ namespace cafmaker
       TMSTrueSpill->SetBranchAddress("nTrueParticles",                 &_TruthSpillNTrueParticles);
       TMSTrueSpill->SetBranchAddress("VertexID",                       _TruthSpillParticleVertexID);
       TMSTrueSpill->SetBranchAddress("Parent",                         _TruthSpillParent);
+      TMSTrueSpill->SetBranchAddress("TrackId",                        _TruthSpillTrackID);
       TMSTrueSpill->SetBranchAddress("BirthPosition",                  _TruthSpillBirthPosition);
       TMSTrueSpill->SetBranchAddress("TrueVtxN",                       &_TruthSpillTrueVtxN);
       TMSTrueSpill->SetBranchAddress("TrueVtxID",                      _TruthSpillTrueVtxID);
@@ -151,12 +152,12 @@ namespace cafmaker
                                                          _TruthSpillTrueVtxZ[trueVtxIdx]);
   }
 
-  unsigned long TMSRecoBranchFiller::ResolveRecoTrackInteractionID(const TruthMatcher * truthMatch, int recoTrackIdx) const
+  int TMSRecoBranchFiller::ResolveRecoTrackTruthParticleIndex(int recoTrackIdx) const
   {
     if (recoTrackIdx < 0)
       throw std::runtime_error("Requested reco track index is negative");
 
-    int particleIdx = _RecoTruePartId[recoTrackIdx];
+    const int particleIdx = _RecoTruePartId[recoTrackIdx];
     if (particleIdx < 0 || particleIdx >= _TruthSpillNTrueParticles)
     {
       std::stringstream ss;
@@ -164,17 +165,54 @@ namespace cafmaker
       throw std::runtime_error(ss.str());
     }
 
+    return particleIdx;
+  }
+
+  int TMSRecoBranchFiller::FindTruthSpillParticleIndex(int vertexId, int trackId) const
+  {
+    for (int i = 0; i < _TruthSpillNTrueParticles; ++i)
+    {
+      if (_TruthSpillParticleVertexID[i] == vertexId && _TruthSpillTrackID[i] == trackId)
+        return i;
+    }
+    return -1;
+  }
+
+  int TMSRecoBranchFiller::ResolvePrimaryTruthParticleIndex(int particleIdx, int recoTrackIdx) const
+  {
+    std::vector<int> visited;
     while (_TruthSpillParent[particleIdx] != -1)
     {
-      int parentIdx = _TruthSpillParent[particleIdx];
-      if (parentIdx < 0 || parentIdx >= _TruthSpillNTrueParticles)
+      if (std::find(visited.begin(), visited.end(), particleIdx) != visited.end())
       {
-        std::stringstream ss;
-        ss << "Truth_Spill particle " << particleIdx << " has out-of-range parent index " << parentIdx << "\n";
-        throw std::runtime_error(ss.str());
+        LOG.WARNING() << "TMS reco track " << recoTrackIdx
+                      << " encountered a loop while resolving Truth_Spill parents;"
+                      << " falling back to particle index " << particleIdx << "\n";
+        return particleIdx;
+      }
+      visited.push_back(particleIdx);
+
+      const int parentTrackId = _TruthSpillParent[particleIdx];
+      const int vertexId = _TruthSpillParticleVertexID[particleIdx];
+      const int parentIdx = FindTruthSpillParticleIndex(vertexId, parentTrackId);
+      if (parentIdx < 0)
+      {
+        LOG.WARNING() << "TMS reco track " << recoTrackIdx
+                      << " could not resolve parent track ID " << parentTrackId
+                      << " from Truth_Spill particle index " << particleIdx
+                      << " (vertex ID " << vertexId << ");"
+                      << " falling back to the current particle instead of crashing\n";
+        return particleIdx;
       }
       particleIdx = parentIdx;
     }
+
+    return particleIdx;
+  }
+
+  unsigned long TMSRecoBranchFiller::ResolveRecoTrackInteractionID(const TruthMatcher * truthMatch, int recoTrackIdx) const
+  {
+    const int particleIdx = ResolvePrimaryTruthParticleIndex(ResolveRecoTrackTruthParticleIndex(recoTrackIdx), recoTrackIdx);
 
     const int trueVtxId = _TruthSpillParticleVertexID[particleIdx];
     const double birthX = _TruthSpillBirthPosition[particleIdx][0];
@@ -297,7 +335,8 @@ namespace cafmaker
                                                                                { return ixn.id == srTrueInt.id; })));
 
           // TODO: Make TMS care about prim/sec tracks (check _RecoTruePartIdSec for secondaries)
-          const int partG4ID = _RecoTruePartId[j];
+          const int recoTruthParticleIdx = ResolveRecoTrackTruthParticleIndex(j);
+          const int partG4ID = _TruthSpillTrackID[recoTruthParticleIdx];
           truthMatcher->GetTrueParticle(sr, srTrueInt, partG4ID, true);
           const int truthVecIdx = static_cast<int>(std::distance(srTrueInt.prim.begin(),
                                                                  std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(),

--- a/src/reco/TMSRecoBranchFiller.cxx
+++ b/src/reco/TMSRecoBranchFiller.cxx
@@ -412,35 +412,43 @@ namespace cafmaker
 
         lastSpillNo = _SpillNo;
 
-        Trigger & prev_trig = fTriggers.back(); // trigger before 'trig'
-        fTriggers.emplace_back();               // add new trigger entry (unfilled)
-        Trigger & trig      = fTriggers.back(); // trigger we're working on
-
-        trig.evtID = entry;
-        trig.triggerType = 1; // TODO real number?
-
-        if (entry == 0)
-          trig.triggerTime_ns = 0;
-        else
-          trig.triggerTime_ns = prev_trig.triggerTime_ns + 2E8 ;
-
-        if (entry == 0)
-          trig.triggerTime_s = 0;
-        else
+        if (!fTriggers.empty())
         {
+          Trigger & prev_trig = fTriggers.back(); // trigger before 'trig'
+          fTriggers.emplace_back();               // add new trigger entry (unfilled)
+          Trigger & trig      = fTriggers.back(); // trigger we're working on
+
+          trig.evtID = entry;
+          trig.triggerType = 1; // TODO real number?
+
+          trig.triggerTime_ns = prev_trig.triggerTime_ns + 2E8 ;
           trig.triggerTime_s = prev_trig.triggerTime_s + 1; // TODO: Pull the 1.2 from correct place in file
           if (trig.triggerTime_ns >= 1E9) // If we have 1s worth of ns then add 1s and remove 1s worth of ns
           {
             trig.triggerTime_s += 1;
             trig.triggerTime_ns -= 1E9;
           }
-        }
 
-        LOG.VERBOSE() << "  added trigger:  evtID=" << trig.evtID
-                      << ", triggerType=" << trig.triggerType
-                      << ", triggerTime_s=" << trig.triggerTime_s
-                      << ", triggerTime_ns=" << trig.triggerTime_ns
-                      << "\n";
+          LOG.VERBOSE() << "  added trigger:  evtID=" << trig.evtID
+                        << ", triggerType=" << trig.triggerType
+                        << ", triggerTime_s=" << trig.triggerTime_s
+                        << ", triggerTime_ns=" << trig.triggerTime_ns
+                        << "\n";
+        }
+        else
+        {
+          fTriggers.emplace_back();
+          Trigger & trig = fTriggers.back();
+          trig.evtID = entry;
+          trig.triggerType = 1; // TODO real number?
+          trig.triggerTime_ns = 0;
+          trig.triggerTime_s = 0;
+          LOG.VERBOSE() << "  added trigger:  evtID=" << trig.evtID
+                        << ", triggerType=" << trig.triggerType
+                        << ", triggerTime_s=" << trig.triggerTime_s
+                        << ", triggerTime_ns=" << trig.triggerTime_ns
+                        << "\n";
+        }
       }
       fLastTriggerReqd = fTriggers.end();  // since we just modified the list, any iterators have been invalidated
     }

--- a/src/reco/TMSRecoBranchFiller.cxx
+++ b/src/reco/TMSRecoBranchFiller.cxx
@@ -3,6 +3,7 @@
 
 #include <cmath>
 #include <limits>
+#include <unordered_set>
 
 /*
  * Liam O'Sullivan <liam.osullivan@uni-mainz.de>  -  Oct 2024
@@ -185,17 +186,17 @@ namespace cafmaker
 
   int TMSRecoBranchFiller::ResolvePrimaryTruthParticleIndex(int particleIdx, int recoTrackIdx) const
   {
-    std::vector<int> visited;
+    std::unordered_set<int> visited;
     while (_TruthSpillParent[particleIdx] != -1)
     {
-      if (std::find(visited.begin(), visited.end(), particleIdx) != visited.end())
+      if (visited.find(particleIdx) != visited.end())
       {
         LOG.WARNING() << "TMS reco track " << recoTrackIdx
                       << " encountered a loop while resolving Truth_Spill parents;"
                       << " falling back to particle index " << particleIdx << "\n";
         return particleIdx;
       }
-      visited.push_back(particleIdx);
+      visited.insert(particleIdx);
 
       const int parentTrackId = _TruthSpillParent[particleIdx];
       const int vertexId = _TruthSpillParticleVertexID[particleIdx];

--- a/src/reco/TMSRecoBranchFiller.cxx
+++ b/src/reco/TMSRecoBranchFiller.cxx
@@ -12,10 +12,12 @@
 namespace cafmaker
 {
 
-  TMSRecoBranchFiller::TMSRecoBranchFiller(const std::string &tmsRecoFilename)
+  TMSRecoBranchFiller::TMSRecoBranchFiller(const std::string &tmsRecoFilename,
+                                           double vertexMatchToleranceMm)
     : IRecoBranchFiller("TMS"),
     fTriggers(),
-    fLastTriggerReqd(fTriggers.end())
+    fLastTriggerReqd(fTriggers.end()),
+    fVertexMatchToleranceMm(vertexMatchToleranceMm)
   {
     fTMSRecoFile = new TFile(tmsRecoFilename.c_str(), "READ");
     name = std::string("TMS");
@@ -222,7 +224,6 @@ namespace cafmaker
     const double birthY = _TruthSpillBirthPosition[particleIdx][1];
     const double birthZ = _TruthSpillBirthPosition[particleIdx][2];
 
-    constexpr double kVertexMatchToleranceMm = 100.0;
     int matchedVtxIdx = -1;
     int nearestVtxIdx = -1;
     double nearestDist2 = std::numeric_limits<double>::infinity();
@@ -240,7 +241,7 @@ namespace cafmaker
 
       if (_TruthSpillTrueVtxID[i] != trueVtxId)
         continue;
-      if (dist2 > kVertexMatchToleranceMm * kVertexMatchToleranceMm)
+      if (dist2 > fVertexMatchToleranceMm * fVertexMatchToleranceMm)
         continue;
 
       if (matchedVtxIdx >= 0)
@@ -260,7 +261,7 @@ namespace cafmaker
     {
       LOG.WARNING() << "Reco track " << recoTrackIdx
                     << " could not match primary particle birth position to a Truth_Spill vertex for vertex ID "
-                    << trueVtxId << " within " << kVertexMatchToleranceMm << " mm;"
+                    << trueVtxId << " within " << fVertexMatchToleranceMm << " mm;"
                     << " falling back to nearest Truth_Spill vertex index " << nearestVtxIdx
                     << " at distance " << std::sqrt(nearestDist2) << " mm\n";
       return ResolveTrueInteractionIDFromVertexIndex(truthMatch, nearestVtxIdx);

--- a/src/reco/TMSRecoBranchFiller.cxx
+++ b/src/reco/TMSRecoBranchFiller.cxx
@@ -1,58 +1,8 @@
 #include "TMSRecoBranchFiller.h"
 #include "truth/FillTruth.h"
 
-#include <chrono>
 #include <cmath>
-#include <cstdlib>
 #include <limits>
-#include <string>
-
-namespace
-{
-  bool TMSRecoTimingEnabled()
-  {
-    static const bool enabled = []()
-    {
-      const char * env = std::getenv("ND_CAFMAKER_TIMING");
-      if (!env) return false;
-      const std::string value(env);
-      return !value.empty() && value != "0" && value != "false" && value != "FALSE";
-    }();
-    return enabled;
-  }
-
-  class ScopedTiming
-  {
-    public:
-      ScopedTiming(bool enabled, cafmaker::TMSRecoBranchFiller::TimingSummary & summary)
-        : fEnabled(enabled), fSummary(summary)
-      {
-        if (fEnabled)
-          fStart = std::chrono::steady_clock::now();
-      }
-
-      ~ScopedTiming()
-      {
-        if (!fEnabled) return;
-        ++fSummary.calls;
-        fSummary.totalMs += std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - fStart).count();
-      }
-
-    private:
-      bool fEnabled = false;
-      cafmaker::TMSRecoBranchFiller::TimingSummary & fSummary;
-      std::chrono::steady_clock::time_point fStart;
-  };
-
-  void PrintTimingSummaryLine(const char * label, const cafmaker::TMSRecoBranchFiller::TimingSummary & summary)
-  {
-    std::cerr << "  " << label << ": total=" << summary.totalMs << " ms"
-              << ", calls=" << summary.calls;
-    if (summary.calls > 0)
-      std::cerr << ", avg=" << (summary.totalMs / summary.calls) << " ms/call";
-    std::cerr << "\n";
-  }
-}
 
 /*
  * Liam O'Sullivan <liam.osullivan@uni-mainz.de>  -  Oct 2024
@@ -67,8 +17,6 @@ namespace cafmaker
     fTriggers(),
     fLastTriggerReqd(fTriggers.end())
   {
-    fTiming.enabled = TMSRecoTimingEnabled();
-
     fTMSRecoFile = new TFile(tmsRecoFilename.c_str(), "READ");
     name = std::string("TMS");
 
@@ -157,57 +105,6 @@ namespace cafmaker
 
 
   TMSRecoBranchFiller::~TMSRecoBranchFiller() {
-    if (fTiming.enabled)
-    {
-      std::cerr << "[ND_CAFMaker timing] TMSRecoBranchFiller summary\n";
-      PrintTimingSummaryLine("LoadTruthSpillEntry", fTiming.loadTruthSpillEntry);
-      PrintTimingSummaryLine("BuildTruthSpillEntryMap", fTiming.buildTruthSpillEntryMap);
-      PrintTimingSummaryLine("ResolveTrueInteractionIDFromVertexIndex", fTiming.resolveTrueInteractionIDFromVertexIndex);
-      PrintTimingSummaryLine("ResolveRecoTrackTruthParticleIndex", fTiming.resolveRecoTrackTruthParticleIndex);
-      PrintTimingSummaryLine("FindTruthSpillParticleIndex", fTiming.findTruthSpillParticleIndex);
-      PrintTimingSummaryLine("ResolvePrimaryTruthParticleIndex", fTiming.resolvePrimaryTruthParticleIndex);
-      PrintTimingSummaryLine("ResolveRecoTrackInteractionID", fTiming.resolveRecoTrackInteractionID);
-      PrintTimingSummaryLine("GetTrueInteraction", fTiming.getTrueInteraction);
-      PrintTimingSummaryLine("GetTrueParticle", fTiming.getTrueParticle);
-      PrintTimingSummaryLine("FindSRTrueInteractionIndex", fTiming.findSRTrueInteractionIndex);
-      PrintTimingSummaryLine("FindSRTrueParticleIndex", fTiming.findSRTrueParticleIndex);
-      PrintTimingSummaryLine("_FillRecoBranches", fTiming.fillRecoBranches);
-      PrintTimingSummaryLine("FillInteractions", fTiming.fillInteractions);
-      PrintTimingSummaryLine("GetTriggers", fTiming.getTriggers);
-      std::cerr << "  BuildTruthSpillEntryMap: entries_scanned=" << fTiming.buildTruthSpillEntryMapEntries
-                << ", map_size=" << fTruthSpillEntryBySpillNo.size() << "\n";
-      std::cerr << "  LoadTruthSpillEntry: misses=" << fTiming.loadTruthSpillEntryMisses << "\n";
-      std::cerr << "  ResolvePrimaryTruthParticleIndex: parent_steps=" << fTiming.resolvePrimaryParentSteps
-                << ", loop_fallbacks=" << fTiming.resolvePrimaryLoopFallbacks
-                << ", missing_parent_fallbacks=" << fTiming.resolvePrimaryMissingParentFallbacks;
-      if (fTiming.resolvePrimaryTruthParticleIndex.calls > 0)
-        std::cerr << ", avg_steps/call="
-                  << (static_cast<double>(fTiming.resolvePrimaryParentSteps) / fTiming.resolvePrimaryTruthParticleIndex.calls);
-      std::cerr << "\n";
-      std::cerr << "  FindTruthSpillParticleIndex: entries_scanned=" << fTiming.findTruthSpillParticleIndexEntriesScanned
-                << ", hits=" << fTiming.findTruthSpillParticleIndexHits;
-      if (fTiming.findTruthSpillParticleIndex.calls > 0)
-        std::cerr << ", avg_entries/call="
-                  << (static_cast<double>(fTiming.findTruthSpillParticleIndexEntriesScanned) / fTiming.findTruthSpillParticleIndex.calls);
-      std::cerr << "\n";
-      std::cerr << "  ResolveRecoTrackInteractionID: vertex_scans=" << fTiming.resolveRecoTrackInteractionVertexScans
-                << ", exact_matches=" << fTiming.resolveRecoTrackInteractionExactMatches
-                << ", nearest_fallbacks=" << fTiming.resolveRecoTrackInteractionNearestFallbacks
-                << ", multi_matches=" << fTiming.resolveRecoTrackInteractionMultiMatches;
-      if (fTiming.resolveRecoTrackInteractionID.calls > 0)
-        std::cerr << ", avg_vertices/call="
-                  << (static_cast<double>(fTiming.resolveRecoTrackInteractionVertexScans) / fTiming.resolveRecoTrackInteractionID.calls);
-      std::cerr << "\n";
-      std::cerr << "  _FillRecoBranches: spills_processed=" << fTiming.fillRecoBranchesSpillsProcessed
-                << ", tracks_processed=" << fTiming.fillRecoBranchesTracksProcessed;
-      if (fTiming.fillRecoBranches.calls > 0)
-        std::cerr << ", avg_tracks/call="
-                  << (static_cast<double>(fTiming.fillRecoBranchesTracksProcessed) / fTiming.fillRecoBranches.calls);
-      std::cerr << "\n";
-      std::cerr << "  GetTriggers: entries_scanned=" << fTiming.getTriggersEntriesScanned
-                << ", triggers_created=" << fTiming.getTriggersCreated << "\n";
-    }
-
     delete TMSRecoTree;    
     delete TMSLCTree;
     fTMSRecoFile->Close();
@@ -219,14 +116,10 @@ namespace cafmaker
 
   void TMSRecoBranchFiller::LoadTruthSpillEntry(int spillNo) const
   {
-    ScopedTiming timing(fTiming.enabled, fTiming.loadTruthSpillEntry);
-
     if (fTruthSpillEntryBySpillNo.empty())
     {
-      ScopedTiming buildTiming(fTiming.enabled, fTiming.buildTruthSpillEntryMap);
       for (Long64_t entry = 0; entry < TMSTrueSpill->GetEntries(); ++entry)
       {
-        ++fTiming.buildTruthSpillEntryMapEntries;
         TMSTrueSpill->GetEntry(entry);
         auto [it, inserted] = fTruthSpillEntryBySpillNo.emplace(_TruthSpillSpillNo, entry);
         if (!inserted && it->second != entry)
@@ -241,7 +134,6 @@ namespace cafmaker
     auto it = fTruthSpillEntryBySpillNo.find(spillNo);
     if (it == fTruthSpillEntryBySpillNo.end())
     {
-      ++fTiming.loadTruthSpillEntryMisses;
       std::stringstream ss;
       ss << "Could not find Truth_Spill entry for SpillNo " << spillNo << "\n";
       throw std::runtime_error(ss.str());
@@ -252,8 +144,6 @@ namespace cafmaker
 
   unsigned long TMSRecoBranchFiller::ResolveTrueInteractionIDFromVertexIndex(const TruthMatcher * truthMatch, int trueVtxIdx) const
   {
-    ScopedTiming timing(fTiming.enabled, fTiming.resolveTrueInteractionIDFromVertexIndex);
-
     if (!truthMatch)
       throw std::runtime_error("TMSRecoBranchFiller requires TruthMatcher to resolve true interaction IDs");
     if (trueVtxIdx < 0 || trueVtxIdx >= _TruthSpillTrueVtxN)
@@ -267,8 +157,6 @@ namespace cafmaker
 
   int TMSRecoBranchFiller::ResolveRecoTrackTruthParticleIndex(int recoTrackIdx) const
   {
-    ScopedTiming timing(fTiming.enabled, fTiming.resolveRecoTrackTruthParticleIndex);
-
     if (recoTrackIdx < 0)
       throw std::runtime_error("Requested reco track index is negative");
 
@@ -285,31 +173,21 @@ namespace cafmaker
 
   int TMSRecoBranchFiller::FindTruthSpillParticleIndex(int vertexId, int trackId) const
   {
-    ScopedTiming timing(fTiming.enabled, fTiming.findTruthSpillParticleIndex);
-
     for (int i = 0; i < _TruthSpillNTrueParticles; ++i)
     {
-      ++fTiming.findTruthSpillParticleIndexEntriesScanned;
       if (_TruthSpillParticleVertexID[i] == vertexId && _TruthSpillTrackID[i] == trackId)
-      {
-        ++fTiming.findTruthSpillParticleIndexHits;
         return i;
-      }
     }
     return -1;
   }
 
   int TMSRecoBranchFiller::ResolvePrimaryTruthParticleIndex(int particleIdx, int recoTrackIdx) const
   {
-    ScopedTiming timing(fTiming.enabled, fTiming.resolvePrimaryTruthParticleIndex);
-
     std::vector<int> visited;
     while (_TruthSpillParent[particleIdx] != -1)
     {
-      ++fTiming.resolvePrimaryParentSteps;
       if (std::find(visited.begin(), visited.end(), particleIdx) != visited.end())
       {
-        ++fTiming.resolvePrimaryLoopFallbacks;
         LOG.WARNING() << "TMS reco track " << recoTrackIdx
                       << " encountered a loop while resolving Truth_Spill parents;"
                       << " falling back to particle index " << particleIdx << "\n";
@@ -322,7 +200,6 @@ namespace cafmaker
       const int parentIdx = FindTruthSpillParticleIndex(vertexId, parentTrackId);
       if (parentIdx < 0)
       {
-        ++fTiming.resolvePrimaryMissingParentFallbacks;
         LOG.WARNING() << "TMS reco track " << recoTrackIdx
                       << " could not resolve parent track ID " << parentTrackId
                       << " from Truth_Spill particle index " << particleIdx
@@ -338,8 +215,6 @@ namespace cafmaker
 
   unsigned long TMSRecoBranchFiller::ResolveRecoTrackInteractionID(const TruthMatcher * truthMatch, int recoTrackIdx) const
   {
-    ScopedTiming timing(fTiming.enabled, fTiming.resolveRecoTrackInteractionID);
-
     const int particleIdx = ResolvePrimaryTruthParticleIndex(ResolveRecoTrackTruthParticleIndex(recoTrackIdx), recoTrackIdx);
 
     const int trueVtxId = _TruthSpillParticleVertexID[particleIdx];
@@ -353,7 +228,6 @@ namespace cafmaker
     double nearestDist2 = std::numeric_limits<double>::infinity();
     for (int i = 0; i < _TruthSpillTrueVtxN; ++i)
     {
-      ++fTiming.resolveRecoTrackInteractionVertexScans;
       const double dx = _TruthSpillTrueVtxX[i] - birthX;
       const double dy = _TruthSpillTrueVtxY[i] - birthY;
       const double dz = _TruthSpillTrueVtxZ[i] - birthZ;
@@ -371,7 +245,6 @@ namespace cafmaker
 
       if (matchedVtxIdx >= 0)
       {
-        ++fTiming.resolveRecoTrackInteractionMultiMatches;
         LOG.WARNING() << "Reco track " << recoTrackIdx
                       << " matched multiple Truth_Spill vertices for vertex ID " << trueVtxId
                       << "; using the first in-tolerance match instead of crashing\n";
@@ -381,14 +254,10 @@ namespace cafmaker
     }
 
     if (matchedVtxIdx >= 0)
-    {
-      ++fTiming.resolveRecoTrackInteractionExactMatches;
       return ResolveTrueInteractionIDFromVertexIndex(truthMatch, matchedVtxIdx);
-    }
 
     if (nearestVtxIdx >= 0)
     {
-      ++fTiming.resolveRecoTrackInteractionNearestFallbacks;
       LOG.WARNING() << "Reco track " << recoTrackIdx
                     << " could not match primary particle birth position to a Truth_Spill vertex for vertex ID "
                     << trueVtxId << " within " << kVertexMatchToleranceMm << " mm;"
@@ -406,7 +275,6 @@ namespace cafmaker
                                               const cafmaker::Params &par,
                                               const TruthMatcher *truthMatcher) const
   {
-    ScopedTiming timing(fTiming.enabled, fTiming.fillRecoBranches);
 
     sr.meta.tms.enabled = true;
 
@@ -431,15 +299,11 @@ namespace cafmaker
 
     caf::SRTMSInt *interaction;
 
-    ++fTiming.fillRecoBranchesSpillsProcessed;
     LoadTruthSpillEntry(LastSpillNo);
     for (int i_tvtx = 0; i_tvtx < _TruthSpillTrueVtxN; ++i_tvtx)
     {
       auto neutrino_event_id = ResolveTrueInteractionIDFromVertexIndex(truthMatcher, i_tvtx);
-      {
-        ScopedTiming subTiming(fTiming.enabled, fTiming.getTrueInteraction);
-        (void)truthMatcher->GetTrueInteraction(sr, neutrino_event_id, true); // called for side effect of registering the interaction; cast suppresses unused-return-value warning
-      }
+      (void)truthMatcher->GetTrueInteraction(sr, neutrino_event_id, true); // called for side effect of registering the interaction; cast suppresses unused-return-value warning
     }
 
     // the i index is incremented at the end of the following while()
@@ -451,7 +315,6 @@ namespace cafmaker
       if (_nTracks > 0)
       {        
         for (int j = 0; j < _nTracks; ++j) {
-          ++fTiming.fillRecoBranchesTracksProcessed;
           sr.nd.tms.nixn++;
           sr.nd.tms.ixn.emplace_back();
 
@@ -480,37 +343,21 @@ namespace cafmaker
            *  The run numbers in the GHEP(?) or edep files are of the run number, followed by the event number, so we recreate that.
            * Long cos it's very long innit. Sorry. */
           const auto genieIxnID = ResolveRecoTrackInteractionID(truthMatcher, j);
-          caf::SRTrueInteraction* srTrueIntPtr = nullptr;
-          {
-            ScopedTiming subTiming(fTiming.enabled, fTiming.getTrueInteraction);
-            srTrueIntPtr = &truthMatcher->GetTrueInteraction(sr, genieIxnID);
-          }
-          caf::SRTrueInteraction& srTrueInt = *srTrueIntPtr;
+          caf::SRTrueInteraction& srTrueInt = truthMatcher->GetTrueInteraction(sr, genieIxnID);
 
-          int srTrueIntIdx = -1;
-          {
-            ScopedTiming subTiming(fTiming.enabled, fTiming.findSRTrueInteractionIndex);
-            srTrueIntIdx = static_cast<int>(std::distance(sr.mc.nu.begin(),
-                                                          std::find_if(sr.mc.nu.begin(), sr.mc.nu.end(),
-                                                                       [&srTrueInt](const caf::SRTrueInteraction& ixn)
-                                                                       { return ixn.id == srTrueInt.id; })));
-          }
+          const int srTrueIntIdx = static_cast<int>(std::distance(sr.mc.nu.begin(),
+                                                                  std::find_if(sr.mc.nu.begin(), sr.mc.nu.end(),
+                                                                               [&srTrueInt](const caf::SRTrueInteraction& ixn)
+                                                                               { return ixn.id == srTrueInt.id; })));
 
           // TODO: Make TMS care about prim/sec tracks (check _RecoTruePartIdSec for secondaries)
           const int recoTruthParticleIdx = ResolveRecoTrackTruthParticleIndex(j);
           const int partG4ID = _TruthSpillTrackID[recoTruthParticleIdx];
-          {
-            ScopedTiming subTiming(fTiming.enabled, fTiming.getTrueParticle);
-            truthMatcher->GetTrueParticle(sr, srTrueInt, partG4ID, true);
-          }
-          int truthVecIdx = -1;
-          {
-            ScopedTiming subTiming(fTiming.enabled, fTiming.findSRTrueParticleIndex);
-            truthVecIdx = static_cast<int>(std::distance(srTrueInt.prim.begin(),
-                                                         std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(),
-                                                                      [partG4ID](const caf::SRTrueParticle& part)
-                                                                      { return part.G4ID == partG4ID; })));
-          }
+          truthMatcher->GetTrueParticle(sr, srTrueInt, partG4ID, true);
+          const int truthVecIdx = static_cast<int>(std::distance(srTrueInt.prim.begin(),
+                                                                 std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(),
+                                                                              [partG4ID](const caf::SRTrueParticle& part)
+                                                                              { return part.G4ID == partG4ID; })));
 
           interaction->tracks[0].truth.push_back(caf::TrueParticleID{srTrueIntIdx,
                                                                       caf::TrueParticleID::PartType::kPrimary,
@@ -527,17 +374,11 @@ namespace cafmaker
 
   void TMSRecoBranchFiller::FillInteractions(const TruthMatcher * truthMatch, caf::StandardRecord &sr) const
   {
-    ScopedTiming timing(fTiming.enabled, fTiming.fillInteractions);
 
     for (int i_int = 0; i_int < _TruthSpillTrueVtxN; ++i_int)
     {
       auto neutrino_event_id = ResolveTrueInteractionIDFromVertexIndex(truthMatch, i_int);
-      caf::SRTrueInteraction * srTrueIntPtr = nullptr;
-      {
-        ScopedTiming subTiming(fTiming.enabled, fTiming.getTrueInteraction);
-        srTrueIntPtr = &truthMatch->GetTrueInteraction(sr, neutrino_event_id);
-      }
-      caf::SRTrueInteraction & srTrueInt = *srTrueIntPtr;
+      caf::SRTrueInteraction & srTrueInt = truthMatch->GetTrueInteraction(sr, neutrino_event_id);
       LOG.VERBOSE() << "    --> resulting SRTrueInteraction has the following particles in it:\n";
       for (const caf::SRTrueParticle & part : srTrueInt.prim)
           LOG.VERBOSE() << "    (prim) id = " << part.G4ID << " pdg = " << part.pdg << ", energy = " << part.p.E << "\n";
@@ -552,7 +393,6 @@ namespace cafmaker
   // TODO: In future this nastiness will be handled by TMS
   std::deque<Trigger> TMSRecoBranchFiller::GetTriggers(int triggerType, bool beamOnly) const
   {
-    ScopedTiming timing(fTiming.enabled, fTiming.getTriggers);
     std::deque<Trigger> triggers;
     int lastSpillNo = std::numeric_limits<int>::lowest(); // Starting value, small number so next spill number is larger
 
@@ -563,7 +403,6 @@ namespace cafmaker
 
       for (int entry = 0; entry < TMSRecoTree->GetEntries(); entry++)
       {
-        ++fTiming.getTriggersEntriesScanned;
         TMSRecoTree->GetEntry(entry);
 
         if (_SpillNo == lastSpillNo)
@@ -571,45 +410,35 @@ namespace cafmaker
 
         lastSpillNo = _SpillNo;
 
-        if (!fTriggers.empty())
-        {
-          Trigger & prev_trig = fTriggers.back(); // trigger before 'trig'
-          fTriggers.emplace_back();               // add new trigger entry (unfilled)
-          Trigger & trig      = fTriggers.back(); // trigger we're working on
+        Trigger & prev_trig = fTriggers.back(); // trigger before 'trig'
+        fTriggers.emplace_back();               // add new trigger entry (unfilled)
+        Trigger & trig      = fTriggers.back(); // trigger we're working on
 
-          trig.evtID = entry;
-          trig.triggerType = 1; // TODO real number?
+        trig.evtID = entry;
+        trig.triggerType = 1; // TODO real number?
 
+        if (entry == 0)
+          trig.triggerTime_ns = 0;
+        else
           trig.triggerTime_ns = prev_trig.triggerTime_ns + 2E8 ;
+
+        if (entry == 0)
+          trig.triggerTime_s = 0;
+        else
+        {
           trig.triggerTime_s = prev_trig.triggerTime_s + 1; // TODO: Pull the 1.2 from correct place in file
           if (trig.triggerTime_ns >= 1E9) // If we have 1s worth of ns then add 1s and remove 1s worth of ns
           {
             trig.triggerTime_s += 1;
             trig.triggerTime_ns -= 1E9;
           }
-
-          LOG.VERBOSE() << "  added trigger:  evtID=" << trig.evtID
-                        << ", triggerType=" << trig.triggerType
-                        << ", triggerTime_s=" << trig.triggerTime_s
-                        << ", triggerTime_ns=" << trig.triggerTime_ns
-                        << "\n";
         }
-        else
-        {
-          fTriggers.emplace_back();
-          Trigger & trig = fTriggers.back();
-          trig.evtID = entry;
-          trig.triggerType = 1; // TODO real number?
-          trig.triggerTime_ns = 0;
-          trig.triggerTime_s = 0;
-          LOG.VERBOSE() << "  added trigger:  evtID=" << trig.evtID
-                        << ", triggerType=" << trig.triggerType
-                        << ", triggerTime_s=" << trig.triggerTime_s
-                        << ", triggerTime_ns=" << trig.triggerTime_ns
-                        << "\n";
-        }
-        ++fTiming.getTriggersCreated;
 
+        LOG.VERBOSE() << "  added trigger:  evtID=" << trig.evtID
+                      << ", triggerType=" << trig.triggerType
+                      << ", triggerTime_s=" << trig.triggerTime_s
+                      << ", triggerTime_ns=" << trig.triggerTime_ns
+                      << "\n";
       }
       fLastTriggerReqd = fTriggers.end();  // since we just modified the list, any iterators have been invalidated
     }

--- a/src/reco/TMSRecoBranchFiller.cxx
+++ b/src/reco/TMSRecoBranchFiller.cxx
@@ -1,8 +1,58 @@
 #include "TMSRecoBranchFiller.h"
 #include "truth/FillTruth.h"
 
+#include <chrono>
 #include <cmath>
+#include <cstdlib>
 #include <limits>
+#include <string>
+
+namespace
+{
+  bool TMSRecoTimingEnabled()
+  {
+    static const bool enabled = []()
+    {
+      const char * env = std::getenv("ND_CAFMAKER_TIMING");
+      if (!env) return false;
+      const std::string value(env);
+      return !value.empty() && value != "0" && value != "false" && value != "FALSE";
+    }();
+    return enabled;
+  }
+
+  class ScopedTiming
+  {
+    public:
+      ScopedTiming(bool enabled, cafmaker::TMSRecoBranchFiller::TimingSummary & summary)
+        : fEnabled(enabled), fSummary(summary)
+      {
+        if (fEnabled)
+          fStart = std::chrono::steady_clock::now();
+      }
+
+      ~ScopedTiming()
+      {
+        if (!fEnabled) return;
+        ++fSummary.calls;
+        fSummary.totalMs += std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - fStart).count();
+      }
+
+    private:
+      bool fEnabled = false;
+      cafmaker::TMSRecoBranchFiller::TimingSummary & fSummary;
+      std::chrono::steady_clock::time_point fStart;
+  };
+
+  void PrintTimingSummaryLine(const char * label, const cafmaker::TMSRecoBranchFiller::TimingSummary & summary)
+  {
+    std::cerr << "  " << label << ": total=" << summary.totalMs << " ms"
+              << ", calls=" << summary.calls;
+    if (summary.calls > 0)
+      std::cerr << ", avg=" << (summary.totalMs / summary.calls) << " ms/call";
+    std::cerr << "\n";
+  }
+}
 
 /*
  * Liam O'Sullivan <liam.osullivan@uni-mainz.de>  -  Oct 2024
@@ -17,6 +67,8 @@ namespace cafmaker
     fTriggers(),
     fLastTriggerReqd(fTriggers.end())
   {
+    fTiming.enabled = TMSRecoTimingEnabled();
+
     fTMSRecoFile = new TFile(tmsRecoFilename.c_str(), "READ");
     name = std::string("TMS");
 
@@ -105,6 +157,57 @@ namespace cafmaker
 
 
   TMSRecoBranchFiller::~TMSRecoBranchFiller() {
+    if (fTiming.enabled)
+    {
+      std::cerr << "[ND_CAFMaker timing] TMSRecoBranchFiller summary\n";
+      PrintTimingSummaryLine("LoadTruthSpillEntry", fTiming.loadTruthSpillEntry);
+      PrintTimingSummaryLine("BuildTruthSpillEntryMap", fTiming.buildTruthSpillEntryMap);
+      PrintTimingSummaryLine("ResolveTrueInteractionIDFromVertexIndex", fTiming.resolveTrueInteractionIDFromVertexIndex);
+      PrintTimingSummaryLine("ResolveRecoTrackTruthParticleIndex", fTiming.resolveRecoTrackTruthParticleIndex);
+      PrintTimingSummaryLine("FindTruthSpillParticleIndex", fTiming.findTruthSpillParticleIndex);
+      PrintTimingSummaryLine("ResolvePrimaryTruthParticleIndex", fTiming.resolvePrimaryTruthParticleIndex);
+      PrintTimingSummaryLine("ResolveRecoTrackInteractionID", fTiming.resolveRecoTrackInteractionID);
+      PrintTimingSummaryLine("GetTrueInteraction", fTiming.getTrueInteraction);
+      PrintTimingSummaryLine("GetTrueParticle", fTiming.getTrueParticle);
+      PrintTimingSummaryLine("FindSRTrueInteractionIndex", fTiming.findSRTrueInteractionIndex);
+      PrintTimingSummaryLine("FindSRTrueParticleIndex", fTiming.findSRTrueParticleIndex);
+      PrintTimingSummaryLine("_FillRecoBranches", fTiming.fillRecoBranches);
+      PrintTimingSummaryLine("FillInteractions", fTiming.fillInteractions);
+      PrintTimingSummaryLine("GetTriggers", fTiming.getTriggers);
+      std::cerr << "  BuildTruthSpillEntryMap: entries_scanned=" << fTiming.buildTruthSpillEntryMapEntries
+                << ", map_size=" << fTruthSpillEntryBySpillNo.size() << "\n";
+      std::cerr << "  LoadTruthSpillEntry: misses=" << fTiming.loadTruthSpillEntryMisses << "\n";
+      std::cerr << "  ResolvePrimaryTruthParticleIndex: parent_steps=" << fTiming.resolvePrimaryParentSteps
+                << ", loop_fallbacks=" << fTiming.resolvePrimaryLoopFallbacks
+                << ", missing_parent_fallbacks=" << fTiming.resolvePrimaryMissingParentFallbacks;
+      if (fTiming.resolvePrimaryTruthParticleIndex.calls > 0)
+        std::cerr << ", avg_steps/call="
+                  << (static_cast<double>(fTiming.resolvePrimaryParentSteps) / fTiming.resolvePrimaryTruthParticleIndex.calls);
+      std::cerr << "\n";
+      std::cerr << "  FindTruthSpillParticleIndex: entries_scanned=" << fTiming.findTruthSpillParticleIndexEntriesScanned
+                << ", hits=" << fTiming.findTruthSpillParticleIndexHits;
+      if (fTiming.findTruthSpillParticleIndex.calls > 0)
+        std::cerr << ", avg_entries/call="
+                  << (static_cast<double>(fTiming.findTruthSpillParticleIndexEntriesScanned) / fTiming.findTruthSpillParticleIndex.calls);
+      std::cerr << "\n";
+      std::cerr << "  ResolveRecoTrackInteractionID: vertex_scans=" << fTiming.resolveRecoTrackInteractionVertexScans
+                << ", exact_matches=" << fTiming.resolveRecoTrackInteractionExactMatches
+                << ", nearest_fallbacks=" << fTiming.resolveRecoTrackInteractionNearestFallbacks
+                << ", multi_matches=" << fTiming.resolveRecoTrackInteractionMultiMatches;
+      if (fTiming.resolveRecoTrackInteractionID.calls > 0)
+        std::cerr << ", avg_vertices/call="
+                  << (static_cast<double>(fTiming.resolveRecoTrackInteractionVertexScans) / fTiming.resolveRecoTrackInteractionID.calls);
+      std::cerr << "\n";
+      std::cerr << "  _FillRecoBranches: spills_processed=" << fTiming.fillRecoBranchesSpillsProcessed
+                << ", tracks_processed=" << fTiming.fillRecoBranchesTracksProcessed;
+      if (fTiming.fillRecoBranches.calls > 0)
+        std::cerr << ", avg_tracks/call="
+                  << (static_cast<double>(fTiming.fillRecoBranchesTracksProcessed) / fTiming.fillRecoBranches.calls);
+      std::cerr << "\n";
+      std::cerr << "  GetTriggers: entries_scanned=" << fTiming.getTriggersEntriesScanned
+                << ", triggers_created=" << fTiming.getTriggersCreated << "\n";
+    }
+
     delete TMSRecoTree;    
     delete TMSLCTree;
     fTMSRecoFile->Close();
@@ -116,10 +219,14 @@ namespace cafmaker
 
   void TMSRecoBranchFiller::LoadTruthSpillEntry(int spillNo) const
   {
+    ScopedTiming timing(fTiming.enabled, fTiming.loadTruthSpillEntry);
+
     if (fTruthSpillEntryBySpillNo.empty())
     {
+      ScopedTiming buildTiming(fTiming.enabled, fTiming.buildTruthSpillEntryMap);
       for (Long64_t entry = 0; entry < TMSTrueSpill->GetEntries(); ++entry)
       {
+        ++fTiming.buildTruthSpillEntryMapEntries;
         TMSTrueSpill->GetEntry(entry);
         auto [it, inserted] = fTruthSpillEntryBySpillNo.emplace(_TruthSpillSpillNo, entry);
         if (!inserted && it->second != entry)
@@ -134,6 +241,7 @@ namespace cafmaker
     auto it = fTruthSpillEntryBySpillNo.find(spillNo);
     if (it == fTruthSpillEntryBySpillNo.end())
     {
+      ++fTiming.loadTruthSpillEntryMisses;
       std::stringstream ss;
       ss << "Could not find Truth_Spill entry for SpillNo " << spillNo << "\n";
       throw std::runtime_error(ss.str());
@@ -144,6 +252,8 @@ namespace cafmaker
 
   unsigned long TMSRecoBranchFiller::ResolveTrueInteractionIDFromVertexIndex(const TruthMatcher * truthMatch, int trueVtxIdx) const
   {
+    ScopedTiming timing(fTiming.enabled, fTiming.resolveTrueInteractionIDFromVertexIndex);
+
     if (!truthMatch)
       throw std::runtime_error("TMSRecoBranchFiller requires TruthMatcher to resolve true interaction IDs");
     if (trueVtxIdx < 0 || trueVtxIdx >= _TruthSpillTrueVtxN)
@@ -157,6 +267,8 @@ namespace cafmaker
 
   int TMSRecoBranchFiller::ResolveRecoTrackTruthParticleIndex(int recoTrackIdx) const
   {
+    ScopedTiming timing(fTiming.enabled, fTiming.resolveRecoTrackTruthParticleIndex);
+
     if (recoTrackIdx < 0)
       throw std::runtime_error("Requested reco track index is negative");
 
@@ -173,21 +285,31 @@ namespace cafmaker
 
   int TMSRecoBranchFiller::FindTruthSpillParticleIndex(int vertexId, int trackId) const
   {
+    ScopedTiming timing(fTiming.enabled, fTiming.findTruthSpillParticleIndex);
+
     for (int i = 0; i < _TruthSpillNTrueParticles; ++i)
     {
+      ++fTiming.findTruthSpillParticleIndexEntriesScanned;
       if (_TruthSpillParticleVertexID[i] == vertexId && _TruthSpillTrackID[i] == trackId)
+      {
+        ++fTiming.findTruthSpillParticleIndexHits;
         return i;
+      }
     }
     return -1;
   }
 
   int TMSRecoBranchFiller::ResolvePrimaryTruthParticleIndex(int particleIdx, int recoTrackIdx) const
   {
+    ScopedTiming timing(fTiming.enabled, fTiming.resolvePrimaryTruthParticleIndex);
+
     std::vector<int> visited;
     while (_TruthSpillParent[particleIdx] != -1)
     {
+      ++fTiming.resolvePrimaryParentSteps;
       if (std::find(visited.begin(), visited.end(), particleIdx) != visited.end())
       {
+        ++fTiming.resolvePrimaryLoopFallbacks;
         LOG.WARNING() << "TMS reco track " << recoTrackIdx
                       << " encountered a loop while resolving Truth_Spill parents;"
                       << " falling back to particle index " << particleIdx << "\n";
@@ -200,6 +322,7 @@ namespace cafmaker
       const int parentIdx = FindTruthSpillParticleIndex(vertexId, parentTrackId);
       if (parentIdx < 0)
       {
+        ++fTiming.resolvePrimaryMissingParentFallbacks;
         LOG.WARNING() << "TMS reco track " << recoTrackIdx
                       << " could not resolve parent track ID " << parentTrackId
                       << " from Truth_Spill particle index " << particleIdx
@@ -215,6 +338,8 @@ namespace cafmaker
 
   unsigned long TMSRecoBranchFiller::ResolveRecoTrackInteractionID(const TruthMatcher * truthMatch, int recoTrackIdx) const
   {
+    ScopedTiming timing(fTiming.enabled, fTiming.resolveRecoTrackInteractionID);
+
     const int particleIdx = ResolvePrimaryTruthParticleIndex(ResolveRecoTrackTruthParticleIndex(recoTrackIdx), recoTrackIdx);
 
     const int trueVtxId = _TruthSpillParticleVertexID[particleIdx];
@@ -228,6 +353,7 @@ namespace cafmaker
     double nearestDist2 = std::numeric_limits<double>::infinity();
     for (int i = 0; i < _TruthSpillTrueVtxN; ++i)
     {
+      ++fTiming.resolveRecoTrackInteractionVertexScans;
       const double dx = _TruthSpillTrueVtxX[i] - birthX;
       const double dy = _TruthSpillTrueVtxY[i] - birthY;
       const double dz = _TruthSpillTrueVtxZ[i] - birthZ;
@@ -245,6 +371,7 @@ namespace cafmaker
 
       if (matchedVtxIdx >= 0)
       {
+        ++fTiming.resolveRecoTrackInteractionMultiMatches;
         LOG.WARNING() << "Reco track " << recoTrackIdx
                       << " matched multiple Truth_Spill vertices for vertex ID " << trueVtxId
                       << "; using the first in-tolerance match instead of crashing\n";
@@ -254,10 +381,14 @@ namespace cafmaker
     }
 
     if (matchedVtxIdx >= 0)
+    {
+      ++fTiming.resolveRecoTrackInteractionExactMatches;
       return ResolveTrueInteractionIDFromVertexIndex(truthMatch, matchedVtxIdx);
+    }
 
     if (nearestVtxIdx >= 0)
     {
+      ++fTiming.resolveRecoTrackInteractionNearestFallbacks;
       LOG.WARNING() << "Reco track " << recoTrackIdx
                     << " could not match primary particle birth position to a Truth_Spill vertex for vertex ID "
                     << trueVtxId << " within " << kVertexMatchToleranceMm << " mm;"
@@ -275,6 +406,7 @@ namespace cafmaker
                                               const cafmaker::Params &par,
                                               const TruthMatcher *truthMatcher) const
   {
+    ScopedTiming timing(fTiming.enabled, fTiming.fillRecoBranches);
 
     sr.meta.tms.enabled = true;
 
@@ -299,11 +431,15 @@ namespace cafmaker
 
     caf::SRTMSInt *interaction;
 
+    ++fTiming.fillRecoBranchesSpillsProcessed;
     LoadTruthSpillEntry(LastSpillNo);
     for (int i_tvtx = 0; i_tvtx < _TruthSpillTrueVtxN; ++i_tvtx)
     {
       auto neutrino_event_id = ResolveTrueInteractionIDFromVertexIndex(truthMatcher, i_tvtx);
-      (void)truthMatcher->GetTrueInteraction(sr, neutrino_event_id, true); // called for side effect of registering the interaction; cast suppresses unused-return-value warning
+      {
+        ScopedTiming subTiming(fTiming.enabled, fTiming.getTrueInteraction);
+        (void)truthMatcher->GetTrueInteraction(sr, neutrino_event_id, true); // called for side effect of registering the interaction; cast suppresses unused-return-value warning
+      }
     }
 
     // the i index is incremented at the end of the following while()
@@ -315,6 +451,7 @@ namespace cafmaker
       if (_nTracks > 0)
       {        
         for (int j = 0; j < _nTracks; ++j) {
+          ++fTiming.fillRecoBranchesTracksProcessed;
           sr.nd.tms.nixn++;
           sr.nd.tms.ixn.emplace_back();
 
@@ -343,21 +480,37 @@ namespace cafmaker
            *  The run numbers in the GHEP(?) or edep files are of the run number, followed by the event number, so we recreate that.
            * Long cos it's very long innit. Sorry. */
           const auto genieIxnID = ResolveRecoTrackInteractionID(truthMatcher, j);
-          caf::SRTrueInteraction& srTrueInt = truthMatcher->GetTrueInteraction(sr, genieIxnID);
+          caf::SRTrueInteraction* srTrueIntPtr = nullptr;
+          {
+            ScopedTiming subTiming(fTiming.enabled, fTiming.getTrueInteraction);
+            srTrueIntPtr = &truthMatcher->GetTrueInteraction(sr, genieIxnID);
+          }
+          caf::SRTrueInteraction& srTrueInt = *srTrueIntPtr;
 
-          const int srTrueIntIdx = static_cast<int>(std::distance(sr.mc.nu.begin(),
-                                                                  std::find_if(sr.mc.nu.begin(), sr.mc.nu.end(),
-                                                                               [&srTrueInt](const caf::SRTrueInteraction& ixn)
-                                                                               { return ixn.id == srTrueInt.id; })));
+          int srTrueIntIdx = -1;
+          {
+            ScopedTiming subTiming(fTiming.enabled, fTiming.findSRTrueInteractionIndex);
+            srTrueIntIdx = static_cast<int>(std::distance(sr.mc.nu.begin(),
+                                                          std::find_if(sr.mc.nu.begin(), sr.mc.nu.end(),
+                                                                       [&srTrueInt](const caf::SRTrueInteraction& ixn)
+                                                                       { return ixn.id == srTrueInt.id; })));
+          }
 
           // TODO: Make TMS care about prim/sec tracks (check _RecoTruePartIdSec for secondaries)
           const int recoTruthParticleIdx = ResolveRecoTrackTruthParticleIndex(j);
           const int partG4ID = _TruthSpillTrackID[recoTruthParticleIdx];
-          truthMatcher->GetTrueParticle(sr, srTrueInt, partG4ID, true);
-          const int truthVecIdx = static_cast<int>(std::distance(srTrueInt.prim.begin(),
-                                                                 std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(),
-                                                                              [partG4ID](const caf::SRTrueParticle& part)
-                                                                              { return part.G4ID == partG4ID; })));
+          {
+            ScopedTiming subTiming(fTiming.enabled, fTiming.getTrueParticle);
+            truthMatcher->GetTrueParticle(sr, srTrueInt, partG4ID, true);
+          }
+          int truthVecIdx = -1;
+          {
+            ScopedTiming subTiming(fTiming.enabled, fTiming.findSRTrueParticleIndex);
+            truthVecIdx = static_cast<int>(std::distance(srTrueInt.prim.begin(),
+                                                         std::find_if(srTrueInt.prim.begin(), srTrueInt.prim.end(),
+                                                                      [partG4ID](const caf::SRTrueParticle& part)
+                                                                      { return part.G4ID == partG4ID; })));
+          }
 
           interaction->tracks[0].truth.push_back(caf::TrueParticleID{srTrueIntIdx,
                                                                       caf::TrueParticleID::PartType::kPrimary,
@@ -374,11 +527,17 @@ namespace cafmaker
 
   void TMSRecoBranchFiller::FillInteractions(const TruthMatcher * truthMatch, caf::StandardRecord &sr) const
   {
+    ScopedTiming timing(fTiming.enabled, fTiming.fillInteractions);
 
     for (int i_int = 0; i_int < _TruthSpillTrueVtxN; ++i_int)
     {
       auto neutrino_event_id = ResolveTrueInteractionIDFromVertexIndex(truthMatch, i_int);
-      caf::SRTrueInteraction & srTrueInt = truthMatch->GetTrueInteraction(sr, neutrino_event_id);
+      caf::SRTrueInteraction * srTrueIntPtr = nullptr;
+      {
+        ScopedTiming subTiming(fTiming.enabled, fTiming.getTrueInteraction);
+        srTrueIntPtr = &truthMatch->GetTrueInteraction(sr, neutrino_event_id);
+      }
+      caf::SRTrueInteraction & srTrueInt = *srTrueIntPtr;
       LOG.VERBOSE() << "    --> resulting SRTrueInteraction has the following particles in it:\n";
       for (const caf::SRTrueParticle & part : srTrueInt.prim)
           LOG.VERBOSE() << "    (prim) id = " << part.G4ID << " pdg = " << part.pdg << ", energy = " << part.p.E << "\n";
@@ -393,6 +552,7 @@ namespace cafmaker
   // TODO: In future this nastiness will be handled by TMS
   std::deque<Trigger> TMSRecoBranchFiller::GetTriggers(int triggerType, bool beamOnly) const
   {
+    ScopedTiming timing(fTiming.enabled, fTiming.getTriggers);
     std::deque<Trigger> triggers;
     int lastSpillNo = std::numeric_limits<int>::lowest(); // Starting value, small number so next spill number is larger
 
@@ -403,6 +563,7 @@ namespace cafmaker
 
       for (int entry = 0; entry < TMSRecoTree->GetEntries(); entry++)
       {
+        ++fTiming.getTriggersEntriesScanned;
         TMSRecoTree->GetEntry(entry);
 
         if (_SpillNo == lastSpillNo)
@@ -410,35 +571,45 @@ namespace cafmaker
 
         lastSpillNo = _SpillNo;
 
-        Trigger & prev_trig = fTriggers.back(); // trigger before 'trig'
-        fTriggers.emplace_back();               // add new trigger entry (unfilled)
-        Trigger & trig      = fTriggers.back(); // trigger we're working on
-
-        trig.evtID = entry;
-        trig.triggerType = 1; // TODO real number?
-
-        if (entry == 0)
-          trig.triggerTime_ns = 0;
-        else
-          trig.triggerTime_ns = prev_trig.triggerTime_ns + 2E8 ;
-
-        if (entry == 0)
-          trig.triggerTime_s = 0;
-        else
+        if (!fTriggers.empty())
         {
+          Trigger & prev_trig = fTriggers.back(); // trigger before 'trig'
+          fTriggers.emplace_back();               // add new trigger entry (unfilled)
+          Trigger & trig      = fTriggers.back(); // trigger we're working on
+
+          trig.evtID = entry;
+          trig.triggerType = 1; // TODO real number?
+
+          trig.triggerTime_ns = prev_trig.triggerTime_ns + 2E8 ;
           trig.triggerTime_s = prev_trig.triggerTime_s + 1; // TODO: Pull the 1.2 from correct place in file
           if (trig.triggerTime_ns >= 1E9) // If we have 1s worth of ns then add 1s and remove 1s worth of ns
           {
             trig.triggerTime_s += 1;
             trig.triggerTime_ns -= 1E9;
           }
-        }
 
-        LOG.VERBOSE() << "  added trigger:  evtID=" << trig.evtID
-                      << ", triggerType=" << trig.triggerType
-                      << ", triggerTime_s=" << trig.triggerTime_s
-                      << ", triggerTime_ns=" << trig.triggerTime_ns
-                      << "\n";
+          LOG.VERBOSE() << "  added trigger:  evtID=" << trig.evtID
+                        << ", triggerType=" << trig.triggerType
+                        << ", triggerTime_s=" << trig.triggerTime_s
+                        << ", triggerTime_ns=" << trig.triggerTime_ns
+                        << "\n";
+        }
+        else
+        {
+          fTriggers.emplace_back();
+          Trigger & trig = fTriggers.back();
+          trig.evtID = entry;
+          trig.triggerType = 1; // TODO real number?
+          trig.triggerTime_ns = 0;
+          trig.triggerTime_s = 0;
+          LOG.VERBOSE() << "  added trigger:  evtID=" << trig.evtID
+                        << ", triggerType=" << trig.triggerType
+                        << ", triggerTime_s=" << trig.triggerTime_s
+                        << ", triggerTime_ns=" << trig.triggerTime_ns
+                        << "\n";
+        }
+        ++fTiming.getTriggersCreated;
+
       }
       fLastTriggerReqd = fTriggers.end();  // since we just modified the list, any iterators have been invalidated
     }

--- a/src/reco/TMSRecoBranchFiller.cxx
+++ b/src/reco/TMSRecoBranchFiller.cxx
@@ -1,6 +1,9 @@
 #include "TMSRecoBranchFiller.h"
 #include "truth/FillTruth.h"
 
+#include <cmath>
+#include <limits>
+
 /*
  * Liam O'Sullivan <liam.osullivan@uni-mainz.de>  -  Oct 2024
  * Put together mostly from the previous example and the MINERvA RecoBranchFiller
@@ -221,36 +224,49 @@ namespace cafmaker
 
     constexpr double kVertexMatchToleranceMm = 100.0;
     int matchedVtxIdx = -1;
+    int nearestVtxIdx = -1;
+    double nearestDist2 = std::numeric_limits<double>::infinity();
     for (int i = 0; i < _TruthSpillTrueVtxN; ++i)
     {
-      if (_TruthSpillTrueVtxID[i] != trueVtxId)
-        continue;
-
       const double dx = _TruthSpillTrueVtxX[i] - birthX;
       const double dy = _TruthSpillTrueVtxY[i] - birthY;
       const double dz = _TruthSpillTrueVtxZ[i] - birthZ;
       const double dist2 = dx*dx + dy*dy + dz*dz;
+      if (dist2 < nearestDist2)
+      {
+        nearestDist2 = dist2;
+        nearestVtxIdx = i;
+      }
+
+      if (_TruthSpillTrueVtxID[i] != trueVtxId)
+        continue;
       if (dist2 > kVertexMatchToleranceMm * kVertexMatchToleranceMm)
         continue;
 
       if (matchedVtxIdx >= 0)
       {
-        std::stringstream ss;
-        ss << "Reco track " << recoTrackIdx << " matches multiple Truth_Spill vertices for vertex ID " << trueVtxId << "\n";
-        throw std::runtime_error(ss.str());
+        LOG.WARNING() << "Reco track " << recoTrackIdx
+                      << " matched multiple Truth_Spill vertices for vertex ID " << trueVtxId
+                      << "; using the first in-tolerance match instead of crashing\n";
+        continue;
       }
       matchedVtxIdx = i;
     }
 
-    if (matchedVtxIdx < 0)
+    if (matchedVtxIdx >= 0)
+      return ResolveTrueInteractionIDFromVertexIndex(truthMatch, matchedVtxIdx);
+
+    if (nearestVtxIdx >= 0)
     {
-      std::stringstream ss;
-      ss << "Reco track " << recoTrackIdx << " could not match primary particle birth position to a Truth_Spill vertex for vertex ID "
-         << trueVtxId << " within " << kVertexMatchToleranceMm << " mm\n";
-      throw std::runtime_error(ss.str());
+      LOG.WARNING() << "Reco track " << recoTrackIdx
+                    << " could not match primary particle birth position to a Truth_Spill vertex for vertex ID "
+                    << trueVtxId << " within " << kVertexMatchToleranceMm << " mm;"
+                    << " falling back to nearest Truth_Spill vertex index " << nearestVtxIdx
+                    << " at distance " << std::sqrt(nearestDist2) << " mm\n";
+      return ResolveTrueInteractionIDFromVertexIndex(truthMatch, nearestVtxIdx);
     }
 
-    return ResolveTrueInteractionIDFromVertexIndex(truthMatch, matchedVtxIdx);
+    throw std::runtime_error("Truth_Spill contains no vertices to resolve reco track interaction ID");
   }
 
   // here we copy all the TMS reco into the SRTMS branch of the StandardRecord object.

--- a/src/reco/TMSRecoBranchFiller.cxx
+++ b/src/reco/TMSRecoBranchFiller.cxx
@@ -145,10 +145,10 @@ namespace cafmaker
     if (trueVtxIdx < 0 || trueVtxIdx >= _TruthSpillTrueVtxN)
       throw std::runtime_error("Requested Truth_Spill vertex index is out of range");
 
-    return truthMatch->ResolveVertexID(static_cast<unsigned int>(_TruthSpillTrueVtxID[trueVtxIdx]),
-                                       _TruthSpillTrueVtxX[trueVtxIdx],
-                                       _TruthSpillTrueVtxY[trueVtxIdx],
-                                       _TruthSpillTrueVtxZ[trueVtxIdx]);
+    return truthMatch->ResolveVertexIDFromRunAndPosition(static_cast<unsigned long>(_TruthSpillRunNo),
+                                                         _TruthSpillTrueVtxX[trueVtxIdx],
+                                                         _TruthSpillTrueVtxY[trueVtxIdx],
+                                                         _TruthSpillTrueVtxZ[trueVtxIdx]);
   }
 
   unsigned long TMSRecoBranchFiller::ResolveRecoTrackInteractionID(const TruthMatcher * truthMatch, int recoTrackIdx) const

--- a/src/reco/TMSRecoBranchFiller.cxx
+++ b/src/reco/TMSRecoBranchFiller.cxx
@@ -106,12 +106,16 @@ namespace cafmaker
     fTMSRecoFile = NULL;
   }
 
-  unsigned long TMSRecoBranchFiller::ResolveTrueInteractionID(const TruthMatcher * truthMatch, int trueVtxId) const
+  unsigned long TMSRecoBranchFiller::ResolveTrueInteractionID(const TruthMatcher * truthMatch,
+                                                              int trueVtxId,
+                                                              double trueVtxX,
+                                                              double trueVtxY,
+                                                              double trueVtxZ) const
   {
     if (!truthMatch)
       throw std::runtime_error("TMSRecoBranchFiller requires TruthMatcher to resolve true interaction IDs");
 
-    return truthMatch->ResolveVertexID(static_cast<unsigned int>(trueVtxId));
+    return truthMatch->ResolveVertexID(static_cast<unsigned int>(trueVtxId), trueVtxX, trueVtxY, trueVtxZ);
   }
 
   // here we copy all the TMS reco into the SRTMS branch of the StandardRecord object.
@@ -151,7 +155,7 @@ namespace cafmaker
 
       for (int i_tvtx=0; i_tvtx<_TrueVtxN; i_tvtx++)
       {
-        auto neutrino_event_id = ResolveTrueInteractionID(truthMatcher, _TrueVtxId[i_tvtx]);
+        auto neutrino_event_id = ResolveTrueInteractionID(truthMatcher, _TrueVtxId[i_tvtx], _TrueVtxX[i_tvtx], _TrueVtxY[i_tvtx], _TrueVtxZ[i_tvtx]);
         (void)truthMatcher->GetTrueInteraction(sr, neutrino_event_id, true); // called for side effect of registering the interaction; cast suppresses unused-return-value warning
       }
     }
@@ -192,7 +196,7 @@ namespace cafmaker
           /*  Fill Truth
            *  The run numbers in the GHEP(?) or edep files are of the run number, followed by the event number, so we recreate that.
            * Long cos it's very long innit. Sorry. */
-          const auto genieIxnID = ResolveTrueInteractionID(truthMatcher, _RecoTrueVtxId[j]);
+          const auto genieIxnID = ResolveTrueInteractionID(truthMatcher, _RecoTrueVtxId[j], _TrueVtxX[j], _TrueVtxY[j], _TrueVtxZ[j]);
           caf::SRTrueInteraction& srTrueInt = truthMatcher->GetTrueInteraction(sr, genieIxnID);
 
           const int srTrueIntIdx = static_cast<int>(std::distance(sr.mc.nu.begin(),
@@ -227,7 +231,7 @@ namespace cafmaker
     for (int i_int = 0; i_int<_TrueVtxN; i_int++)
     {
       //Long_t neutrino_event_id = _TrueVtxId[i_int];//mc_int_edepsimId[i_int];
-      auto neutrino_event_id = ResolveTrueInteractionID(truthMatch, _TrueVtxId[i_int]);
+      auto neutrino_event_id = ResolveTrueInteractionID(truthMatch, _TrueVtxId[i_int], _TrueVtxX[i_int], _TrueVtxY[i_int], _TrueVtxZ[i_int]);
       caf::SRTrueInteraction & srTrueInt = truthMatch->GetTrueInteraction(sr, neutrino_event_id);
       LOG.VERBOSE() << "    --> resulting SRTrueInteraction has the following particles in it:\n";
       for (const caf::SRTrueParticle & part : srTrueInt.prim)

--- a/src/reco/TMSRecoBranchFiller.cxx
+++ b/src/reco/TMSRecoBranchFiller.cxx
@@ -106,6 +106,14 @@ namespace cafmaker
     fTMSRecoFile = NULL;
   }
 
+  unsigned long TMSRecoBranchFiller::ResolveTrueInteractionID(const TruthMatcher * truthMatch, int trueVtxId) const
+  {
+    if (!truthMatch)
+      throw std::runtime_error("TMSRecoBranchFiller requires TruthMatcher to resolve true interaction IDs");
+
+    return truthMatch->ResolveVertexID(static_cast<unsigned int>(trueVtxId));
+  }
+
   // here we copy all the TMS reco into the SRTMS branch of the StandardRecord object.
   void TMSRecoBranchFiller::_FillRecoBranches(const Trigger &trigger,
                                               caf::StandardRecord &sr,
@@ -143,7 +151,7 @@ namespace cafmaker
 
       for (int i_tvtx=0; i_tvtx<_TrueVtxN; i_tvtx++)
       {
-        auto neutrino_event_id = static_cast<unsigned long> ((_TrueRunNo)*1E6 + _TrueVtxId[i_tvtx]);
+        auto neutrino_event_id = ResolveTrueInteractionID(truthMatcher, _TrueVtxId[i_tvtx]);
         (void)truthMatcher->GetTrueInteraction(sr, neutrino_event_id, true); // called for side effect of registering the interaction; cast suppresses unused-return-value warning
       }
     }
@@ -184,7 +192,7 @@ namespace cafmaker
           /*  Fill Truth
            *  The run numbers in the GHEP(?) or edep files are of the run number, followed by the event number, so we recreate that.
            * Long cos it's very long innit. Sorry. */
-          const auto genieIxnID = static_cast<unsigned long>((_RunNo%100000)*1E6 + _RecoTrueVtxId[j]);
+          const auto genieIxnID = ResolveTrueInteractionID(truthMatcher, _RecoTrueVtxId[j]);
           caf::SRTrueInteraction& srTrueInt = truthMatcher->GetTrueInteraction(sr, genieIxnID);
 
           const int srTrueIntIdx = static_cast<int>(std::distance(sr.mc.nu.begin(),
@@ -219,7 +227,7 @@ namespace cafmaker
     for (int i_int = 0; i_int<_TrueVtxN; i_int++)
     {
       //Long_t neutrino_event_id = _TrueVtxId[i_int];//mc_int_edepsimId[i_int];
-      auto neutrino_event_id = static_cast<unsigned long> (_RunNo*1E6 + _TrueVtxId[i_int]);
+      auto neutrino_event_id = ResolveTrueInteractionID(truthMatch, _TrueVtxId[i_int]);
       caf::SRTrueInteraction & srTrueInt = truthMatch->GetTrueInteraction(sr, neutrino_event_id);
       LOG.VERBOSE() << "    --> resulting SRTrueInteraction has the following particles in it:\n";
       for (const caf::SRTrueParticle & part : srTrueInt.prim)

--- a/src/reco/TMSRecoBranchFiller.cxx
+++ b/src/reco/TMSRecoBranchFiller.cxx
@@ -412,43 +412,34 @@ namespace cafmaker
 
         lastSpillNo = _SpillNo;
 
-        if (!fTriggers.empty())
+        const Trigger * prev_trig = fTriggers.empty() ? nullptr : &fTriggers.back();
+        fTriggers.emplace_back();
+        Trigger & trig = fTriggers.back();
+
+        trig.evtID = entry;
+        trig.triggerType = 1; // TODO real number?
+
+        if (prev_trig)
         {
-          Trigger & prev_trig = fTriggers.back(); // trigger before 'trig'
-          fTriggers.emplace_back();               // add new trigger entry (unfilled)
-          Trigger & trig      = fTriggers.back(); // trigger we're working on
-
-          trig.evtID = entry;
-          trig.triggerType = 1; // TODO real number?
-
-          trig.triggerTime_ns = prev_trig.triggerTime_ns + 2E8 ;
-          trig.triggerTime_s = prev_trig.triggerTime_s + 1; // TODO: Pull the 1.2 from correct place in file
+          trig.triggerTime_ns = prev_trig->triggerTime_ns + 2E8 ;
+          trig.triggerTime_s = prev_trig->triggerTime_s + 1; // TODO: Pull the 1.2 from correct place in file
           if (trig.triggerTime_ns >= 1E9) // If we have 1s worth of ns then add 1s and remove 1s worth of ns
           {
             trig.triggerTime_s += 1;
             trig.triggerTime_ns -= 1E9;
           }
-
-          LOG.VERBOSE() << "  added trigger:  evtID=" << trig.evtID
-                        << ", triggerType=" << trig.triggerType
-                        << ", triggerTime_s=" << trig.triggerTime_s
-                        << ", triggerTime_ns=" << trig.triggerTime_ns
-                        << "\n";
         }
         else
         {
-          fTriggers.emplace_back();
-          Trigger & trig = fTriggers.back();
-          trig.evtID = entry;
-          trig.triggerType = 1; // TODO real number?
           trig.triggerTime_ns = 0;
           trig.triggerTime_s = 0;
-          LOG.VERBOSE() << "  added trigger:  evtID=" << trig.evtID
-                        << ", triggerType=" << trig.triggerType
-                        << ", triggerTime_s=" << trig.triggerTime_s
-                        << ", triggerTime_ns=" << trig.triggerTime_ns
-                        << "\n";
         }
+
+        LOG.VERBOSE() << "  added trigger:  evtID=" << trig.evtID
+                      << ", triggerType=" << trig.triggerType
+                      << ", triggerTime_s=" << trig.triggerTime_s
+                      << ", triggerTime_ns=" << trig.triggerTime_ns
+                      << "\n";
       }
       fLastTriggerReqd = fTriggers.end();  // since we just modified the list, any iterators have been invalidated
     }

--- a/src/reco/TMSRecoBranchFiller.h
+++ b/src/reco/TMSRecoBranchFiller.h
@@ -8,11 +8,9 @@
 #ifndef ND_CAFMAKER_TMSRECOBRANCHFILLER_H
 #define ND_CAFMAKER_TMSRECOBRANCHFILLER_H
 
-#include <cstddef>
-#include <deque>
 #include <iostream>
+#include <deque>
 #include <map>
-#include <vector>
 
 // The virtual base class
 #include "IRecoBranchFiller.h"
@@ -36,47 +34,6 @@ namespace cafmaker
       RecoFillerType FillerType() const override { return RecoFillerType::BaseReco; }
 
       ~TMSRecoBranchFiller();
-
-      struct TimingSummary
-      {
-        double totalMs = 0.0;
-        std::size_t calls = 0;
-      };
-
-      struct TimingStats
-      {
-        bool enabled = false;
-        TimingSummary loadTruthSpillEntry;
-        TimingSummary buildTruthSpillEntryMap;
-        TimingSummary resolveTrueInteractionIDFromVertexIndex;
-        TimingSummary resolveRecoTrackTruthParticleIndex;
-        TimingSummary findTruthSpillParticleIndex;
-        TimingSummary resolvePrimaryTruthParticleIndex;
-        TimingSummary resolveRecoTrackInteractionID;
-        TimingSummary getTrueInteraction;
-        TimingSummary getTrueParticle;
-        TimingSummary findSRTrueInteractionIndex;
-        TimingSummary findSRTrueParticleIndex;
-        TimingSummary fillRecoBranches;
-        TimingSummary fillInteractions;
-        TimingSummary getTriggers;
-
-        std::size_t buildTruthSpillEntryMapEntries = 0;
-        std::size_t loadTruthSpillEntryMisses = 0;
-        std::size_t resolvePrimaryParentSteps = 0;
-        std::size_t resolvePrimaryLoopFallbacks = 0;
-        std::size_t resolvePrimaryMissingParentFallbacks = 0;
-        std::size_t findTruthSpillParticleIndexEntriesScanned = 0;
-        std::size_t findTruthSpillParticleIndexHits = 0;
-        std::size_t resolveRecoTrackInteractionVertexScans = 0;
-        std::size_t resolveRecoTrackInteractionExactMatches = 0;
-        std::size_t resolveRecoTrackInteractionNearestFallbacks = 0;
-        std::size_t resolveRecoTrackInteractionMultiMatches = 0;
-        std::size_t fillRecoBranchesTracksProcessed = 0;
-        std::size_t fillRecoBranchesSpillsProcessed = 0;
-        std::size_t getTriggersEntriesScanned = 0;
-        std::size_t getTriggersCreated = 0;
-      };
 
     private:
       void LoadTruthSpillEntry(int spillNo) const;
@@ -156,7 +113,6 @@ namespace cafmaker
       mutable std::vector<cafmaker::Trigger> fTriggers;
       mutable decltype(fTriggers)::const_iterator  fLastTriggerReqd;    ///< the last trigger requested using _FillRecoBranches()
       mutable std::map<int, Long64_t> fTruthSpillEntryBySpillNo;
-      mutable TimingStats fTiming;
 
   };
 

--- a/src/reco/TMSRecoBranchFiller.h
+++ b/src/reco/TMSRecoBranchFiller.h
@@ -35,7 +35,11 @@ namespace cafmaker
       ~TMSRecoBranchFiller();
 
     private:
-      unsigned long ResolveTrueInteractionID(const TruthMatcher * truthMatch, int trueVtxId) const;
+      unsigned long ResolveTrueInteractionID(const TruthMatcher * truthMatch,
+                                             int trueVtxId,
+                                             double trueVtxX,
+                                             double trueVtxY,
+                                             double trueVtxZ) const;
       void FillInteractions(const TruthMatcher * truthMatch, caf::StandardRecord &sr) const;
 
       void _FillRecoBranches(const Trigger &trigger,

--- a/src/reco/TMSRecoBranchFiller.h
+++ b/src/reco/TMSRecoBranchFiller.h
@@ -38,6 +38,9 @@ namespace cafmaker
     private:
       void LoadTruthSpillEntry(int spillNo) const;
       unsigned long ResolveTrueInteractionIDFromVertexIndex(const TruthMatcher * truthMatch, int trueVtxIdx) const;
+      int ResolveRecoTrackTruthParticleIndex(int recoTrackIdx) const;
+      int FindTruthSpillParticleIndex(int vertexId, int trackId) const;
+      int ResolvePrimaryTruthParticleIndex(int particleIdx, int recoTrackIdx) const;
       unsigned long ResolveRecoTrackInteractionID(const TruthMatcher * truthMatch, int recoTrackIdx) const;
       void FillInteractions(const TruthMatcher * truthMatch, caf::StandardRecord &sr) const;
 
@@ -95,6 +98,7 @@ namespace cafmaker
       mutable int _TruthSpillTrueVtxN;
       mutable int _TruthSpillParticleVertexID[5000];
       mutable int _TruthSpillParent[5000];
+      mutable int _TruthSpillTrackID[5000];
       mutable float _TruthSpillBirthPosition[5000][4];
       mutable int _TruthSpillTrueVtxID[505];
       mutable float _TruthSpillTrueVtxX[505];

--- a/src/reco/TMSRecoBranchFiller.h
+++ b/src/reco/TMSRecoBranchFiller.h
@@ -88,7 +88,7 @@ namespace cafmaker
       float _DirectionX_Upstream[kTMSMaxTracks];
       float _DirectionZ_Upstream[kTMSMaxTracks];
 
-      float _TrackHitPos[kTMSMaxTracks][kTMSMaxLineHits][3];     ///< Kalman filtered reco. track hit positions (x,y,z)
+      float _TrackHitPos[kTMSMaxTracks][kTMSMaxLineHits][4];     ///< Kalman filtered reco. track hit positions (x,y,z[,compat])
       float _TrackRecoHitPos[kTMSMaxTracks][kTMSMaxLineHits][4]; ///< Reco. track hit positions (x,y,z,t)
 
       // Truth_Info branches used for reco-track -> truth lookup

--- a/src/reco/TMSRecoBranchFiller.h
+++ b/src/reco/TMSRecoBranchFiller.h
@@ -55,6 +55,11 @@ namespace cafmaker
       TTree *TMSTrueSpill;
       TTree *TMSLCTree;
 
+      static constexpr int kTMSMaxTracks = 100;
+      static constexpr int kTMSMaxLineHits = 200;
+      static constexpr int kTMSMaxTrueParticles = 20000;
+      static constexpr int kTMSMaxTrueVertices = 5000;
+
       // Save the branches that we're reading in
       int   _RunNo;                      ///< Run Number
       int   _nLines;                     ///< Number of Hough Lines reconstructed
@@ -62,48 +67,47 @@ namespace cafmaker
       int   _SliceNo;                    ///< (Time) Slide Number
       int   _SpillNo;                    ///< Spill Number
       int   _nTracks;                    ///< Number of tracks in Interaction
-      int   _nHitsInTrack[10];           ///< Numebr of Hits in reco. track
-      int   _TrackCharge[10];            ///< Reconstructed Charge of track
-      float _TrackLength[10];            ///< Length [cm] of the reco. track
-      float _TrackArealDensity[10];      ///< Areal Density [g/cm^2] traversed by the reco. track
-      float _TrackMomentum[10];          ///< Reco. momentum of the track [MeV]
-      float _TrackTotalEnergy[10];       ///< Total reco. track energy [MeV]
-      float _TrackEnergyDeposit[10];     ///< Visible energy of reco. track [MeV]
-      float _TrackStartPos[10][3];       ///< Reco. start position of the track (x,y,z)
-      float _TrackEndPos[10][3];         ///< Reco. end position of the track (x,y,z)
-      float _TrackStartDirection[10][3]; ///< Reco. track direction vector at start (x,y,z)
-      float _TrackEndDirection[10][3];   ///< Reco. track direction vector at start (x,y,z)
-      float _Occupancy[10];              ///< Fraction of true energy deposits included in the reco. track
+      int   _nHitsInTrack[kTMSMaxTracks];           ///< Number of hits in reco. track
+      int   _TrackCharge[kTMSMaxTracks];            ///< Reconstructed charge of track
+      float _TrackLength[kTMSMaxTracks];            ///< Length [cm] of the reco. track
+      float _TrackArealDensity[kTMSMaxTracks];      ///< Areal Density [g/cm^2] traversed by the reco. track
+      float _TrackMomentum[kTMSMaxTracks];          ///< Reco. momentum of the track [MeV]
+      float _TrackTotalEnergy[kTMSMaxTracks];       ///< Total reco. track energy [MeV]
+      float _TrackEnergyDeposit[kTMSMaxTracks];     ///< Visible energy of reco. track [MeV]
+      float _TrackStartPos[kTMSMaxTracks][4];       ///< Reco. start position of the track (x,y,z,t)
+      float _TrackEndPos[kTMSMaxTracks][4];         ///< Reco. end position of the track (x,y,z,t)
+      float _TrackStartDirection[kTMSMaxTracks][3]; ///< Reco. track direction vector at start (x,y,z)
+      float _TrackEndDirection[kTMSMaxTracks][3];   ///< Reco. track direction vector at end (x,y,z)
+      float _Occupancy[kTMSMaxTracks];              ///< Fraction of true energy deposits included in the reco. track
 
-      float _TMSStartTime[10];
-      float _TrackTime[10];
+      float _TMSStartTime[kTMSMaxTracks];
+      float _TrackTime[kTMSMaxTracks];
 
-      float _DirectionX_Downstream[10];
-      float _DirectionZ_Downstream[10];
-      float _DirectionX_Upstream[10];
-      float _DirectionZ_Upstream[10];
+      float _DirectionX_Downstream[kTMSMaxTracks];
+      float _DirectionZ_Downstream[kTMSMaxTracks];
+      float _DirectionX_Upstream[kTMSMaxTracks];
+      float _DirectionZ_Upstream[kTMSMaxTracks];
 
-      // [100][200][4] needs to match TMS reco output (check TMS Reco file if in doubt)
-      float _TrackHitPos[100][200][4];     ///< Array of reco. track hit positions (x,y,z,t)
-      float _TrackRecoHitPos[100][200][4]; ///< Array of Kalman filtered reco. track hit positions (x,y,z,t)
+      float _TrackHitPos[kTMSMaxTracks][kTMSMaxLineHits][3];     ///< Kalman filtered reco. track hit positions (x,y,z)
+      float _TrackRecoHitPos[kTMSMaxTracks][kTMSMaxLineHits][4]; ///< Reco. track hit positions (x,y,z,t)
 
       // Truth_Info branches used for reco-track -> truth lookup
-      int _RecoTruePartId[5000];    ///< RecoTrackPrimaryParticleIndex
-      int _RecoTruePartIdSec[5000]; ///< Secondary 
+      int _RecoTruePartId[kTMSMaxTracks];    ///< RecoTrackPrimaryParticleIndex
+      int _RecoTruePartIdSec[kTMSMaxTracks]; ///< RecoTrackSecondaryParticleIndex
 
       // Truth_Spill branches used as the authoritative truth representation
       mutable int _TruthSpillSpillNo;
       mutable int _TruthSpillRunNo;
       mutable int _TruthSpillNTrueParticles;
       mutable int _TruthSpillTrueVtxN;
-      mutable int _TruthSpillParticleVertexID[5000];
-      mutable int _TruthSpillParent[5000];
-      mutable int _TruthSpillTrackID[5000];
-      mutable float _TruthSpillBirthPosition[5000][4];
-      mutable int _TruthSpillTrueVtxID[505];
-      mutable float _TruthSpillTrueVtxX[505];
-      mutable float _TruthSpillTrueVtxY[505];
-      mutable float _TruthSpillTrueVtxZ[505];
+      mutable int _TruthSpillParticleVertexID[kTMSMaxTrueParticles];
+      mutable int _TruthSpillParent[kTMSMaxTrueParticles];
+      mutable int _TruthSpillTrackID[kTMSMaxTrueParticles];
+      mutable float _TruthSpillBirthPosition[kTMSMaxTrueParticles][4];
+      mutable int _TruthSpillTrueVtxID[kTMSMaxTrueVertices];
+      mutable float _TruthSpillTrueVtxX[kTMSMaxTrueVertices];
+      mutable float _TruthSpillTrueVtxY[kTMSMaxTrueVertices];
+      mutable float _TruthSpillTrueVtxZ[kTMSMaxTrueVertices];
 
       bool is_data;
       mutable std::vector<cafmaker::Trigger> fTriggers;

--- a/src/reco/TMSRecoBranchFiller.h
+++ b/src/reco/TMSRecoBranchFiller.h
@@ -27,7 +27,8 @@ namespace cafmaker
   class TMSRecoBranchFiller : public cafmaker::IRecoBranchFiller
   {
     public:
-      TMSRecoBranchFiller(const std::string & tmsRecoFilename);
+      TMSRecoBranchFiller(const std::string & tmsRecoFilename,
+                          double vertexMatchToleranceMm);
 
       std::deque<Trigger> GetTriggers(int triggerType, bool beamOnly) const override;
 
@@ -113,6 +114,7 @@ namespace cafmaker
       mutable std::vector<cafmaker::Trigger> fTriggers;
       mutable decltype(fTriggers)::const_iterator  fLastTriggerReqd;    ///< the last trigger requested using _FillRecoBranches()
       mutable std::map<int, Long64_t> fTruthSpillEntryBySpillNo;
+      double fVertexMatchToleranceMm;
 
   };
 

--- a/src/reco/TMSRecoBranchFiller.h
+++ b/src/reco/TMSRecoBranchFiller.h
@@ -10,6 +10,7 @@
 
 #include <iostream>
 #include <deque>
+#include <map>
 
 // The virtual base class
 #include "IRecoBranchFiller.h"
@@ -35,11 +36,9 @@ namespace cafmaker
       ~TMSRecoBranchFiller();
 
     private:
-      unsigned long ResolveTrueInteractionID(const TruthMatcher * truthMatch,
-                                             int trueVtxId,
-                                             double trueVtxX,
-                                             double trueVtxY,
-                                             double trueVtxZ) const;
+      void LoadTruthSpillEntry(int spillNo) const;
+      unsigned long ResolveTrueInteractionIDFromVertexIndex(const TruthMatcher * truthMatch, int trueVtxIdx) const;
+      unsigned long ResolveRecoTrackInteractionID(const TruthMatcher * truthMatch, int recoTrackIdx) const;
       void FillInteractions(const TruthMatcher * truthMatch, caf::StandardRecord &sr) const;
 
       void _FillRecoBranches(const Trigger &trigger,
@@ -55,7 +54,6 @@ namespace cafmaker
 
       // Save the branches that we're reading in
       int   _RunNo;                      ///< Run Number
-      int   _TrueRunNo;                  ///< True Run Number
       int   _nLines;                     ///< Number of Hough Lines reconstructed
       int   _EventNo;                    ///< Event Number
       int   _SliceNo;                    ///< (Time) Slide Number
@@ -86,19 +84,27 @@ namespace cafmaker
       float _TrackHitPos[100][200][4];     ///< Array of reco. track hit positions (x,y,z,t)
       float _TrackRecoHitPos[100][200][4]; ///< Array of Kalman filtered reco. track hit positions (x,y,z,t)
 
-      // True particle idx for reco tracks
-      int _TrueVtxN;                ///< N Vertices
-      float _TrueVtxX[5000];        ///< N Vertices
-      float _TrueVtxY[5000];        ///< N Vertices
-      float _TrueVtxZ[5000];        ///< N Vertices
-      int _TrueVtxId[5000];         ///< Vertex
-      int _RecoTrueVtxId[5000];     ///< Vertex
-      int _RecoTruePartId[5000];    ///< Primary
+      // Truth_Info branches used for reco-track -> truth lookup
+      int _RecoTruePartId[5000];    ///< RecoTrackPrimaryParticleIndex
       int _RecoTruePartIdSec[5000]; ///< Secondary 
+
+      // Truth_Spill branches used as the authoritative truth representation
+      mutable int _TruthSpillSpillNo;
+      mutable int _TruthSpillRunNo;
+      mutable int _TruthSpillNTrueParticles;
+      mutable int _TruthSpillTrueVtxN;
+      mutable int _TruthSpillParticleVertexID[5000];
+      mutable int _TruthSpillParent[5000];
+      mutable float _TruthSpillBirthPosition[5000][4];
+      mutable int _TruthSpillTrueVtxID[505];
+      mutable float _TruthSpillTrueVtxX[505];
+      mutable float _TruthSpillTrueVtxY[505];
+      mutable float _TruthSpillTrueVtxZ[505];
 
       bool is_data;
       mutable std::vector<cafmaker::Trigger> fTriggers;
       mutable decltype(fTriggers)::const_iterator  fLastTriggerReqd;    ///< the last trigger requested using _FillRecoBranches()
+      mutable std::map<int, Long64_t> fTruthSpillEntryBySpillNo;
 
   };
 

--- a/src/reco/TMSRecoBranchFiller.h
+++ b/src/reco/TMSRecoBranchFiller.h
@@ -8,9 +8,11 @@
 #ifndef ND_CAFMAKER_TMSRECOBRANCHFILLER_H
 #define ND_CAFMAKER_TMSRECOBRANCHFILLER_H
 
-#include <iostream>
+#include <cstddef>
 #include <deque>
+#include <iostream>
 #include <map>
+#include <vector>
 
 // The virtual base class
 #include "IRecoBranchFiller.h"
@@ -34,6 +36,47 @@ namespace cafmaker
       RecoFillerType FillerType() const override { return RecoFillerType::BaseReco; }
 
       ~TMSRecoBranchFiller();
+
+      struct TimingSummary
+      {
+        double totalMs = 0.0;
+        std::size_t calls = 0;
+      };
+
+      struct TimingStats
+      {
+        bool enabled = false;
+        TimingSummary loadTruthSpillEntry;
+        TimingSummary buildTruthSpillEntryMap;
+        TimingSummary resolveTrueInteractionIDFromVertexIndex;
+        TimingSummary resolveRecoTrackTruthParticleIndex;
+        TimingSummary findTruthSpillParticleIndex;
+        TimingSummary resolvePrimaryTruthParticleIndex;
+        TimingSummary resolveRecoTrackInteractionID;
+        TimingSummary getTrueInteraction;
+        TimingSummary getTrueParticle;
+        TimingSummary findSRTrueInteractionIndex;
+        TimingSummary findSRTrueParticleIndex;
+        TimingSummary fillRecoBranches;
+        TimingSummary fillInteractions;
+        TimingSummary getTriggers;
+
+        std::size_t buildTruthSpillEntryMapEntries = 0;
+        std::size_t loadTruthSpillEntryMisses = 0;
+        std::size_t resolvePrimaryParentSteps = 0;
+        std::size_t resolvePrimaryLoopFallbacks = 0;
+        std::size_t resolvePrimaryMissingParentFallbacks = 0;
+        std::size_t findTruthSpillParticleIndexEntriesScanned = 0;
+        std::size_t findTruthSpillParticleIndexHits = 0;
+        std::size_t resolveRecoTrackInteractionVertexScans = 0;
+        std::size_t resolveRecoTrackInteractionExactMatches = 0;
+        std::size_t resolveRecoTrackInteractionNearestFallbacks = 0;
+        std::size_t resolveRecoTrackInteractionMultiMatches = 0;
+        std::size_t fillRecoBranchesTracksProcessed = 0;
+        std::size_t fillRecoBranchesSpillsProcessed = 0;
+        std::size_t getTriggersEntriesScanned = 0;
+        std::size_t getTriggersCreated = 0;
+      };
 
     private:
       void LoadTruthSpillEntry(int spillNo) const;
@@ -113,6 +156,7 @@ namespace cafmaker
       mutable std::vector<cafmaker::Trigger> fTriggers;
       mutable decltype(fTriggers)::const_iterator  fLastTriggerReqd;    ///< the last trigger requested using _FillRecoBranches()
       mutable std::map<int, Long64_t> fTruthSpillEntryBySpillNo;
+      mutable TimingStats fTiming;
 
   };
 

--- a/src/reco/TMSRecoBranchFiller.h
+++ b/src/reco/TMSRecoBranchFiller.h
@@ -35,6 +35,7 @@ namespace cafmaker
       ~TMSRecoBranchFiller();
 
     private:
+      unsigned long ResolveTrueInteractionID(const TruthMatcher * truthMatch, int trueVtxId) const;
       void FillInteractions(const TruthMatcher * truthMatch, caf::StandardRecord &sr) const;
 
       void _FillRecoBranches(const Trigger &trigger,

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -31,6 +31,11 @@
 #include "Params.h"
 #include "util/FloatMath.h"
 
+namespace
+{
+  constexpr double kTMSPositionResolverYBinWidthMm = 500.0;
+}
+
 /// duneanaobj not guaranteed to be the same as GENIE scattering types
 caf::ScatteringMode GENIE2CAF(genie::EScatteringType sc)
 {
@@ -670,6 +675,16 @@ namespace cafmaker
                                                             event_id,
                                                             pos.X(), pos.Y(), pos.Z()});
     }
+
+    for (auto & [eventId, candidates] : fEventToVertexIDs)
+    {
+      (void)eventId;
+      for (auto & candidate : candidates)
+      {
+        const long long yBin = static_cast<long long>(std::floor(candidate.y / kTMSPositionResolverYBinWidthMm));
+        fVertexCandidatesByYBin[yBin].push_back(&candidate);
+      }
+    }
   }
 
   // ------------------------------------------------------------
@@ -760,35 +775,80 @@ namespace cafmaker
       f_isTreeLoaded = true;
     }
 
+    const auto cacheKey = std::make_tuple(x, y, z);
+    auto cacheIt = fResolvedVertexIDByPosition.find(cacheKey);
+    if (cacheIt != fResolvedVertexIDByPosition.end())
+      return cacheIt->second;
+
     constexpr double kPositionToleranceMm = 1.0;
+    const long long yBin = static_cast<long long>(std::floor(y / kTMSPositionResolverYBinWidthMm));
+
     const VertexCandidate * best = nullptr;
     double bestDist2 = std::numeric_limits<double>::max();
     std::vector<const VertexCandidate*> considered;
     int nMatchesWithinTolerance = 0;
 
-    for (const auto & [eventId, candidates] : fEventToVertexIDs)
+    const auto scanCandidates = [&](const std::vector<const VertexCandidate*> & candidates)
     {
-      (void)eventId;
-      for (const auto & candidate : candidates)
+      for (const auto * candidate : candidates)
       {
-        considered.push_back(&candidate);
+        considered.push_back(candidate);
 
-        double dx = candidate.x - x;
-        double dy = candidate.y - y;
-        double dz = candidate.z - z;
+        double dx = candidate->x - x;
+        double dy = candidate->y - y;
+        double dz = candidate->z - z;
         double dist2 = dx*dx + dy*dy + dz*dz;
         if (dist2 <= kPositionToleranceMm * kPositionToleranceMm)
         {
           ++nMatchesWithinTolerance;
           if (!best || dist2 < bestDist2)
           {
-            best = &candidate;
+            best = candidate;
             bestDist2 = dist2;
           }
         }
         else if (!best && dist2 < bestDist2)
         {
           bestDist2 = dist2;
+        }
+      }
+    };
+
+    for (long long bin = yBin - 1; bin <= yBin + 1; ++bin)
+    {
+      auto it = fVertexCandidatesByYBin.find(bin);
+      if (it != fVertexCandidatesByYBin.end())
+        scanCandidates(it->second);
+    }
+
+    if (!best)
+    {
+      considered.clear();
+      bestDist2 = std::numeric_limits<double>::max();
+      for (const auto & [eventId, candidates] : fEventToVertexIDs)
+      {
+        (void)eventId;
+        for (const auto & candidate : candidates)
+        {
+          considered.push_back(&candidate);
+
+          double dx = candidate.x - x;
+          double dy = candidate.y - y;
+          double dz = candidate.z - z;
+          double dist2 = dx*dx + dy*dy + dz*dz;
+          if (dist2 <= kPositionToleranceMm * kPositionToleranceMm)
+          {
+            ++nMatchesWithinTolerance;
+            if (!best || dist2 < bestDist2)
+            {
+              best = &candidate;
+              bestDist2 = dist2;
+            }
+          }
+          else if (!best && dist2 < bestDist2)
+          {
+            bestDist2 = dist2;
+          }
         }
       }
     }
@@ -825,6 +885,7 @@ namespace cafmaker
                     << best->vertexID << ".\n";
     }
 
+    fResolvedVertexIDByPosition[cacheKey] = best->vertexID;
     return best->vertexID;
   }
 

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -7,8 +7,6 @@
 
 #include "FillTruth.h"
 
-#include <chrono>
-#include <cstdlib>
 #include <map>
 #include <regex>
 
@@ -36,42 +34,6 @@
 namespace
 {
   constexpr double kTMSPositionResolverYBinWidthMm = 500.0;
-
-  bool TruthTimingEnabled()
-  {
-    static const bool enabled = []()
-    {
-      const char * env = std::getenv("ND_CAFMAKER_TIMING");
-      if (!env) return false;
-      const std::string value(env);
-      return !value.empty() && value != "0" && value != "false" && value != "FALSE";
-    }();
-    return enabled;
-  }
-
-  class ScopedTiming
-  {
-    public:
-      ScopedTiming(bool enabled, double & totalMs, std::size_t & calls)
-        : fEnabled(enabled), fTotalMs(totalMs), fCalls(calls)
-      {
-        if (fEnabled)
-          fStart = std::chrono::steady_clock::now();
-      }
-
-      ~ScopedTiming()
-      {
-        if (!fEnabled) return;
-        ++fCalls;
-        fTotalMs += std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - fStart).count();
-      }
-
-    private:
-      bool fEnabled = false;
-      double & fTotalMs;
-      std::size_t & fCalls;
-      std::chrono::steady_clock::time_point fStart;
-  };
 }
 
 /// duneanaobj not guaranteed to be the same as GENIE scattering types
@@ -676,7 +638,6 @@ namespace cafmaker
   TruthMatcher::EdepSimTreeContainer::EdepSimTreeContainer(std::string filename)
   : cafmaker::Loggable("GTreeContainer")
   {
-    fTiming.enabled = TruthTimingEnabled();
     fEdepFile = TFile::Open(filename.c_str());
     fG4Event = 0;
     if (fEdepFile && !fEdepFile->IsZombie())
@@ -691,34 +652,8 @@ namespace cafmaker
   }
 
   // ------------------------------------------------------------
-  TruthMatcher::EdepSimTreeContainer::~EdepSimTreeContainer()
-  {
-    if (!fTiming.enabled) return;
-
-    const double loadTreeAvgMs = fTiming.loadTreeCalls ? fTiming.loadTreeMs / fTiming.loadTreeCalls : 0.0;
-    const double resolveVertexIDAvgMs = fTiming.resolveVertexIDCalls ? fTiming.resolveVertexIDMs / fTiming.resolveVertexIDCalls : 0.0;
-    const double resolveRunPosAvgMs = fTiming.resolveRunPosCalls ? fTiming.resolveRunPosMs / fTiming.resolveRunPosCalls : 0.0;
-    const double resolveRunPosAvgCandidates = fTiming.resolveRunPosCalls ? static_cast<double>(fTiming.resolveRunPosCandidatesScanned) / fTiming.resolveRunPosCalls : 0.0;
-
-    std::cerr << "[ND_CAFMaker timing] EdepSimTreeContainer summary\n"
-              << "  LoadTree: calls=" << fTiming.loadTreeCalls
-              << " total_ms=" << fTiming.loadTreeMs
-              << " avg_ms=" << loadTreeAvgMs << "\n"
-              << "  ResolveVertexID: calls=" << fTiming.resolveVertexIDCalls
-              << " total_ms=" << fTiming.resolveVertexIDMs
-              << " avg_ms=" << resolveVertexIDAvgMs << "\n"
-              << "  ResolveVertexIDFromRunAndPosition: calls=" << fTiming.resolveRunPosCalls
-              << " total_ms=" << fTiming.resolveRunPosMs
-              << " avg_ms=" << resolveRunPosAvgMs
-              << " cache_hits=" << fTiming.resolveRunPosCacheHits
-              << " cache_misses=" << fTiming.resolveRunPosCacheMisses
-              << " avg_candidates_scanned=" << resolveRunPosAvgCandidates << "\n";
-  }
-
-  // ------------------------------------------------------------
   void  TruthMatcher::EdepSimTreeContainer::LoadTree()
   {
-    ScopedTiming timing(fTiming.enabled, fTiming.loadTreeMs, fTiming.loadTreeCalls);
     for (int i = 0; i<fEdepTree->GetEntries(); i++)
     {
       fEdepTree->GetEntry(i);
@@ -762,7 +697,6 @@ namespace cafmaker
   // ------------------------------------------------------------
   unsigned long int TruthMatcher::EdepSimTreeContainer::ResolveVertexID(unsigned int evtNum, double x, double y, double z)
   {
-    ScopedTiming timing(fTiming.enabled, fTiming.resolveVertexIDMs, fTiming.resolveVertexIDCalls);
     if (!f_isTreeLoaded)
     {
       LoadTree();
@@ -835,7 +769,6 @@ namespace cafmaker
   // ------------------------------------------------------------
   unsigned long int TruthMatcher::EdepSimTreeContainer::ResolveVertexIDFromRunAndPosition(unsigned long int baseRunNum, double x, double y, double z)
   {
-    ScopedTiming timing(fTiming.enabled, fTiming.resolveRunPosMs, fTiming.resolveRunPosCalls);
     if (!f_isTreeLoaded)
     {
       LoadTree();
@@ -845,11 +778,7 @@ namespace cafmaker
     const auto cacheKey = std::make_tuple(x, y, z);
     auto cacheIt = fResolvedVertexIDByPosition.find(cacheKey);
     if (cacheIt != fResolvedVertexIDByPosition.end())
-    {
-      if (fTiming.enabled) ++fTiming.resolveRunPosCacheHits;
       return cacheIt->second;
-    }
-    if (fTiming.enabled) ++fTiming.resolveRunPosCacheMisses;
 
     constexpr double kPositionToleranceMm = 1.0;
     const long long yBin = static_cast<long long>(std::floor(y / kTMSPositionResolverYBinWidthMm));
@@ -864,7 +793,6 @@ namespace cafmaker
       for (const auto * candidate : candidates)
       {
         considered.push_back(candidate);
-        if (fTiming.enabled) ++fTiming.resolveRunPosCandidatesScanned;
 
         double dx = candidate->x - x;
         double dy = candidate->y - y;
@@ -903,7 +831,6 @@ namespace cafmaker
         for (const auto & candidate : candidates)
         {
           considered.push_back(&candidate);
-          if (fTiming.enabled) ++fTiming.resolveRunPosCandidatesScanned;
 
           double dx = candidate.x - x;
           double dy = candidate.y - y;

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -7,6 +7,8 @@
 
 #include "FillTruth.h"
 
+#include <chrono>
+#include <cstdlib>
 #include <map>
 #include <regex>
 
@@ -34,6 +36,42 @@
 namespace
 {
   constexpr double kTMSPositionResolverYBinWidthMm = 500.0;
+
+  bool TruthTimingEnabled()
+  {
+    static const bool enabled = []()
+    {
+      const char * env = std::getenv("ND_CAFMAKER_TIMING");
+      if (!env) return false;
+      const std::string value(env);
+      return !value.empty() && value != "0" && value != "false" && value != "FALSE";
+    }();
+    return enabled;
+  }
+
+  class ScopedTiming
+  {
+    public:
+      ScopedTiming(bool enabled, double & totalMs, std::size_t & calls)
+        : fEnabled(enabled), fTotalMs(totalMs), fCalls(calls)
+      {
+        if (fEnabled)
+          fStart = std::chrono::steady_clock::now();
+      }
+
+      ~ScopedTiming()
+      {
+        if (!fEnabled) return;
+        ++fCalls;
+        fTotalMs += std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - fStart).count();
+      }
+
+    private:
+      bool fEnabled = false;
+      double & fTotalMs;
+      std::size_t & fCalls;
+      std::chrono::steady_clock::time_point fStart;
+  };
 }
 
 /// duneanaobj not guaranteed to be the same as GENIE scattering types
@@ -638,6 +676,7 @@ namespace cafmaker
   TruthMatcher::EdepSimTreeContainer::EdepSimTreeContainer(std::string filename)
   : cafmaker::Loggable("GTreeContainer")
   {
+    fTiming.enabled = TruthTimingEnabled();
     fEdepFile = TFile::Open(filename.c_str());
     fG4Event = 0;
     if (fEdepFile && !fEdepFile->IsZombie())
@@ -652,8 +691,34 @@ namespace cafmaker
   }
 
   // ------------------------------------------------------------
+  TruthMatcher::EdepSimTreeContainer::~EdepSimTreeContainer()
+  {
+    if (!fTiming.enabled) return;
+
+    const double loadTreeAvgMs = fTiming.loadTreeCalls ? fTiming.loadTreeMs / fTiming.loadTreeCalls : 0.0;
+    const double resolveVertexIDAvgMs = fTiming.resolveVertexIDCalls ? fTiming.resolveVertexIDMs / fTiming.resolveVertexIDCalls : 0.0;
+    const double resolveRunPosAvgMs = fTiming.resolveRunPosCalls ? fTiming.resolveRunPosMs / fTiming.resolveRunPosCalls : 0.0;
+    const double resolveRunPosAvgCandidates = fTiming.resolveRunPosCalls ? static_cast<double>(fTiming.resolveRunPosCandidatesScanned) / fTiming.resolveRunPosCalls : 0.0;
+
+    std::cerr << "[ND_CAFMaker timing] EdepSimTreeContainer summary\n"
+              << "  LoadTree: calls=" << fTiming.loadTreeCalls
+              << " total_ms=" << fTiming.loadTreeMs
+              << " avg_ms=" << loadTreeAvgMs << "\n"
+              << "  ResolveVertexID: calls=" << fTiming.resolveVertexIDCalls
+              << " total_ms=" << fTiming.resolveVertexIDMs
+              << " avg_ms=" << resolveVertexIDAvgMs << "\n"
+              << "  ResolveVertexIDFromRunAndPosition: calls=" << fTiming.resolveRunPosCalls
+              << " total_ms=" << fTiming.resolveRunPosMs
+              << " avg_ms=" << resolveRunPosAvgMs
+              << " cache_hits=" << fTiming.resolveRunPosCacheHits
+              << " cache_misses=" << fTiming.resolveRunPosCacheMisses
+              << " avg_candidates_scanned=" << resolveRunPosAvgCandidates << "\n";
+  }
+
+  // ------------------------------------------------------------
   void  TruthMatcher::EdepSimTreeContainer::LoadTree()
   {
+    ScopedTiming timing(fTiming.enabled, fTiming.loadTreeMs, fTiming.loadTreeCalls);
     for (int i = 0; i<fEdepTree->GetEntries(); i++)
     {
       fEdepTree->GetEntry(i);
@@ -697,6 +762,7 @@ namespace cafmaker
   // ------------------------------------------------------------
   unsigned long int TruthMatcher::EdepSimTreeContainer::ResolveVertexID(unsigned int evtNum, double x, double y, double z)
   {
+    ScopedTiming timing(fTiming.enabled, fTiming.resolveVertexIDMs, fTiming.resolveVertexIDCalls);
     if (!f_isTreeLoaded)
     {
       LoadTree();
@@ -769,6 +835,7 @@ namespace cafmaker
   // ------------------------------------------------------------
   unsigned long int TruthMatcher::EdepSimTreeContainer::ResolveVertexIDFromRunAndPosition(unsigned long int baseRunNum, double x, double y, double z)
   {
+    ScopedTiming timing(fTiming.enabled, fTiming.resolveRunPosMs, fTiming.resolveRunPosCalls);
     if (!f_isTreeLoaded)
     {
       LoadTree();
@@ -778,7 +845,11 @@ namespace cafmaker
     const auto cacheKey = std::make_tuple(x, y, z);
     auto cacheIt = fResolvedVertexIDByPosition.find(cacheKey);
     if (cacheIt != fResolvedVertexIDByPosition.end())
+    {
+      if (fTiming.enabled) ++fTiming.resolveRunPosCacheHits;
       return cacheIt->second;
+    }
+    if (fTiming.enabled) ++fTiming.resolveRunPosCacheMisses;
 
     constexpr double kPositionToleranceMm = 1.0;
     const long long yBin = static_cast<long long>(std::floor(y / kTMSPositionResolverYBinWidthMm));
@@ -793,6 +864,7 @@ namespace cafmaker
       for (const auto * candidate : candidates)
       {
         considered.push_back(candidate);
+        if (fTiming.enabled) ++fTiming.resolveRunPosCandidatesScanned;
 
         double dx = candidate->x - x;
         double dy = candidate->y - y;
@@ -831,6 +903,7 @@ namespace cafmaker
         for (const auto & candidate : candidates)
         {
           considered.push_back(&candidate);
+          if (fTiming.enabled) ++fTiming.resolveRunPosCandidatesScanned;
 
           double dx = candidate.x - x;
           double dy = candidate.y - y;

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -482,12 +482,12 @@ namespace cafmaker
   }
 
   // ------------------------------------------------------------
-  unsigned long TruthMatcher::ResolveVertexIDFromRunAndPosition(unsigned long baseRunNum, double x, double y, double z) const
+  unsigned long TruthMatcher::ResolveVertexIDFromRunAndPosition(unsigned long runNumForErrMsg, double x, double y, double z) const
   {
     if (!HaveEDEPSIM())
       throw std::runtime_error("TruthMatcher::ResolveVertexIDFromRunAndPosition() requires an EDepSim file");
 
-    return fEdepSimTree.ResolveVertexIDFromRunAndPosition(baseRunNum, x, y, z);
+    return fEdepSimTree.ResolveVertexIDFromRunAndPosition(runNumForErrMsg, x, y, z);
   }
 
   // ------------------------------------------------------------
@@ -769,7 +769,7 @@ namespace cafmaker
   }
 
   // ------------------------------------------------------------
-  unsigned long int TruthMatcher::EdepSimTreeContainer::ResolveVertexIDFromRunAndPosition(unsigned long int baseRunNum, double x, double y, double z)
+  unsigned long int TruthMatcher::EdepSimTreeContainer::ResolveVertexIDFromRunAndPosition(unsigned long int runNumForErrMsg, double x, double y, double z)
   {
     if (!f_isTreeLoaded)
     {
@@ -857,7 +857,7 @@ namespace cafmaker
     if (!best)
     {
       std::stringstream ss;
-      ss << "EDepSim position-only resolver for base run " << baseRunNum
+      ss << "EDepSim position-only resolver for base run " << runNumForErrMsg
          << " considered " << considered.size() << " candidate packed vertex IDs, but none matched TMS truth position ("
          << x << ", " << y << ", " << z << ") within " << fPositionToleranceMm
          << " mm. Closest distance was " << std::sqrt(bestDist2) << " mm\n"
@@ -879,7 +879,7 @@ namespace cafmaker
 
     if (nMatchesWithinTolerance > 1)
     {
-      LOG.WARNING() << "EDepSim position-only resolver for base run " << baseRunNum
+      LOG.WARNING() << "EDepSim position-only resolver for base run " << runNumForErrMsg
                     << " found " << nMatchesWithinTolerance << " packed vertex IDs within "
                     << fPositionToleranceMm << " mm of TMS truth position ("
                     << x << ", " << y << ", " << z << "); choosing closest match with vertexID="

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -139,11 +139,12 @@ namespace cafmaker
   TruthMatcher::TruthMatcher(const std::vector<std::string> & ghepFilenames,
                              std::string edepsimFilename,
                              const genie::NtpMCEventRecord *gEvt,
-                             std::function<int(const genie::NtpMCEventRecord *)> genieFillerCallback)
+                             std::function<int(const genie::NtpMCEventRecord *)> genieFillerCallback,
+                             double positionToleranceMm)
     : cafmaker::Loggable("TruthMatcher"),
       fGTrees(ghepFilenames, gEvt),
       fGENIEWriterCallback(std::move(genieFillerCallback)),
-      fEdepSimTree(edepsimFilename)
+      fEdepSimTree(edepsimFilename, positionToleranceMm)
   {
     if (HaveGENIE() && !HaveEDEPSIM())
     LOG_S("TruthMatcher::FillInteraction").WARNING() << "CAFMaker has GENIE but no Edepsim, truth will be limited, should not be used for official production \n";
@@ -635,8 +636,10 @@ namespace cafmaker
   }
 
   // ------------------------------------------------------------
-  TruthMatcher::EdepSimTreeContainer::EdepSimTreeContainer(std::string filename)
-  : cafmaker::Loggable("GTreeContainer")
+  TruthMatcher::EdepSimTreeContainer::EdepSimTreeContainer(std::string filename,
+                                                           double positionToleranceMm)
+  : cafmaker::Loggable("GTreeContainer"),
+    fPositionToleranceMm(positionToleranceMm)
   {
     fEdepFile = TFile::Open(filename.c_str());
     fG4Event = 0;
@@ -712,7 +715,6 @@ namespace cafmaker
       throw std::range_error(ss.str());
     }
 
-    constexpr double kPositionToleranceMm = 1.0;
     const VertexCandidate * best = nullptr;
     double bestDist2 = std::numeric_limits<double>::max();
     for (const auto & candidate : it->second)
@@ -721,13 +723,13 @@ namespace cafmaker
       double dy = candidate.y - y;
       double dz = candidate.z - z;
       double dist2 = dx*dx + dy*dy + dz*dz;
-      if (dist2 <= kPositionToleranceMm * kPositionToleranceMm)
+      if (dist2 <= fPositionToleranceMm * fPositionToleranceMm)
       {
         if (best)
         {
           std::stringstream ss;
           ss << "EDepSim event ID " << evtNum << " matches multiple packed vertex IDs within "
-             << kPositionToleranceMm << " mm of TMS truth position (" << x << ", " << y << ", " << z << ")\n";
+             << fPositionToleranceMm << " mm of TMS truth position (" << x << ", " << y << ", " << z << ")\n";
           LOG.FATAL() << ss.str();
           throw std::runtime_error(ss.str());
         }
@@ -745,7 +747,7 @@ namespace cafmaker
       std::stringstream ss;
       ss << "EDepSim event ID " << evtNum << " had " << it->second.size()
          << " candidate packed vertex IDs, but none matched TMS truth position ("
-         << x << ", " << y << ", " << z << ") within " << kPositionToleranceMm
+         << x << ", " << y << ", " << z << ") within " << fPositionToleranceMm
          << " mm. Closest distance was " << std::sqrt(bestDist2) << " mm\n"
          << "Candidates considered:\n";
       for (const auto & candidate : it->second)
@@ -780,7 +782,6 @@ namespace cafmaker
     if (cacheIt != fResolvedVertexIDByPosition.end())
       return cacheIt->second;
 
-    constexpr double kPositionToleranceMm = 1.0;
     const long long yBin = static_cast<long long>(std::floor(y / kTMSPositionResolverYBinWidthMm));
 
     const VertexCandidate * best = nullptr;
@@ -798,7 +799,7 @@ namespace cafmaker
         double dy = candidate->y - y;
         double dz = candidate->z - z;
         double dist2 = dx*dx + dy*dy + dz*dz;
-        if (dist2 <= kPositionToleranceMm * kPositionToleranceMm)
+        if (dist2 <= fPositionToleranceMm * fPositionToleranceMm)
         {
           ++nMatchesWithinTolerance;
           if (!best || dist2 < bestDist2)
@@ -836,7 +837,7 @@ namespace cafmaker
           double dy = candidate.y - y;
           double dz = candidate.z - z;
           double dist2 = dx*dx + dy*dy + dz*dz;
-          if (dist2 <= kPositionToleranceMm * kPositionToleranceMm)
+          if (dist2 <= fPositionToleranceMm * fPositionToleranceMm)
           {
             ++nMatchesWithinTolerance;
             if (!best || dist2 < bestDist2)
@@ -858,7 +859,7 @@ namespace cafmaker
       std::stringstream ss;
       ss << "EDepSim position-only resolver for base run " << baseRunNum
          << " considered " << considered.size() << " candidate packed vertex IDs, but none matched TMS truth position ("
-         << x << ", " << y << ", " << z << ") within " << kPositionToleranceMm
+         << x << ", " << y << ", " << z << ") within " << fPositionToleranceMm
          << " mm. Closest distance was " << std::sqrt(bestDist2) << " mm\n"
          << "Candidates considered:\n";
       for (const auto * candidate : considered)
@@ -880,7 +881,7 @@ namespace cafmaker
     {
       LOG.WARNING() << "EDepSim position-only resolver for base run " << baseRunNum
                     << " found " << nMatchesWithinTolerance << " packed vertex IDs within "
-                    << kPositionToleranceMm << " mm of TMS truth position ("
+                    << fPositionToleranceMm << " mm of TMS truth position ("
                     << x << ", " << y << ", " << z << "); choosing closest match with vertexID="
                     << best->vertexID << ".\n";
     }

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -761,7 +761,8 @@ namespace cafmaker
     }
 
     constexpr double kPositionToleranceMm = 1.0;
-    const unsigned long int rockRunNum = baseRunNum + 1000000000ul;
+    const unsigned long int normalizedRunNum = (baseRunNum >= 1000000000ul) ? (baseRunNum - 1000000000ul) : baseRunNum;
+    const unsigned long int rockRunNum = normalizedRunNum + 1000000000ul;
     const VertexCandidate * best = nullptr;
     double bestDist2 = std::numeric_limits<double>::max();
     std::vector<const VertexCandidate*> considered;
@@ -771,7 +772,7 @@ namespace cafmaker
       (void)eventId;
       for (const auto & candidate : candidates)
       {
-        if (candidate.runID != baseRunNum && candidate.runID != rockRunNum)
+        if (candidate.runID != normalizedRunNum && candidate.runID != rockRunNum)
           continue;
         considered.push_back(&candidate);
 

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -467,12 +467,12 @@ namespace cafmaker
   }
 
   // ------------------------------------------------------------
-  unsigned long TruthMatcher::ResolveVertexID(unsigned int evtNum) const
+  unsigned long TruthMatcher::ResolveVertexID(unsigned int evtNum, double x, double y, double z) const
   {
     if (!HaveEDEPSIM())
       throw std::runtime_error("TruthMatcher::ResolveVertexID() requires an EDepSim file");
 
-    return fEdepSimTree.ResolveVertexID(evtNum);
+    return fEdepSimTree.ResolveVertexID(evtNum, x, y, z);
   }
 
   // ------------------------------------------------------------
@@ -646,16 +646,17 @@ namespace cafmaker
       unsigned long int vertex_id = static_cast<unsigned long int>(fG4Event->RunId) * 1000000ul + static_cast<unsigned long int>(fG4Event->EventId);
       fEdepEntries[vertex_id] = i;
 
-      unsigned int event_id = static_cast<unsigned int>(fG4Event->EventId);
-      auto [it, inserted] = fEventToVertexID.emplace(event_id, vertex_id);
-      if (!inserted && it->second != vertex_id)
+      if (fG4Event->Primaries.empty())
       {
         std::stringstream ss;
-        ss << "EDepSim event ID " << event_id << " maps to multiple packed vertex IDs ("
-           << it->second << " and " << vertex_id << "). TMS resolution by EventId is ambiguous.\n";
+        ss << "EDepSim event with packed vertex ID " << vertex_id << " has no primary vertices\n";
         LOG.FATAL() << ss.str();
         throw std::runtime_error(ss.str());
       }
+
+      const auto & pos = fG4Event->Primaries.front().Position;
+      unsigned int event_id = static_cast<unsigned int>(fG4Event->EventId);
+      fEventToVertexIDs[event_id].push_back(VertexCandidate{vertex_id, pos.X(), pos.Y(), pos.Z()});
     }
   }
 
@@ -667,7 +668,7 @@ namespace cafmaker
   }
 
   // ------------------------------------------------------------
-  unsigned long int TruthMatcher::EdepSimTreeContainer::ResolveVertexID(unsigned int evtNum)
+  unsigned long int TruthMatcher::EdepSimTreeContainer::ResolveVertexID(unsigned int evtNum, double x, double y, double z)
   {
     if (!f_isTreeLoaded)
     {
@@ -675,8 +676,8 @@ namespace cafmaker
       f_isTreeLoaded = true;
     }
 
-    auto it = fEventToVertexID.find(evtNum);
-    if (it == fEventToVertexID.end())
+    auto it = fEventToVertexIDs.find(evtNum);
+    if (it == fEventToVertexIDs.end())
     {
       std::stringstream ss;
       ss << "EDepSim event ID " << evtNum << " was not found while resolving a packed vertex ID\n";
@@ -684,7 +685,46 @@ namespace cafmaker
       throw std::range_error(ss.str());
     }
 
-    return it->second;
+    constexpr double kPositionToleranceMm = 1.0;
+    const VertexCandidate * best = nullptr;
+    double bestDist2 = std::numeric_limits<double>::max();
+    for (const auto & candidate : it->second)
+    {
+      double dx = candidate.x - x;
+      double dy = candidate.y - y;
+      double dz = candidate.z - z;
+      double dist2 = dx*dx + dy*dy + dz*dz;
+      if (dist2 <= kPositionToleranceMm * kPositionToleranceMm)
+      {
+        if (best)
+        {
+          std::stringstream ss;
+          ss << "EDepSim event ID " << evtNum << " matches multiple packed vertex IDs within "
+             << kPositionToleranceMm << " mm of TMS truth position (" << x << ", " << y << ", " << z << ")\n";
+          LOG.FATAL() << ss.str();
+          throw std::runtime_error(ss.str());
+        }
+        best = &candidate;
+        bestDist2 = dist2;
+      }
+      else if (!best && dist2 < bestDist2)
+      {
+        bestDist2 = dist2;
+      }
+    }
+
+    if (!best)
+    {
+      std::stringstream ss;
+      ss << "EDepSim event ID " << evtNum << " had " << it->second.size()
+         << " candidate packed vertex IDs, but none matched TMS truth position ("
+         << x << ", " << y << ", " << z << ") within " << kPositionToleranceMm
+         << " mm. Closest distance was " << std::sqrt(bestDist2) << " mm\n";
+      LOG.FATAL() << ss.str();
+      throw std::runtime_error(ss.str());
+    }
+
+    return best->vertexID;
   }
 
   // ------------------------------------------------------------

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -467,6 +467,15 @@ namespace cafmaker
   }
 
   // ------------------------------------------------------------
+  unsigned long TruthMatcher::ResolveVertexID(unsigned int evtNum) const
+  {
+    if (!HaveEDEPSIM())
+      throw std::runtime_error("TruthMatcher::ResolveVertexID() requires an EDepSim file");
+
+    return fEdepSimTree.ResolveVertexID(evtNum);
+  }
+
+  // ------------------------------------------------------------
   bool TruthMatcher::HaveGENIE() const
   {
     static auto isNull = [](const std::pair<unsigned long int, const TTree*>& pair) -> bool { return !pair.second; };
@@ -634,15 +643,48 @@ namespace cafmaker
     for (int i = 0; i<fEdepTree->GetEntries(); i++)
     {
       fEdepTree->GetEntry(i);
-      long int vertex_id = fG4Event->RunId * 1e6 + fG4Event->EventId;                                                                                                                              fEdepEntries[vertex_id] = i;
+      unsigned long int vertex_id = static_cast<unsigned long int>(fG4Event->RunId) * 1000000ul + static_cast<unsigned long int>(fG4Event->EventId);
+      fEdepEntries[vertex_id] = i;
+
+      unsigned int event_id = static_cast<unsigned int>(fG4Event->EventId);
+      auto [it, inserted] = fEventToVertexID.emplace(event_id, vertex_id);
+      if (!inserted && it->second != vertex_id)
+      {
+        std::stringstream ss;
+        ss << "EDepSim event ID " << event_id << " maps to multiple packed vertex IDs ("
+           << it->second << " and " << vertex_id << "). TMS resolution by EventId is ambiguous.\n";
+        LOG.FATAL() << ss.str();
+        throw std::runtime_error(ss.str());
+      }
     }
   }
 
   // ------------------------------------------------------------
   void TruthMatcher::EdepSimTreeContainer::SelectEvent(unsigned long runNum, unsigned int evtNum)
   {
-    long int vertex_id = runNum * 1e6 + evtNum;
-     SelectEvent(vertex_id); 
+    unsigned long int vertex_id = runNum * 1000000ul + evtNum;
+    SelectEvent(vertex_id);
+  }
+
+  // ------------------------------------------------------------
+  unsigned long int TruthMatcher::EdepSimTreeContainer::ResolveVertexID(unsigned int evtNum)
+  {
+    if (!f_isTreeLoaded)
+    {
+      LoadTree();
+      f_isTreeLoaded = true;
+    }
+
+    auto it = fEventToVertexID.find(evtNum);
+    if (it == fEventToVertexID.end())
+    {
+      std::stringstream ss;
+      ss << "EDepSim event ID " << evtNum << " was not found while resolving a packed vertex ID\n";
+      LOG.FATAL() << ss.str();
+      throw std::range_error(ss.str());
+    }
+
+    return it->second;
   }
 
   // ------------------------------------------------------------

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -591,6 +591,22 @@ namespace cafmaker
       fGTrees[run] = tree;
       tree->SetBranchAddress("gmcrec", &fGEvt);
 
+      auto & entries = fGEntries[run];
+      for (long long i = 0; i < tree->GetEntries(); ++i)
+      {
+        tree->GetEntry(i);
+        unsigned int eventNum = fGEvt->hdr.ievent;
+        auto [itEntry, inserted] = entries.emplace(eventNum, i);
+        if (!inserted)
+        {
+          std::stringstream msg;
+          msg << "Duplicate GENIE event number " << eventNum << " found for run " << run
+              << " while indexing file '" << fname << "'\n";
+          LOG.FATAL() << msg.str();
+          throw std::runtime_error(msg.str());
+        }
+      }
+
       LOG.INFO() << "Loaded TTree for run " << run << " from file: " << fname << "\n";
     }
   }
@@ -669,12 +685,33 @@ namespace cafmaker
       LOG.FATAL() << ss.str();
       throw std::range_error(ss.str());
     }
-    if (it_tree->second->GetEntry(evtNum) == 0)
+
+    auto it_runEntries = fGEntries.find(runNum);
+    if (it_runEntries == fGEntries.end())
     {
       std::stringstream ss;
-      ss << "Event number " << evtNum << " was not found in run: " << runNum << "\n";
+      ss << "Run number " << runNum << " has no indexed GENIE events\n";
       LOG.FATAL() << ss.str();
       throw std::range_error(ss.str());
+    }
+
+    auto it_entry = it_runEntries->second.find(evtNum);
+    if (it_entry == it_runEntries->second.end())
+    {
+      std::stringstream ss;
+      ss << "GENIE event number " << evtNum << " was not found in run " << runNum << "\n";
+      LOG.FATAL() << ss.str();
+      throw std::range_error(ss.str());
+    }
+
+    long long bytesRead = it_tree->second->GetEntry(it_entry->second);
+    if (bytesRead <= 0)
+    {
+      std::stringstream ss;
+      ss << "Failed to read GENIE event number " << evtNum << " in run " << runNum
+         << " from tree entry " << it_entry->second << " (GetEntry returned " << bytesRead << ")\n";
+      LOG.FATAL() << ss.str();
+      throw std::runtime_error(ss.str());
     }
   }
 

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -476,6 +476,15 @@ namespace cafmaker
   }
 
   // ------------------------------------------------------------
+  unsigned long TruthMatcher::ResolveVertexIDFromRunAndPosition(unsigned long baseRunNum, double x, double y, double z) const
+  {
+    if (!HaveEDEPSIM())
+      throw std::runtime_error("TruthMatcher::ResolveVertexIDFromRunAndPosition() requires an EDepSim file");
+
+    return fEdepSimTree.ResolveVertexIDFromRunAndPosition(baseRunNum, x, y, z);
+  }
+
+  // ------------------------------------------------------------
   bool TruthMatcher::HaveGENIE() const
   {
     static auto isNull = [](const std::pair<unsigned long int, const TTree*>& pair) -> bool { return !pair.second; };
@@ -656,7 +665,10 @@ namespace cafmaker
 
       const auto & pos = fG4Event->Primaries.front().Position;
       unsigned int event_id = static_cast<unsigned int>(fG4Event->EventId);
-      fEventToVertexIDs[event_id].push_back(VertexCandidate{vertex_id, pos.X(), pos.Y(), pos.Z()});
+      fEventToVertexIDs[event_id].push_back(VertexCandidate{vertex_id,
+                                                            static_cast<unsigned long int>(fG4Event->RunId),
+                                                            event_id,
+                                                            pos.X(), pos.Y(), pos.Z()});
     }
   }
 
@@ -727,8 +739,84 @@ namespace cafmaker
         double dy = candidate.y - y;
         double dz = candidate.z - z;
         double dist = std::sqrt(dx*dx + dy*dy + dz*dz);
-        ss << "  vertexID=" << candidate.vertexID
+        ss << "  runID=" << candidate.runID << " eventID=" << candidate.eventID
+           << " vertexID=" << candidate.vertexID
            << " pos=(" << candidate.x << ", " << candidate.y << ", " << candidate.z << ")"
+           << " dist_mm=" << dist << "\n";
+      }
+      LOG.FATAL() << ss.str();
+      throw std::runtime_error(ss.str());
+    }
+
+    return best->vertexID;
+  }
+
+  // ------------------------------------------------------------
+  unsigned long int TruthMatcher::EdepSimTreeContainer::ResolveVertexIDFromRunAndPosition(unsigned long int baseRunNum, double x, double y, double z)
+  {
+    if (!f_isTreeLoaded)
+    {
+      LoadTree();
+      f_isTreeLoaded = true;
+    }
+
+    constexpr double kPositionToleranceMm = 1.0;
+    const unsigned long int rockRunNum = baseRunNum + 1000000000ul;
+    const VertexCandidate * best = nullptr;
+    double bestDist2 = std::numeric_limits<double>::max();
+    std::vector<const VertexCandidate*> considered;
+
+    for (const auto & [eventId, candidates] : fEventToVertexIDs)
+    {
+      (void)eventId;
+      for (const auto & candidate : candidates)
+      {
+        if (candidate.runID != baseRunNum && candidate.runID != rockRunNum)
+          continue;
+        considered.push_back(&candidate);
+
+        double dx = candidate.x - x;
+        double dy = candidate.y - y;
+        double dz = candidate.z - z;
+        double dist2 = dx*dx + dy*dy + dz*dz;
+        if (dist2 <= kPositionToleranceMm * kPositionToleranceMm)
+        {
+          if (best)
+          {
+            std::stringstream ss;
+            ss << "EDepSim run-filtered resolver for base run " << baseRunNum
+               << " matched multiple packed vertex IDs within " << kPositionToleranceMm
+               << " mm of TMS truth position (" << x << ", " << y << ", " << z << ")\n";
+            LOG.FATAL() << ss.str();
+            throw std::runtime_error(ss.str());
+          }
+          best = &candidate;
+          bestDist2 = dist2;
+        }
+        else if (!best && dist2 < bestDist2)
+        {
+          bestDist2 = dist2;
+        }
+      }
+    }
+
+    if (!best)
+    {
+      std::stringstream ss;
+      ss << "EDepSim run-filtered resolver for base run " << baseRunNum
+         << " considered " << considered.size() << " candidate packed vertex IDs, but none matched TMS truth position ("
+         << x << ", " << y << ", " << z << ") within " << kPositionToleranceMm
+         << " mm. Closest distance was " << std::sqrt(bestDist2) << " mm\n"
+         << "Candidates considered:\n";
+      for (const auto * candidate : considered)
+      {
+        double dx = candidate->x - x;
+        double dy = candidate->y - y;
+        double dz = candidate->z - z;
+        double dist = std::sqrt(dx*dx + dy*dy + dz*dz);
+        ss << "  runID=" << candidate->runID << " eventID=" << candidate->eventID
+           << " vertexID=" << candidate->vertexID
+           << " pos=(" << candidate->x << ", " << candidate->y << ", " << candidate->z << ")"
            << " dist_mm=" << dist << "\n";
       }
       LOG.FATAL() << ss.str();

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -761,19 +761,16 @@ namespace cafmaker
     }
 
     constexpr double kPositionToleranceMm = 1.0;
-    const unsigned long int normalizedRunNum = (baseRunNum >= 1000000000ul) ? (baseRunNum - 1000000000ul) : baseRunNum;
-    const unsigned long int rockRunNum = normalizedRunNum + 1000000000ul;
     const VertexCandidate * best = nullptr;
     double bestDist2 = std::numeric_limits<double>::max();
     std::vector<const VertexCandidate*> considered;
+    int nMatchesWithinTolerance = 0;
 
     for (const auto & [eventId, candidates] : fEventToVertexIDs)
     {
       (void)eventId;
       for (const auto & candidate : candidates)
       {
-        if (candidate.runID != normalizedRunNum && candidate.runID != rockRunNum)
-          continue;
         considered.push_back(&candidate);
 
         double dx = candidate.x - x;
@@ -782,17 +779,12 @@ namespace cafmaker
         double dist2 = dx*dx + dy*dy + dz*dz;
         if (dist2 <= kPositionToleranceMm * kPositionToleranceMm)
         {
-          if (best)
+          ++nMatchesWithinTolerance;
+          if (!best || dist2 < bestDist2)
           {
-            std::stringstream ss;
-            ss << "EDepSim run-filtered resolver for base run " << baseRunNum
-               << " matched multiple packed vertex IDs within " << kPositionToleranceMm
-               << " mm of TMS truth position (" << x << ", " << y << ", " << z << ")\n";
-            LOG.FATAL() << ss.str();
-            throw std::runtime_error(ss.str());
+            best = &candidate;
+            bestDist2 = dist2;
           }
-          best = &candidate;
-          bestDist2 = dist2;
         }
         else if (!best && dist2 < bestDist2)
         {
@@ -804,7 +796,7 @@ namespace cafmaker
     if (!best)
     {
       std::stringstream ss;
-      ss << "EDepSim run-filtered resolver for base run " << baseRunNum
+      ss << "EDepSim position-only resolver for base run " << baseRunNum
          << " considered " << considered.size() << " candidate packed vertex IDs, but none matched TMS truth position ("
          << x << ", " << y << ", " << z << ") within " << kPositionToleranceMm
          << " mm. Closest distance was " << std::sqrt(bestDist2) << " mm\n"
@@ -822,6 +814,15 @@ namespace cafmaker
       }
       LOG.FATAL() << ss.str();
       throw std::runtime_error(ss.str());
+    }
+
+    if (nMatchesWithinTolerance > 1)
+    {
+      LOG.WARNING() << "EDepSim position-only resolver for base run " << baseRunNum
+                    << " found " << nMatchesWithinTolerance << " packed vertex IDs within "
+                    << kPositionToleranceMm << " mm of TMS truth position ("
+                    << x << ", " << y << ", " << z << "); choosing closest match with vertexID="
+                    << best->vertexID << ".\n";
     }
 
     return best->vertexID;

--- a/src/truth/FillTruth.cxx
+++ b/src/truth/FillTruth.cxx
@@ -719,7 +719,18 @@ namespace cafmaker
       ss << "EDepSim event ID " << evtNum << " had " << it->second.size()
          << " candidate packed vertex IDs, but none matched TMS truth position ("
          << x << ", " << y << ", " << z << ") within " << kPositionToleranceMm
-         << " mm. Closest distance was " << std::sqrt(bestDist2) << " mm\n";
+         << " mm. Closest distance was " << std::sqrt(bestDist2) << " mm\n"
+         << "Candidates considered:\n";
+      for (const auto & candidate : it->second)
+      {
+        double dx = candidate.x - x;
+        double dy = candidate.y - y;
+        double dz = candidate.z - z;
+        double dist = std::sqrt(dx*dx + dy*dy + dz*dz);
+        ss << "  vertexID=" << candidate.vertexID
+           << " pos=(" << candidate.x << ", " << candidate.y << ", " << candidate.z << ")"
+           << " dist_mm=" << dist << "\n";
+      }
       LOG.FATAL() << ss.str();
       throw std::runtime_error(ss.str());
     }

--- a/src/truth/FillTruth.h
+++ b/src/truth/FillTruth.h
@@ -12,7 +12,6 @@
 #include <functional>
 #include <iostream>
 #include <limits>
-#include <cmath>
 #include <map>
 #include <memory>
 #include <sstream>

--- a/src/truth/FillTruth.h
+++ b/src/truth/FillTruth.h
@@ -183,6 +183,9 @@
       /// Resolve an EDepSim EventId plus vertex position (mm) into the legacy packed vertex ID
       /// (run*1e6 + event). This preserves current CAFMaker conventions, even though the encoding is brittle.
       unsigned long ResolveVertexID(unsigned int evtNum, double x, double y, double z) const;
+      /// TMS-specific resolver: use a spill/base run number and vertex position, considering only
+      /// EDepSim candidates from baseRun or baseRun+1e9.
+      unsigned long ResolveVertexIDFromRunAndPosition(unsigned long baseRunNum, double x, double y, double z) const;
       bool HaveGENIE() const;
       bool HaveEDEPSIM() const;
       void SetLogThrehsold(cafmaker::Logger::THRESHOLD thresh) override;
@@ -229,6 +232,8 @@
           struct VertexCandidate
           {
             unsigned long int vertexID;
+            unsigned long int runID;
+            unsigned int eventID;
             double x;
             double y;
             double z;
@@ -238,6 +243,7 @@
           void SelectEvent(unsigned long int runNum, unsigned int evtNum);
           void SelectEvent(unsigned long int vertex_id);
           unsigned long int ResolveVertexID(unsigned int evtNum, double x, double y, double z);
+          unsigned long int ResolveVertexIDFromRunAndPosition(unsigned long int baseRunNum, double x, double y, double z);
           const TG4Event * G4Event() const;
           const TTree * GetEdepTree() const;
          

--- a/src/truth/FillTruth.h
+++ b/src/truth/FillTruth.h
@@ -133,7 +133,8 @@
       TruthMatcher(const std::vector<std::string> & ghepFilenames,
                   std::string edepsimFilename,
                    const genie::NtpMCEventRecord *gEvt,
-                   std::function<int(const genie::NtpMCEventRecord *)> genieFillerCallback);
+                   std::function<int(const genie::NtpMCEventRecord *)> genieFillerCallback,
+                   double positionToleranceMm);
 
       /// Find a TrueParticle within a given StandardRecord, or, if it doesn't exist, optionally make a new one
       ///
@@ -240,7 +241,8 @@
             double z;
           };
 
-          EdepSimTreeContainer(std::string filename);
+          EdepSimTreeContainer(std::string filename,
+                               double positionToleranceMm);
           void SelectEvent(unsigned long int runNum, unsigned int evtNum);
           void SelectEvent(unsigned long int vertex_id);
           unsigned long int ResolveVertexID(unsigned int evtNum, double x, double y, double z);
@@ -257,6 +259,7 @@
           std::map<unsigned int, std::vector<VertexCandidate>> fEventToVertexIDs;
           std::map<long long, std::vector<const VertexCandidate*>> fVertexCandidatesByYBin;
           std::map<std::tuple<double, double, double>, unsigned long int> fResolvedVertexIDByPosition;
+          double fPositionToleranceMm;
           const TG4Event * fG4Event;
           bool f_isTreeLoaded;
       };

--- a/src/truth/FillTruth.h
+++ b/src/truth/FillTruth.h
@@ -179,6 +179,9 @@
       /// \param createNew  Should a new SRTrueInteraction be made if one corresponding to the given ID is not found?
       /// \return           The caf::SRTrueParticle that was found, or if none found and createNew is true, a new instance
       caf::SRTrueInteraction & GetTrueInteraction(caf::StandardRecord & sr, unsigned long ixnID, bool createNew = true) const;
+      /// Resolve an EDepSim EventId into the legacy packed vertex ID (run*1e6 + event).
+      /// This preserves current CAFMaker conventions, even though the encoding is brittle.
+      unsigned long ResolveVertexID(unsigned int evtNum) const;
       bool HaveGENIE() const;
       bool HaveEDEPSIM() const;
       void SetLogThrehsold(cafmaker::Logger::THRESHOLD thresh) override;
@@ -226,6 +229,7 @@
           EdepSimTreeContainer(std::string filename);
           void SelectEvent(unsigned long int runNum, unsigned int evtNum);
           void SelectEvent(unsigned long int vertex_id);
+          unsigned long int ResolveVertexID(unsigned int evtNum);
           const TG4Event * G4Event() const;
           const TTree * GetEdepTree() const;
          
@@ -235,6 +239,7 @@
           TFile * fEdepFile;
           TTree * fEdepTree;
           std::map<unsigned long int, int> fEdepEntries;
+          std::map<unsigned int, unsigned long int> fEventToVertexID;
           const TG4Event * fG4Event;
           bool f_isTreeLoaded;
       };

--- a/src/truth/FillTruth.h
+++ b/src/truth/FillTruth.h
@@ -9,7 +9,6 @@
 #define ND_CAFMAKER_FILLTRUTH_H
 
 #include <cmath>
-#include <cstddef>
 #include <functional>
 #include <iostream>
 #include <limits>
@@ -243,7 +242,6 @@
           };
 
           EdepSimTreeContainer(std::string filename);
-          ~EdepSimTreeContainer();
           void SelectEvent(unsigned long int runNum, unsigned int evtNum);
           void SelectEvent(unsigned long int vertex_id);
           unsigned long int ResolveVertexID(unsigned int evtNum, double x, double y, double z);
@@ -254,27 +252,12 @@
           void  LoadTree();
 
         private:
-          struct TimingStats
-          {
-            bool enabled = false;
-            std::size_t loadTreeCalls = 0;
-            double loadTreeMs = 0.0;
-            std::size_t resolveVertexIDCalls = 0;
-            double resolveVertexIDMs = 0.0;
-            std::size_t resolveRunPosCalls = 0;
-            double resolveRunPosMs = 0.0;
-            std::size_t resolveRunPosCacheHits = 0;
-            std::size_t resolveRunPosCacheMisses = 0;
-            std::size_t resolveRunPosCandidatesScanned = 0;
-          };
-
           TFile * fEdepFile;
           TTree * fEdepTree;
           std::map<unsigned long int, int> fEdepEntries;
           std::map<unsigned int, std::vector<VertexCandidate>> fEventToVertexIDs;
           std::map<long long, std::vector<const VertexCandidate*>> fVertexCandidatesByYBin;
           std::map<std::tuple<double, double, double>, unsigned long int> fResolvedVertexIDByPosition;
-          TimingStats fTiming;
           const TG4Event * fG4Event;
           bool f_isTreeLoaded;
       };

--- a/src/truth/FillTruth.h
+++ b/src/truth/FillTruth.h
@@ -210,6 +210,7 @@
         private:
           const genie::NtpMCEventRecord * fGEvt;
           std::map<unsigned long int, TTree*> fGTrees;
+          std::map<unsigned long int, std::map<unsigned int, long long>> fGEntries;
           std::vector<std::unique_ptr<TFile>> fGFiles;
       };
 

--- a/src/truth/FillTruth.h
+++ b/src/truth/FillTruth.h
@@ -12,9 +12,11 @@
 #include <functional>
 #include <iostream>
 #include <limits>
+#include <cmath>
 #include <map>
 #include <memory>
 #include <sstream>
+#include <tuple>
 #include <vector>
 
 #include "fwd.h"
@@ -254,6 +256,8 @@
           TTree * fEdepTree;
           std::map<unsigned long int, int> fEdepEntries;
           std::map<unsigned int, std::vector<VertexCandidate>> fEventToVertexIDs;
+          std::map<long long, std::vector<const VertexCandidate*>> fVertexCandidatesByYBin;
+          std::map<std::tuple<double, double, double>, unsigned long int> fResolvedVertexIDByPosition;
           const TG4Event * fG4Event;
           bool f_isTreeLoaded;
       };

--- a/src/truth/FillTruth.h
+++ b/src/truth/FillTruth.h
@@ -15,6 +15,7 @@
 #include <map>
 #include <memory>
 #include <sstream>
+#include <vector>
 
 #include "fwd.h"
 #include "util/Loggable.h"
@@ -179,9 +180,9 @@
       /// \param createNew  Should a new SRTrueInteraction be made if one corresponding to the given ID is not found?
       /// \return           The caf::SRTrueParticle that was found, or if none found and createNew is true, a new instance
       caf::SRTrueInteraction & GetTrueInteraction(caf::StandardRecord & sr, unsigned long ixnID, bool createNew = true) const;
-      /// Resolve an EDepSim EventId into the legacy packed vertex ID (run*1e6 + event).
-      /// This preserves current CAFMaker conventions, even though the encoding is brittle.
-      unsigned long ResolveVertexID(unsigned int evtNum) const;
+      /// Resolve an EDepSim EventId plus vertex position (mm) into the legacy packed vertex ID
+      /// (run*1e6 + event). This preserves current CAFMaker conventions, even though the encoding is brittle.
+      unsigned long ResolveVertexID(unsigned int evtNum, double x, double y, double z) const;
       bool HaveGENIE() const;
       bool HaveEDEPSIM() const;
       void SetLogThrehsold(cafmaker::Logger::THRESHOLD thresh) override;
@@ -225,11 +226,18 @@
       class EdepSimTreeContainer : public cafmaker::Loggable
       {
         public:
+          struct VertexCandidate
+          {
+            unsigned long int vertexID;
+            double x;
+            double y;
+            double z;
+          };
 
           EdepSimTreeContainer(std::string filename);
           void SelectEvent(unsigned long int runNum, unsigned int evtNum);
           void SelectEvent(unsigned long int vertex_id);
-          unsigned long int ResolveVertexID(unsigned int evtNum);
+          unsigned long int ResolveVertexID(unsigned int evtNum, double x, double y, double z);
           const TG4Event * G4Event() const;
           const TTree * GetEdepTree() const;
          
@@ -239,7 +247,7 @@
           TFile * fEdepFile;
           TTree * fEdepTree;
           std::map<unsigned long int, int> fEdepEntries;
-          std::map<unsigned int, unsigned long int> fEventToVertexID;
+          std::map<unsigned int, std::vector<VertexCandidate>> fEventToVertexIDs;
           const TG4Event * fG4Event;
           bool f_isTreeLoaded;
       };

--- a/src/truth/FillTruth.h
+++ b/src/truth/FillTruth.h
@@ -9,6 +9,7 @@
 #define ND_CAFMAKER_FILLTRUTH_H
 
 #include <cmath>
+#include <cstddef>
 #include <functional>
 #include <iostream>
 #include <limits>
@@ -242,6 +243,7 @@
           };
 
           EdepSimTreeContainer(std::string filename);
+          ~EdepSimTreeContainer();
           void SelectEvent(unsigned long int runNum, unsigned int evtNum);
           void SelectEvent(unsigned long int vertex_id);
           unsigned long int ResolveVertexID(unsigned int evtNum, double x, double y, double z);
@@ -252,12 +254,27 @@
           void  LoadTree();
 
         private:
+          struct TimingStats
+          {
+            bool enabled = false;
+            std::size_t loadTreeCalls = 0;
+            double loadTreeMs = 0.0;
+            std::size_t resolveVertexIDCalls = 0;
+            double resolveVertexIDMs = 0.0;
+            std::size_t resolveRunPosCalls = 0;
+            double resolveRunPosMs = 0.0;
+            std::size_t resolveRunPosCacheHits = 0;
+            std::size_t resolveRunPosCacheMisses = 0;
+            std::size_t resolveRunPosCandidatesScanned = 0;
+          };
+
           TFile * fEdepFile;
           TTree * fEdepTree;
           std::map<unsigned long int, int> fEdepEntries;
           std::map<unsigned int, std::vector<VertexCandidate>> fEventToVertexIDs;
           std::map<long long, std::vector<const VertexCandidate*>> fVertexCandidatesByYBin;
           std::map<std::tuple<double, double, double>, unsigned long int> fResolvedVertexIDByPosition;
+          TimingStats fTiming;
           const TG4Event * fG4Event;
           bool f_isTreeLoaded;
       };

--- a/src/truth/FillTruth.h
+++ b/src/truth/FillTruth.h
@@ -186,8 +186,8 @@
       /// (run*1e6 + event). This preserves current CAFMaker conventions, even though the encoding is brittle.
       unsigned long ResolveVertexID(unsigned int evtNum, double x, double y, double z) const;
       /// TMS-specific resolver: use the Truth_Spill vertex position to recover the legacy packed
-      /// vertex ID. The base run number is retained only for diagnostics; matching is position-only.
-      unsigned long ResolveVertexIDFromRunAndPosition(unsigned long baseRunNum, double x, double y, double z) const;
+      /// vertex ID. The run number is retained only for diagnostics/error messages; matching is position-only.
+      unsigned long ResolveVertexIDFromRunAndPosition(unsigned long runNumForErrMsg, double x, double y, double z) const;
       bool HaveGENIE() const;
       bool HaveEDEPSIM() const;
       void SetLogThrehsold(cafmaker::Logger::THRESHOLD thresh) override;
@@ -246,7 +246,7 @@
           void SelectEvent(unsigned long int runNum, unsigned int evtNum);
           void SelectEvent(unsigned long int vertex_id);
           unsigned long int ResolveVertexID(unsigned int evtNum, double x, double y, double z);
-          unsigned long int ResolveVertexIDFromRunAndPosition(unsigned long int baseRunNum, double x, double y, double z);
+          unsigned long int ResolveVertexIDFromRunAndPosition(unsigned long int runNumForErrMsg, double x, double y, double z);
           const TG4Event * G4Event() const;
           const TTree * GetEdepTree() const;
          

--- a/src/truth/FillTruth.h
+++ b/src/truth/FillTruth.h
@@ -183,8 +183,8 @@
       /// Resolve an EDepSim EventId plus vertex position (mm) into the legacy packed vertex ID
       /// (run*1e6 + event). This preserves current CAFMaker conventions, even though the encoding is brittle.
       unsigned long ResolveVertexID(unsigned int evtNum, double x, double y, double z) const;
-      /// TMS-specific resolver: use a spill/base run number and vertex position, considering only
-      /// EDepSim candidates from baseRun or baseRun+1e9.
+      /// TMS-specific resolver: use the Truth_Spill vertex position to recover the legacy packed
+      /// vertex ID. The base run number is retained only for diagnostics; matching is position-only.
       unsigned long ResolveVertexIDFromRunAndPosition(unsigned long baseRunNum, double x, double y, double z) const;
       bool HaveGENIE() const;
       bool HaveEDEPSIM() const;


### PR DESCRIPTION
Fixes the SelectEvent function. The issue is from a mismatch between event ID variables and entry numbers. Rock files only save events that have neutrinos of high enough energy to hit the rock box, but the event ids are indexed as if all entries are saved

The solution was to create a map on opening the files. Then that map can be quickly referenced rather than scanning per SelectEvent call. Specifically, it's a map of maps to create unique mapping from (run, event num) -> (run, entry num). ...Map

There are a bunch of checks to make sure every mapping is unique and every SelectEvent found the actual run and entry. It will fatally crash if this is not the case, so this should fix the duplicate data issue in #132

# Changed files
src/truth/FillTruth.cxx
src/truth/FillTruth.h