### PR TITLE
Minor: Variable Name Update

### DIFF
--- a/src/reco/NDLArMINERvAMatchRecoFiller.cxx
+++ b/src/reco/NDLArMINERvAMatchRecoFiller.cxx
@@ -134,7 +134,7 @@ namespace cafmaker
               match.larid = larid;
               match.minervaid = mnvid;
               match.transdispl = residual;
-              match.angdispl = costheta;
+              match.cosangdispl = costheta;
 
               if (isnan(mult_map_spine[larid].transdispl))
                 mult_map_spine[larid] = match;
@@ -172,7 +172,7 @@ namespace cafmaker
               match.larid = larid;
               match.minervaid = mnvid;
               match.transdispl = residual;
-              match.angdispl = costheta;
+              match.cosangdispl = costheta;
 
               if (isnan(mult_map_pandora[larid].transdispl))
                 mult_map_pandora[larid] = match;

--- a/src/reco/NDLArTMSMatchRecoFiller.cxx
+++ b/src/reco/NDLArTMSMatchRecoFiller.cxx
@@ -69,7 +69,7 @@ namespace cafmaker
 //          match.larid = ilar;
 //          match.tmsid = itms;
 //          match.transdispl = residual;
-//          match.angdispl = costheta;
+//          match.cosangdispl = costheta;
 //          sr.nd.trkmatch.emplace_back(match);
 //          sr.nd.ntrkmatch += 1;
 //          // Can also have multiple track matches, so don't break at the end of the match

--- a/src/reco/NDLArTMSUniqueMatchRecoFiller.cxx
+++ b/src/reco/NDLArTMSUniqueMatchRecoFiller.cxx
@@ -286,7 +286,7 @@ namespace cafmaker
       potential_match.larid = larid;
       potential_match.matchScore = matchScore;
       potential_match.transdispl = sqrt(pow(delta_x,2)+pow(delta_y,2));
-      potential_match.angdispl = cos(TMath::Pi()/180.0 * angles[2]);
+      potential_match.cosangdispl = cos(TMath::Pi()/180.0 * angles[2]);
 
       caf::SRTrack joint_track = potential_match.trk;
       joint_track.start = trk.start;


### PR DESCRIPTION
Change all instances of `angdisp` to `cosangdisp` to reflect changes in `duneanaobj`.

Should be merged with PR   in `duneanaobj`.

Closes #144.