### PR TITLE
130 create a branch filler for sandreco experimental

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 export CXX = g++ 
-export CXXFLAGS = -g -Wall -fPIC -DNO_ART -O2
+ifdef SANDRECO_LEGACY
+  SANDRECO_LEGACY_FLAG = -DENABLE_SANDRECO_LEGACY
+endif
+export CXXFLAGS = -g -Wall -fPIC -DNO_ART -O2 $(SANDRECO_LEGACY_FLAG)
 export ROOTFLAGS = $(shell root-config --cflags)
 export INCLUDE = -I$(HDF5_INC)
 INCLUDE += -I$(GENIE_INC)/GENIE

--- a/src/Params.h
+++ b/src/Params.h
@@ -20,7 +20,7 @@ namespace cafmaker
 
     // fixme: placeholder.  won't work for data, which will need to either pass through from upstream or interface to POT database here
     fhicl::Atom<float> POTPerSpill { fhicl::Name("POTPerSpill"), fhicl::Comment("Fixed POT per spill (units of 10^13).")};
-    
+
     fhicl::Atom<bool> fhc        { fhicl::Name("IsFHC"),    fhicl::Comment("Is this an FHC run?"), true };
     fhicl::Atom<bool> IsGasTPC   { fhicl::Name("IsGasTPC"), fhicl::Comment("Was GArTPC geometry used? (If not, TMS)"), false };
 
@@ -43,9 +43,10 @@ namespace cafmaker
     fhicl::OptionalAtom<std::string> ndlarRecoFile  { fhicl::Name{"NDLArRecoFile"}, fhicl::Comment("Input ND-LAr (ML) reco .h5 file") };
     fhicl::OptionalAtom<std::string> tmsRecoFile  { fhicl::Name{"TMSRecoFile"}, fhicl::Comment("Input TMS reco .root file") };
     fhicl::OptionalAtom<std::string> sandRecoFile  { fhicl::Name{"SANDRecoFile"}, fhicl::Comment("Input SAND reco .root file") };
+    fhicl::OptionalAtom<std::string> sandRecoExperimentalFile { fhicl::Name{"SANDRecoExperimentalFile"}, fhicl::Comment("Input SAND fake_reco CAF .root file") };
     fhicl::OptionalAtom<std::string> minervaRecoFile  { fhicl::Name{"MINERVARecoFile"}, fhicl::Comment("Input MINERVA reco .root file") };
     fhicl::OptionalAtom<std::string> pandoraLArRecoNDFile  { fhicl::Name{"PandoraLArRecoNDFile"}, fhicl::Comment("Input Pandora LArRecoND .root file") };
-    
+
     // this is optional by way of the default value. Will result in an extra output file if enabled
     fhicl::Atom<bool> makeFlatCAF { fhicl::Name{"MakeFlatCAF"}, fhicl::Comment("Make 'flat' CAF in addition to structured CAF?"), true };
 
@@ -61,8 +62,8 @@ namespace cafmaker
 
     // 0.1 s is default
     fhicl::Atom<float>  beamMatchDT { fhicl::Name("BeamMatchDeltaT"), fhicl::Comment("Maximum time difference, in s, between triggers and beam"), 0.1 };
-    
-    // Minerva - 2x2 offsets in mm - Defaults are what's inside the simulation, hopefully that won't be needed in the future 
+
+    // Minerva - 2x2 offsets in mm - Defaults are what's inside the simulation, hopefully that won't be needed in the future
     fhicl::Atom<float> mx2_2x2_offsetX {fhicl::Name("Mx2_2x2_offsetX"), fhicl::Comment("Mx2 - 2x2 offset in X direction in cm"), 0.};
     fhicl::Atom<float> mx2_2x2_offsetY {fhicl::Name("Mx2_2x2_offsetY"), fhicl::Comment("Mx2 - 2x2 offset in Y direction in cm"), 218.};
     fhicl::Atom<float> mx2_2x2_offsetZ {fhicl::Name("Mx2_2x2_offsetZ"), fhicl::Comment("Mx2 - 2x2 offset in Z direction in cm"), 6913.};

--- a/src/makeCAF.C
+++ b/src/makeCAF.C
@@ -127,20 +127,32 @@ std::vector<std::unique_ptr<cafmaker::IRecoBranchFiller>> getRecoFillers(const c
 
   std::cout << "Filling Reco info for the following cases:\n";
 
-  
   std::string ndlarFile;
   if (par().cafmaker().ndlarRecoFile(ndlarFile))
   {
     recoFillers.emplace_back(std::make_unique<cafmaker::MLNDLArRecoBranchFiller>(ndlarFile));
     std::cout << "   ND-LAr (Deep-Learn-Physics ML)\n";
-  } 
-  
-  std::string sandFile;
-  if (par().cafmaker().sandRecoFile(sandFile))
-  {
-    recoFillers.emplace_back(std::make_unique<cafmaker::SANDRecoBranchFiller>(sandFile));
-    std::cout << "   SAND\n";
   }
+
+  #ifdef ENABLE_SANDRECO_LEGACY
+
+  std::string sandFile;
+  if (par().cafmaker().sandRecoFile(sandFile)) {
+    recoFillers.emplace_back(
+      std::make_unique<cafmaker::SANDRecoBranchFiller<cafmaker::SANDRecoVersion::legacy>>(sandFile));
+    std::cout << "   SAND (legacy)\n";
+  }
+
+  #else
+
+  std::string sandExpFile;
+  if (par().cafmaker().sandRecoExperimentalFile(sandExpFile)) {
+    recoFillers.emplace_back(
+      std::make_unique<cafmaker::SANDRecoBranchFiller<cafmaker::SANDRecoVersion::experimental>>(sandExpFile));
+    std::cout << "   SAND (experimental)\n";
+  }
+
+  #endif
 
   // Pandora LArRecoND
   std::string pandoraFile;
@@ -172,15 +184,15 @@ std::vector<std::unique_ptr<cafmaker::IRecoBranchFiller>> getRecoFillers(const c
   {
     recoFillers.emplace_back(std::make_unique<cafmaker::NDLArTMSMatchRecoFiller>());
 
-    recoFillers.emplace_back(std::make_unique<cafmaker::NDLArTMSUniqueMatchRecoFiller>(par().cafmaker().sigmaX(), 
-                                                                                      par().cafmaker().sigmaY(), 
-                                                                                      par().cafmaker().singleAngle(), 
-                                                                                      par().cafmaker().sigmaTh(), 
-                                                                                      par().cafmaker().sigmaThX(), 
-                                                                                      par().cafmaker().sigmaThY(), 
-                                                                                      par().cafmaker().useTime(), 
-                                                                                      par().cafmaker().meanT(), 
-                                                                                      par().cafmaker().sigmaT(), 
+    recoFillers.emplace_back(std::make_unique<cafmaker::NDLArTMSUniqueMatchRecoFiller>(par().cafmaker().sigmaX(),
+                                                                                      par().cafmaker().sigmaY(),
+                                                                                      par().cafmaker().singleAngle(),
+                                                                                      par().cafmaker().sigmaTh(),
+                                                                                      par().cafmaker().sigmaThX(),
+                                                                                      par().cafmaker().sigmaThY(),
+                                                                                      par().cafmaker().useTime(),
+                                                                                      par().cafmaker().meanT(),
+                                                                                      par().cafmaker().sigmaT(),
                                                                                       par().cafmaker().fcut()));
     std::cout << "   ND-LAr + TMS matching\n";
   }
@@ -299,14 +311,14 @@ buildTriggerList(std::map<const cafmaker::IRecoBranchFiller*, std::deque<cafmake
 
         if(it_trig != fillerTrigPair.second.end()){
             if (it_trig != fillerTrigPair.second.begin()) {
-                //Move the trigger to the front 
+                //Move the trigger to the front
                 cafmaker::Trigger temp = std::move(*it_trig);
                 fillerTrigPair.second.erase(it_trig);
                 fillerTrigPair.second.push_front(std::move(temp));
             }
         }
         else continue; //Not found any trigger that match with ref trigger type
-      
+
         const auto & trig = fillerTrigPair.second.front();
         ss << "       " << fillerTrigPair.first->GetName() << ", " << trig.evtID;
 
@@ -315,7 +327,7 @@ buildTriggerList(std::map<const cafmaker::IRecoBranchFiller*, std::deque<cafmake
         // we only need to check the first one in each other stream
 
 
-        
+
         if (doTriggersMatch( trigGroup.front().second, fillerTrigPair.second.front(), trigMatchMaxDT))
         {
           ss << " -->  MATCHES\n";
@@ -434,7 +446,7 @@ void loop(CAF &caf,
 
   bool useIFBeam = false;
   if (ghepFilenames.empty() && edepsimFilename.empty() && !par().cafmaker().ForceDisableIFBeam()) useIFBeam = true;
-  
+
   cafmaker::IFBeam beamManager(par, groupedTriggers, useIFBeam); //initialize IFBeam manager if data and when IFBeam is not force disabled
   // Main event loop
   cafmaker::Progress progBar("Processing " + std::to_string(N - start) + " triggers");
@@ -514,7 +526,7 @@ void loop(CAF &caf,
     caf.sr.beam.verticalintTGT = verticalintTGT;
     caf.sr.beam.verticalpos121 = verticalpos121;
     caf.sr.beam.multiwireInfo = multiwireInfo;
-    
+
     cafmaker::LOG_S("").INFO() << "Filling caf tree \n";
     caf.fill();
   }

--- a/src/reco/SANDRecoBranchFiller.cxx
+++ b/src/reco/SANDRecoBranchFiller.cxx
@@ -1,214 +1,213 @@
 /// Fill SAND reco branches using SAND reco data
 ///
-/// \author  L. Di Noto, reworked by M. Vicenzi
+/// \author  L. Di Noto, reworked by M. Vicenzi, S. Lanzi
 /// \date    Apr. 2022
 ///
 
-#include <iostream>
-
-#include "TBranch.h"
-#include "TLeaf.h"
 #include "SANDRecoBranchFiller.h"
-#include "truth/FillTruth.h"
-
-#ifdef ENABLE_SAND
-#warning Including SANDRecoBranchFiller in build
 
 #include "duneanaobj/StandardRecord/StandardRecord.h"
 
-#include "TFile.h"
-#include "TSystem.h"
-#include "TTree.h"
+#include <TFile.h>
+#include <TTree.h>
+
+#ifdef ENABLE_SANDRECO_LEGACY
 #include "struct.h"
-
-namespace cafmaker
-{
-
-  SANDRecoBranchFiller::SANDRecoBranchFiller(const std::string &SANDRecoFilename)
-      : IRecoBranchFiller("SAND"),
-        fTriggers(),
-        fLastTriggerReqd(fTriggers.end())
-  {
-  
-    if (SANDRecoFilename.empty()) {
-      std::cerr << "ERROR: SANDRecoBranchFiller: SANDRecoFilename is empty!" << std::endl;
-      SetConfigured(false);
-      return;
-    }
-    fSANDRecoFile = new TFile(SANDRecoFilename.c_str());
-    if (!fSANDRecoFile || fSANDRecoFile->IsZombie()) {
-      std::cerr << "ERROR: SANDRecoBranchFiller: Could not open file " << SANDRecoFilename << std::endl;
-      SetConfigured(false);
-      return;
-    }
-    NDSANDRecoTree = (TTree *)fSANDRecoFile->Get("tReco");
-    if (!NDSANDRecoTree)
-    {
-      std::cerr << "Error: NDSANDRecoTree is null. Tree 'tReco' not found in file." << std::endl;
-      fSANDRecoFile->ls(); 
-      SetConfigured(false);
-      return;
-    }
-   
-    SetConfigured(true);
-  }
-
-  
-  void SANDRecoBranchFiller::_FillRecoBranches(const Trigger &trigger,
-                                               caf::StandardRecord &sr,
-                                               const cafmaker::Params &par, const TruthMatcher *truthMatcher) const
-  {
-  
-    if (!NDSANDRecoTree) {
-      std::cerr << "ERROR: SANDRecoBranchFiller: NDSANDRecoTree is null!" << std::endl;
-      return;
-    }
-   
-    auto it_start = (fLastTriggerReqd == fTriggers.end()) ? fTriggers.cbegin() : fLastTriggerReqd;
-    auto itTrig = std::find(it_start, fTriggers.cend(), trigger);
-    if (itTrig == fTriggers.end())
-    {
-      LOG.FATAL() << "Reco branch filler '" << GetName() << "' could not find trigger with evtID == " << trigger.evtID << "!  Abort.\n";
-      abort();
-    }
-    
-    std::size_t idx = std::distance(fTriggers.cbegin(), itTrig);
-    int event_num = idx;
-    
-    sr.meta.sand.event = event_num;
-    LOG.VERBOSE() << "    Reco branch filler '" << GetName() << "', trigger.evtID == " << trigger.evtID << ", internal evt idx = " << idx << ".\n";
-    std::vector<cluster> cl;
-    std::vector<track> tr;
-    auto pcl = &cl;
-    auto ptr = &tr;
-    NDSANDRecoTree->SetBranchAddress("cluster", &pcl);
-    NDSANDRecoTree->SetBranchAddress("track", &ptr);
-    NDSANDRecoTree->GetEntry(event_num);
-
-    FillECalClusters(truthMatcher, sr, cl);
-   
-    FillTracks(truthMatcher, sr, tr);
-   
-  }
-
-  void SANDRecoBranchFiller::FillECalClusters(const TruthMatcher *truthMatch,
-                                              caf::StandardRecord &sr, std::vector<cluster> &cl) const
-  {
-   
-    size_t n_clusters = cl.size();
-
-    sr.nd.sand.ixn.resize(1);
-    sr.nd.sand.ixn[0].nclusters = n_clusters;
-    sr.nd.sand.ixn[0].ECALClusters.resize(n_clusters);
-
-    for (auto i = 0; i < n_clusters; i++)
-    {
-
-      sr.nd.sand.ixn[0].ECALClusters[i].E = cl[i].e;
-      sr.nd.sand.ixn[0].ECALClusters[i].position.SetXYZ(cl[i].x, cl[i].y, cl[i].z);
-      sr.nd.sand.ixn[0].ECALClusters[i].var_position.SetXYZ(cl[i].varx, cl[i].vary, cl[i].varz);
-      sr.nd.sand.ixn[0].ECALClusters[i].time = cl[i].t; 
-      sr.nd.sand.ixn[0].ECALClusters[i].start.SetXYZ(cl[i].ax, cl[i].ay, cl[i].az);
-      sr.nd.sand.ixn[0].ECALClusters[i].direction.SetXYZ(cl[i].sx, cl[i].sy, cl[i].sz);
-      sr.nd.sand.ixn[0].ECALClusters[i].num_cells = cl[i].reco_cells.size();
-      sr.nd.sand.ixn[0].ECALClusters[i].id = cl[i].tid;
-    }
-    
-    cl.clear();
-  }
-
-  void SANDRecoBranchFiller::FillTracks(const TruthMatcher *truthMatch,
-                                        caf::StandardRecord &sr, std::vector<track> &tr) const
-  {
-
-    size_t n_tracks = tr.size();
-
-
-    sr.nd.sand.ixn.resize(1);
-    sr.nd.sand.ixn[0].ntracks = n_tracks;
-    sr.nd.sand.ixn[0].tracks.resize(n_tracks);
-
-    for (int i = 0; i < n_tracks; i++)
-    {
-      sr.nd.sand.ixn[0].tracks[i].start.SetXYZ(tr[i].x0, tr[i].y0, tr[i].z0);
-      sr.nd.sand.ixn[0].tracks[i].qual = tr[i].chi2_cr;
-    }
-    tr.clear();
-  }
-
-  // todo: this is a placeholder
-  std::deque<Trigger> SANDRecoBranchFiller::GetTriggers(int triggerType, bool beamOnly) const
-  {
-    std::deque<Trigger> triggers;
-    size_t n_entries = NDSANDRecoTree->GetEntries();
-
-    if (fTriggers.empty())
-    {
-      LOG.DEBUG() << "Loading triggers with type " << triggerType << " within branch filler '" << GetName() << "\n";
-      fTriggers.reserve(n_entries);
-
-      std::cout<<"creating triggers"<<std::endl;
-
-      for (size_t i = 0; i < n_entries; i++)
-      {
-        const int placeholderTriggerType = 0;
-        // fixme: this check needs to be fixed when we have trigger type info
-        
-        if (triggerType >= 0 && triggerType != placeholderTriggerType)
-        {
-          LOG.VERBOSE() << "    skipping this event" << "\n";
-          std::cout << "skipping this event" << std::endl;
-          continue;
-        }
-
-        fTriggers.emplace_back();
-        Trigger &trig = fTriggers.back();
-        trig.evtID = i;
-
-        // todo: these are placeholder values until we can propagate enough info through the reco files
-        trig.triggerType = 0;
-        trig.triggerTime_s = i;
-        trig.triggerTime_ns = 0.;
-
-        triggers.push_back(trig);
-
-        LOG.VERBOSE() << "  added trigger:  evtID=" << trig.evtID
-                      << ", triggerType=" << trig.triggerType
-                      << ", triggerTime_s=" << trig.triggerTime_s
-                      << ", triggerTime_ns=" << trig.triggerTime_ns
-                      << "\n";
-      }
-     
-      fLastTriggerReqd = fTriggers.end(); // since we just modified the list, any iterators have been invalidated
-    }
-    else
-    {
-     
-      for (const Trigger &trigger : fTriggers)
-      {
-        if (triggerType < 0 || triggerType == fTriggers.back().triggerType)
-        {
-          triggers.push_back(trigger);
-        }
-      }
-    }
-    std::cout<<"Trigger completed!"<<std::endl;
-    return triggers;
-  }
-}
-
-#else
-#include "reco/SANDRecoBranchFiller.h"
-#include <deque>
-#include <iostream>
-namespace cafmaker {
-SANDRecoBranchFiller::SANDRecoBranchFiller(const std::string &)
-    : IRecoBranchFiller("SAND")
-{
-    std::cerr << "[WARNING] SANDRecoBranchFiller: SAND code is not enabled in this build.\n"
-                 "To enable SAND support, build with 'make ENABLE_SAND_DICT=1'.\n";
-}
-std::deque<Trigger> SANDRecoBranchFiller::GetTriggers(int, bool) const { return {}; }
-void SANDRecoBranchFiller::_FillRecoBranches(const Trigger &, caf::StandardRecord &, const cafmaker::Params &, const TruthMatcher *) const {}
-}
 #endif
+
+namespace cafmaker {
+
+SANDRecoBranchFiller<SANDRecoVersion::experimental>::~SANDRecoBranchFiller() = default;
+
+SANDRecoBranchFiller<SANDRecoVersion::experimental>::SANDRecoBranchFiller(
+    const std::string& cafFilename, std::string treeName)
+    : IRecoBranchFiller("SANDExperimental") {
+  if (cafFilename.empty()) {
+    LOG.WARNING() << GetName() << ": filename is empty\n";
+    SetConfigured(false);
+    return;
+  }
+
+  fFile.reset(TFile::Open(cafFilename.c_str()));
+  if (!fFile || fFile->IsZombie()) {
+    LOG.WARNING() << GetName() << ": could not open '" << cafFilename << "'\n";
+    SetConfigured(false);
+    return;
+  }
+
+  fCAFTree = fFile->Get<TTree>(treeName.c_str());
+  if (!fCAFTree) {
+    LOG.WARNING() << GetName() << ": tree '" << treeName << "' not found in '" << cafFilename
+                  << "'\n";
+    SetConfigured(false);
+    return;
+  }
+
+  fCAFTree->SetBranchAddress("rec", &fSR);
+
+  // Single pass: build evtID → entry map and trigger list
+  const auto nEntries = fCAFTree->GetEntries();
+  fTriggers.reserve(static_cast<std::size_t>(nEntries));
+  for (Long64_t e{}; e != nEntries; ++e) {
+    fCAFTree->GetEntry(e);
+    if (fSR->mc.nnu == 0) {
+      continue;
+    }
+
+    for (std::size_t i{}; i != fSR->mc.nnu; ++i) {
+      fEvtToEntry[fSR->mc.nu[i].id] = e;
+    }
+
+    fTriggers.push_back(Trigger{fSR->mc.nu[0].id, 0, static_cast<unsigned long>(e), 0u});
+  }
+
+  SetConfigured(true);
+}
+
+std::deque<Trigger>
+SANDRecoBranchFiller<SANDRecoVersion::experimental>::GetTriggers(int triggerType,
+                                                                 bool /*beamOnly*/) const {
+  std::deque<Trigger> out;
+  for (const auto& t : fTriggers) {
+    if (triggerType < 0 || t.triggerType == triggerType) {
+      out.push_back(t);
+    }
+  }
+  return out;
+}
+
+void SANDRecoBranchFiller<SANDRecoVersion::experimental>::_FillRecoBranches(
+    const Trigger& trigger, caf::StandardRecord& sr, const cafmaker::Params& /*par*/,
+    const TruthMatcher* /*truthMatcher*/) const {
+  auto it = fEvtToEntry.find(trigger.evtID);
+  if (it == fEvtToEntry.end()) {
+    LOG.WARNING() << GetName() << ": no entry for evtID=" << trigger.evtID << "\n";
+    return;
+  }
+
+  fCAFTree->GetEntry(it->second);
+
+  sr.common.ixn.sandreco  = fSR->common.ixn.sandreco;
+  sr.common.ixn.nsandreco = fSR->common.ixn.nsandreco;
+  sr.nd.sand.ixn          = fSR->nd.sand.ixn;
+  sr.nd.sand.nixn         = fSR->nd.sand.nixn;
+}
+
+#ifdef ENABLE_SANDRECO_LEGACY
+
+SANDRecoBranchFiller<SANDRecoVersion::legacy>::~SANDRecoBranchFiller() = default;
+
+SANDRecoBranchFiller<SANDRecoVersion::legacy>::SANDRecoBranchFiller(const std::string& recoFilename)
+    : IRecoBranchFiller("SAND") {
+  if (recoFilename.empty()) {
+    LOG.WARNING() << GetName() << ": filename is empty\n";
+    SetConfigured(false);
+    return;
+  }
+
+  fFile.reset(TFile::Open(recoFilename.c_str()));
+  if (!fFile || fFile->IsZombie()) {
+    LOG.WARNING() << GetName() << ": could not open '" << recoFilename << "'\n";
+    SetConfigured(false);
+    return;
+  }
+
+  fRecoTree = fFile->Get<TTree>("tReco");
+  if (!fRecoTree) {
+    LOG.WARNING() << GetName() << ": tree 'tReco' not found\n";
+    fFile->ls();
+    SetConfigured(false);
+    return;
+  }
+
+  // evtID = entry index (placeholder — no event ID in legacy reco format)
+  const long nEntries = fRecoTree->GetEntries();
+  fTriggers.reserve(nEntries);
+  for (long e{}; e != nEntries; ++e) {
+    Trigger t;
+    t.evtID          = e;
+    t.triggerType    = 0;
+    t.triggerTime_s  = static_cast<unsigned long>(e);
+    t.triggerTime_ns = 0;
+    fTriggers.push_back(t);
+  }
+
+  SetConfigured(true);
+}
+
+std::deque<Trigger>
+SANDRecoBranchFiller<SANDRecoVersion::legacy>::GetTriggers(int triggerType,
+                                                           bool /*beamOnly*/) const {
+  std::deque<Trigger> out;
+  for (const auto& t : fTriggers) {
+    if (triggerType < 0 || t.triggerType == triggerType) {
+      out.push_back(t);
+    }
+  }
+  return out;
+}
+
+void SANDRecoBranchFiller<SANDRecoVersion::legacy>::_FillRecoBranches(
+    const Trigger& trigger, caf::StandardRecord& sr, const cafmaker::Params& /*par*/,
+    const TruthMatcher* truthMatcher) const {
+  auto it = std::find(fTriggers.begin(), fTriggers.end(), trigger);
+  if (it == fTriggers.end()) {
+    LOG.FATAL() << GetName() << ": no trigger with evtID=" << trigger.evtID << "\n";
+    abort();
+  }
+  const long entry = std::distance(fTriggers.begin(), it);
+
+  // The legacy tree stores vector<cluster>* and vector<track>* branches
+  std::vector<cluster>* pcl = nullptr;
+  std::vector<track>* ptr   = nullptr;
+  fRecoTree->SetBranchAddress("cluster", &pcl);
+  fRecoTree->SetBranchAddress("track", &ptr);
+  fRecoTree->GetEntry(entry);
+
+  if (pcl) {
+    FillECalClusters(truthMatcher, sr, *pcl);
+  }
+  if (ptr) {
+    FillTracks(truthMatcher, sr, *ptr);
+  }
+}
+
+void SANDRecoBranchFiller<SANDRecoVersion::legacy>::FillECalClusters(
+    const TruthMatcher* /*truthMatcher*/, caf::StandardRecord& sr, std::vector<cluster>& cl) const {
+  const std::size_t n = cl.size();
+  sr.nd.sand.ixn.resize(1);
+  auto& ixn     = sr.nd.sand.ixn[0];
+  ixn.nclusters = n;
+  ixn.ECALClusters.resize(n);
+
+  for (std::size_t i{}; i != n; ++i) {
+    auto& c = ixn.ECALClusters[i];
+    c.E     = cl[i].e;
+    c.position.SetXYZ(cl[i].x, cl[i].y, cl[i].z);
+    c.var_position.SetXYZ(cl[i].varx, cl[i].vary, cl[i].varz);
+    c.time = cl[i].t;
+    c.start.SetXYZ(cl[i].ax, cl[i].ay, cl[i].az);
+    c.direction.SetXYZ(cl[i].sx, cl[i].sy, cl[i].sz);
+    c.num_cells = cl[i].reco_cells.size();
+    c.id        = cl[i].tid;
+  }
+}
+
+void SANDRecoBranchFiller<SANDRecoVersion::legacy>::FillTracks(const TruthMatcher* /*truthMatcher*/,
+                                                               caf::StandardRecord& sr,
+                                                               std::vector<track>& tr) const {
+  const std::size_t n = tr.size();
+  sr.nd.sand.ixn.resize(1);
+  auto& ixn   = sr.nd.sand.ixn[0];
+  ixn.ntracks = n;
+  ixn.tracks.resize(n);
+
+  for (std::size_t i{}; i != n; ++i) {
+    ixn.tracks[i].start.SetXYZ(tr[i].x0, tr[i].y0, tr[i].z0);
+    ixn.tracks[i].qual = tr[i].chi2_cr;
+  }
+}
+
+#endif // ENABLE_SANDRECO_LEGACY
+
+} // namespace cafmaker

--- a/src/reco/SANDRecoBranchFiller.h
+++ b/src/reco/SANDRecoBranchFiller.h
@@ -1,64 +1,84 @@
 /// Fill SAND reco branches using SAND reco data
 ///
-/// \author  L. Di Noto, reworked by M. Vicenzi
-/// \date    Apr. 2022
-///
+/// \author  L. Di Noto, reworked by M. Vicenzi, S. Lanzi
 
 #ifndef ND_CAFMAKER_SANDRECOBRANCHFILLER_H
 #define ND_CAFMAKER_SANDRECOBRANCHFILLER_H
 
 #include "IRecoBranchFiller.h"
-#include <deque>
+
+#include <cstdint>
+#include <memory>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
-#ifdef ENABLE_SAND
-#include "struct.h"
-#endif
+class TFile;
+class TTree;
 
-namespace cafmaker
-{
-  class SANDRecoBranchFiller : public cafmaker::IRecoBranchFiller
-  {
-  public:
-    SANDRecoBranchFiller(const std::string &SANDRecoFilename);
-
-    std::deque<Trigger> GetTriggers(int triggerType, bool beamOnly) const override;
-
-    RecoFillerType FillerType() const override { return RecoFillerType::BaseReco; }
-
-  private:
-#ifdef ENABLE_SAND
-    void _FillRecoBranches(const Trigger &trigger,
-                           caf::StandardRecord &sr,
-                           const cafmaker::Params &par,
-                           const TruthMatcher *truthMatcher) const override;
-
-    void FillECalClusters(const TruthMatcher * truthMatch,
-                          caf::StandardRecord &sr, std::vector<cluster> &cl) const;
-    void FillTracks(const TruthMatcher * truthMatch,
-                    caf::StandardRecord &sr, std::vector<track> &tr) const;
-
-    TFile* fSANDRecoFile;
-    TTree* NDSANDRecoTree;
-    TTree* NDSANDEventTree;
-    struct event* fEvent;
-
-    mutable std::vector<cafmaker::Trigger> fTriggers;
-    mutable decltype(fTriggers)::const_iterator fLastTriggerReqd;
-
-#else
-    void _FillRecoBranches(const Trigger &trigger, caf::StandardRecord &sr, const cafmaker::Params &par, const TruthMatcher *truthMatcher) const override;
-    // These members exist even when ENABLE_SAND is false
-    // because ROOT needs them to generate the dictionary correctly.
-    TFile* fSANDRecoFile = nullptr;
-    TTree* NDSANDRecoTree = nullptr;
-    TTree* NDSANDEventTree = nullptr;
-    struct event* fEvent = nullptr;
-
-    mutable std::vector<cafmaker::Trigger> fTriggers;
-    mutable decltype(fTriggers)::const_iterator fLastTriggerReqd;
-#endif
-  };
+namespace caf {
+class StandardRecord;
 }
 
-#endif
+namespace cafmaker {
+
+enum class SANDRecoVersion : std::int8_t { legacy, experimental };
+
+template<SANDRecoVersion V>
+class SANDRecoBranchFiller;
+
+template<>
+class SANDRecoBranchFiller<SANDRecoVersion::experimental> : public IRecoBranchFiller {
+ public:
+  explicit SANDRecoBranchFiller(const std::string& cafFilename, std::string treeName = "cafTree");
+  ~SANDRecoBranchFiller();
+
+  std::deque<Trigger> GetTriggers(int triggerType = -1, bool beamOnly = false) const override;
+
+  RecoFillerType FillerType() const override {
+    return RecoFillerType::BaseReco;
+  }
+
+ private:
+  void _FillRecoBranches(const Trigger&, caf::StandardRecord&, const Params&,
+                         const TruthMatcher*) const override;
+
+  std::unique_ptr<TFile> fFile;
+  TTree* fCAFTree{nullptr}; // owned by fFile
+  caf::StandardRecord* fSR{nullptr};
+  std::unordered_map<long int, long int> fEvtToEntry;
+  std::vector<Trigger> fTriggers;
+};
+
+#ifdef ENABLE_SANDRECO_LEGACY
+
+template<>
+class SANDRecoBranchFiller<SANDRecoVersion::legacy> : public IRecoBranchFiller {
+ public:
+  explicit SANDRecoBranchFiller(const std::string& recoFilename);
+  ~SANDRecoBranchFiller();
+
+  std::deque<Trigger> GetTriggers(int triggerType = -1, bool beamOnly = false) const override;
+
+  RecoFillerType FillerType() const override {
+    return RecoFillerType::BaseReco;
+  }
+
+ private:
+  void _FillRecoBranches(const Trigger&, caf::StandardRecord&, const Params&,
+                         const TruthMatcher*) const override;
+
+  void FillECalClusters(const TruthMatcher*, caf::StandardRecord&, std::vector<cluster>&) const;
+  void FillTracks(const TruthMatcher*, caf::StandardRecord&, std::vector<track>&) const;
+
+  std::unique_ptr<TFile> fFile;
+  TTree* fRecoTree{nullptr}; // owned by fFile
+  struct event* fEvent{nullptr};
+  std::vector<Trigger> fTriggers;
+};
+
+#endif // ENABLE_SANDRECO_LEGACY
+
+} // namespace cafmaker
+
+#endif // ND_CAFMAKER_SANDRECOBRANCHFILLER_H


### PR DESCRIPTION
Adds a branch filler for SANDReco via template explicit specialization, with separate support paths for sandreco-legacy and sandreco-experimental controlled by compilation flags.