### PR TITLE
Group TMS tracks by time slice

### DIFF
--- a/src/reco/NDLArTMSUniqueMatchRecoFiller.cxx
+++ b/src/reco/NDLArTMSUniqueMatchRecoFiller.cxx
@@ -226,45 +226,47 @@ namespace cafmaker
       if (use_time) {
         // this handles time-based matching - using truth-level particle times for now instead of light in LAr
         
-	bool timeFail = false;
-	std::vector<float> tOv = trk.truthOverlap;
-	std::vector<caf::TrueParticleID> truIDs = trk.truth;
-	if (tOv.empty()) {
-	  timeFail = true;
-	}
-	if (truIDs.empty()) {
-	  timeFail = true;
-	}
-	if (truIDs.size() != tOv.size()) {
-	  timeFail = true;
-	}
-	if (!timeFail) {
-	int idx_max = std::distance(tOv.begin(),std::max_element(tOv.begin(),tOv.end()));
-	caf::TrueParticleID partID = truIDs[idx_max]; // ID of true particle that makes up the majority of the track
-	const auto& matchedPart = FindParticle(sr.mc,partID); // gets the particle object corresponding to the ID
-	if (matchedPart != nullptr) {
-	  lar_time = matchedPart->time - 1e9*trigger.triggerTime_s - trigger.triggerTime_ns + time_smear; // adds gaussian smear to the true time with std 10 ns
-	  // Eventually we'll want to fill the LAr time from the track rather than the particle (trk.time instead of matchedPart->time). 
-	  // But LAr tracks from SPINE don't have their time attribute filled yet, so we use the true particle for now to keep the matcher agnostic to the LAr reco method
-	  double tms_time = tms_trk.time;
-          delta_t = tms_time - lar_time;
-          matchScore += pow((delta_t-mean_t)/sigma_t,2); // adds the time difference term to the matchScore
-	  // Following code is for checking if the particle IDs for matching tracks themselves match. This allows you to identify true matches
-	  std::vector<float> tOvTMS = tms_trk.truthOverlap;
-	  std::vector<caf::TrueParticleID> truIDsTMS = tms_trk.truth;
-	  int idx_max_TMS = std::distance(tOvTMS.begin(),std::max_element(tOvTMS.begin(),tOvTMS.end()));
-	  caf::TrueParticleID partIDTMS = truIDsTMS[idx_max_TMS];
-	  const auto& TMSPart = FindParticle(sr.mc,partIDTMS);
-	  // TODO: Right now the partIDTMS values are nonsensical and the TMSPart->G4ID is always a null pointer. There are problems bringing TMS truth info into ND-CAFMaker
-	  // Uncomment the following once this has been fixed
-	  if (TMSPart != nullptr) {
-	    if (matchedPart->G4ID==TMSPart->G4ID) {
-		// TODO: Add "TrueMatch" boolean attribute to the TrackAssn and set to true
-		// std::cout << "True Match!" << std::endl; 
-	       }
-	    }
-     	 }
-	}
+        bool timeFail = false;
+        std::vector<float> tOv = trk.truthOverlap;
+        std::vector<caf::TrueParticleID> truIDs = trk.truth;
+        if (tOv.empty()) {
+          timeFail = true;
+        }
+        if (truIDs.empty()) {
+          timeFail = true;
+        }
+        if (truIDs.size() != tOv.size()) {
+          timeFail = true;
+        }
+        if (!timeFail) {
+          int idx_max = std::distance(tOv.begin(),std::max_element(tOv.begin(),tOv.end()));
+          caf::TrueParticleID partID = truIDs[idx_max]; // ID of true particle that makes up the majority of the track
+          const auto& matchedPart = FindParticle(sr.mc,partID); // gets the particle object corresponding to the ID
+          if (matchedPart != nullptr) {
+            lar_time = matchedPart->time - 1e9*trigger.triggerTime_s - trigger.triggerTime_ns + time_smear; // adds gaussian smear to the true time with std 10 ns
+            // Eventually we'll want to fill the LAr time from the track rather than the particle (trk.time instead of matchedPart->time).
+            // But LAr tracks from SPINE don't have their time attribute filled yet, so we use the true particle for now to keep the matcher agnostic to the LAr reco method
+            double tms_time = tms_trk.time;
+            delta_t = tms_time - lar_time;
+            matchScore += pow((delta_t-mean_t)/sigma_t,2); // adds the time difference term to the matchScore
+            // Following code is for checking if the particle IDs for matching tracks themselves match. This allows you to identify true matches
+            std::vector<float> tOvTMS = tms_trk.truthOverlap;
+            std::vector<caf::TrueParticleID> truIDsTMS = tms_trk.truth;
+            if (!tOvTMS.empty() && !truIDsTMS.empty() && tOvTMS.size() == truIDsTMS.size()) {
+              int idx_max_TMS = std::distance(tOvTMS.begin(),std::max_element(tOvTMS.begin(),tOvTMS.end()));
+              caf::TrueParticleID partIDTMS = truIDsTMS[idx_max_TMS];
+              const auto& TMSPart = FindParticle(sr.mc,partIDTMS);
+              // TODO: Right now the partIDTMS values are nonsensical and the TMSPart->G4ID is always a null pointer. There are problems bringing TMS truth info into ND-CAFMaker
+              // Uncomment the following once this has been fixed
+              if (TMSPart != nullptr) {
+                if (matchedPart->G4ID==TMSPart->G4ID) {
+                  // TODO: Add "TrueMatch" boolean attribute to the TrackAssn and set to true
+                  // std::cout << "True Match!" << std::endl;
+                }
+              }
+            }
+          }
+        }
       }
 
       caf::SRTMSID tmsid;
@@ -355,14 +357,14 @@ namespace cafmaker
           copy(dlpTrkAssns.begin(), dlpTrkAssns.end(), back_inserter(possibleSPINEMatches));
         }
       }
-    
+    }
+
     if (possiblePandoraMatches.size() > 0) {
       Create_matches(possiblePandoraMatches,sr);
-      }
+    }
 
     if (possibleSPINEMatches.size() > 0) {
       Create_matches(possibleSPINEMatches,sr);
-      }
     }
   }
   // todo: this is a placeholder

--- a/src/reco/TMSRecoBranchFiller.cxx
+++ b/src/reco/TMSRecoBranchFiller.cxx
@@ -299,8 +299,6 @@ namespace cafmaker
     TMSRecoTree->GetEntry(i); // Load first entry for now
     LastSpillNo = _SpillNo;
 
-    caf::SRTMSInt *interaction;
-
     LoadTruthSpillEntry(LastSpillNo);
     for (int i_tvtx = 0; i_tvtx < _TruthSpillTrueVtxN; ++i_tvtx)
     {
@@ -314,32 +312,39 @@ namespace cafmaker
     TMSLCTree->GetEntry(i); 
     while (_SpillNo == LastSpillNo && i < TMSRecoTree->GetEntries()) // while we're in the spill
     {
-      if (_nTracks > 0)
-      {        
+      if (_nTracks < 0)
+      {
+        LOG.WARNING() << "Skipping TMS Reco_Tree entry " << i
+                      << " with negative nTracks = " << _nTracks << "\n";
+      }
+      else
+      {
+        ++sr.nd.tms.nixn;
+        sr.nd.tms.ixn.emplace_back();
+
+        caf::SRTMSInt &interaction = sr.nd.tms.ixn.back();
+        interaction.tracks.resize(_nTracks);
+        interaction.ntracks = _nTracks;
+
         for (int j = 0; j < _nTracks; ++j) {
-          sr.nd.tms.nixn++;
-          sr.nd.tms.ixn.emplace_back();
+          caf::SRTrack &track = interaction.tracks[j];
 
-          interaction = &(sr.nd.tms.ixn.back()); // :(
-          interaction->tracks.resize(1); // For now 1 track = 1 interaction; implicit assumption it's all (anti-)muons
-          interaction->ntracks = 1;
+          track.start   = caf::SRVector3D(_TrackStartPos[j][0]/10., _TrackStartPos[j][1]/10., _TrackStartPos[j][2]/10.);
+          track.end     = caf::SRVector3D(_TrackEndPos[j][0]/10., _TrackEndPos[j][1]/10., _TrackEndPos[j][2]/10.);
+          track.dir     = caf::SRVector3D(_TrackStartDirection[j][0], _TrackStartDirection[j][1] , _TrackStartDirection[j][2]);
+          track.enddir  = caf::SRVector3D(_TrackEndDirection[j][0], _TrackEndDirection[j][1] , _TrackEndDirection[j][2]);
 
-          interaction->tracks[0].start   = caf::SRVector3D(_TrackStartPos[j][0]/10., _TrackStartPos[j][1]/10., _TrackStartPos[j][2]/10.);
-          interaction->tracks[0].end     = caf::SRVector3D(_TrackEndPos[j][0]/10., _TrackEndPos[j][1]/10., _TrackEndPos[j][2]/10.);
-          interaction->tracks[0].dir     = caf::SRVector3D(_TrackStartDirection[j][0], _TrackStartDirection[j][1] , _TrackStartDirection[j][2]);
-          interaction->tracks[0].enddir  = caf::SRVector3D(_TrackEndDirection[j][0], _TrackEndDirection[j][1] , _TrackEndDirection[j][2]);
-
-          interaction->tracks[0].time    = static_cast<double>(_TMSStartTime[j]); //Adds time of interaction // TODO: use _TrackTime after prod n4p1
+          track.time    = static_cast<double>(_TMSStartTime[j]); //Adds time of interaction // TODO: use _TrackTime after prod n4p1
 
           // Track info
-          interaction->tracks[0].len_cm    = (_TrackLength[j]>0.0) ? _TrackLength[j]/10. : 0.0; // idk why we have negatives
-          interaction->tracks[0].len_gcm2  = (_TrackArealDensity[j]>0.0) ? _TrackArealDensity[j]/10. : 0.0; // idk why we have negatives
-          interaction->tracks[0].qual      = _Occupancy[j]; // TODO: Apparently this is a "track quality", nominally (hits in track)/(total hits)
-          interaction->tracks[0].Evis      = _TrackEnergyDeposit[j];
+          track.len_cm    = (_TrackLength[j]>0.0) ? _TrackLength[j]/10. : 0.0; // idk why we have negatives
+          track.len_gcm2  = (_TrackArealDensity[j]>0.0) ? _TrackArealDensity[j]/10. : 0.0; // idk why we have negatives
+          track.qual      = _Occupancy[j]; // TODO: Apparently this is a "track quality", nominally (hits in track)/(total hits)
+          track.Evis      = _TrackEnergyDeposit[j];
 
           // As of Jan 2026 the Charge attribute in TMS output is the PDG value, -13 for mu+, 13 for mu-.
           // For CAF files we probably just want a +1 or -1 for the particle charge, so divide by 13 and multiply in a -
-          interaction->tracks[0].charge    = -1 * _TrackCharge[j]/13;
+          track.charge    = -1 * _TrackCharge[j]/13;
 
           /*  Fill Truth
            *  The run numbers in the GHEP(?) or edep files are of the run number, followed by the event number, so we recreate that.
@@ -361,9 +366,9 @@ namespace cafmaker
                                                                               [partG4ID](const caf::SRTrueParticle& part)
                                                                               { return part.G4ID == partG4ID; })));
 
-          interaction->tracks[0].truth.push_back(caf::TrueParticleID{srTrueIntIdx,
-                                                                      caf::TrueParticleID::PartType::kPrimary,
-                                                                      truthVecIdx});
+          track.truth.push_back(caf::TrueParticleID{srTrueIntIdx,
+                                                    caf::TrueParticleID::PartType::kPrimary,
+                                                    truthVecIdx});
         }
       }
 


### PR DESCRIPTION
1. **TMS interaction shape fix**
   - `TMSRecoBranchFiller` now makes one `sr.nd.tms.ixn` per TMS `Reco_Tree` row/time slice.
   - Each interaction contains all tracks in that slice as `tracks[j]`, with `ntracks = _nTracks`.

2. **Duplicate match fix**
   - `NDLArTMSUniqueMatchRecoFiller` now calls `Create_matches()` once after collecting all candidate matches, instead of repeatedly inside the TMS-interaction loop.
   - That prevents previously collected candidates from being reconsidered and appended again.

There’s also a small defensive guard around optional TMS truth-overlap use in time matching, but that’s more of a crash-prevention cleanup than a main behavior change.

# Plots of new behavior
<img width="910" height="802" alt="Screenshot 2026-06-30 204945" src="https://github.com/user-attachments/assets/d8281d73-8ba0-4f0c-9d79-7e0e19ea05aa" />

<img width="700" height="540" alt="Screenshot 2026-06-30 204958" src="https://github.com/user-attachments/assets/5af46eff-6e28-40bd-8cb8-355d14970f70" />
